### PR TITLE
chore: default release notes to public main

### DIFF
--- a/.opencode/command/release-notes.md
+++ b/.opencode/command/release-notes.md
@@ -30,4 +30,5 @@ After reviewing the generated notes:
 - tighten wording only when it improves clarity
 - preserve the existing section structure unless there is a strong reason to merge sections
 - suggest saving the finalized notes to `release-notes/v<version>.md` when a version is known
+- suggest the commands to update local `main` from the target remote before tagging, for example `git checkout main` and `git pull <remote> main`
 - suggest a `gh release create` command if the user wants to publish next

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -15,7 +15,7 @@ const { values } = parseArgs({
   args: normalizedArgv,
   options: {
     from: { type: "string" },
-    to: { type: "string", default: "HEAD" },
+    to: { type: "string" },
     draft: { type: "string" },
     repo: { type: "string" },
     help: { type: "boolean", short: "h", default: false },
@@ -25,7 +25,7 @@ const { values } = parseArgs({
 
 if (values.help) {
   process.stdout.write(
-    `Usage: pnpm release:notes -- [options]\n\nOptions:\n  --from <tag>     Starting git tag. Defaults to latest semver tag.\n  --to <ref>       Ending git ref. Defaults to HEAD.\n  --draft <tag>    Create a draft GitHub release for the provided tag.\n  --repo <owner/repo>  Override GitHub repo slug for compare links and draft release.\n  -h, --help       Show this help message.\n`,
+    `Usage: pnpm release:notes -- [options]\n\nOptions:\n  --from <tag>     Starting git tag. Defaults to latest semver tag.\n  --to <ref>       Ending git ref. Defaults to main for the public repo, otherwise HEAD.\n  --draft <tag>    Create a draft GitHub release for the provided tag.\n  --repo <owner/repo>  Override GitHub repo slug for compare links and draft release.\n  -h, --help       Show this help message.\n`,
   );
   process.exit(0);
 }
@@ -41,6 +41,17 @@ function gh(args) {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
   }).trim();
+}
+
+/** @param {string} remoteName */
+function getRemoteRepo(remoteName) {
+  try {
+    const remote = git(["remote", "get-url", remoteName]);
+    const match = remote.match(/github\.com[:/]([^/]+\/[^/.]+)(?:\.git)?$/);
+    return match?.[1];
+  } catch {
+    return undefined;
+  }
 }
 
 function getLatestSemverTag() {
@@ -155,10 +166,13 @@ function getDefaultFromTag() {
   return getLatestSemverTag();
 }
 
-function getOriginRepo() {
-  const remote = git(["remote", "get-url", "origin"]);
-  const match = remote.match(/github\.com[:/]([^/]+\/[^/.]+)(?:\.git)?$/);
-  return match?.[1];
+function getPreferredRepo() {
+  return getRemoteRepo("public") ?? getRemoteRepo("origin");
+}
+
+/** @param {string | undefined} repo */
+function getDefaultToRef(repo) {
+  return repo === "every-app/open-seo" ? "main" : "HEAD";
 }
 
 /** @param {readonly string[]} rangeArgs */
@@ -266,8 +280,8 @@ function buildNotes({ from, to, repo }) {
 }
 
 const from = values.from ?? getDefaultFromTag();
-const to = values.to;
-const repo = values.repo ?? getOriginRepo();
+const repo = values.repo ?? getPreferredRepo();
+const to = values.to ?? getDefaultToRef(repo);
 const notes = buildNotes({ from, to, repo });
 
 process.stdout.write(`${notes}\n`);


### PR DESCRIPTION
## Summary
- default release note compare links to the `public` remote when available
- use `main` instead of `HEAD` for the public repo so generated changelog links point at the published branch
- remind the release-notes command to pull the target remote's `main` branch before tagging