### PR TITLE
chore: allow Docker preview host override

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@
 # Optional app port
 # PORT=3001
 
+# Optional reverse-proxy hosts for Docker self-hosting
+# ALLOWED_HOST=yourdomain.com
+
 # Optional image tag override for Docker self-hosting
 # OPEN_SEO_IMAGE=ghcr.io/every-app/open-seo:latest
 

--- a/Dockerfile.selfhost
+++ b/Dockerfile.selfhost
@@ -15,4 +15,4 @@ COPY . .
 
 EXPOSE 3001
 
-CMD ["sh", "-c", "pnpm run db:migrate:local && pnpm exec vite dev --host 0.0.0.0 --port ${PORT:-3001}"]
+CMD ["sh", "-c", "pnpm run db:migrate:local && pnpm run build && pnpm exec vite preview --host 0.0.0.0 --port ${PORT:-3001}"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,6 +6,7 @@ services:
       # Required for local Docker self-hosting: exposes Compose env vars to cloudflare:workers bindings.
       - CLOUDFLARE_INCLUDE_PROCESS_ENV=true
       - PORT=${PORT:-3001}
+      - ALLOWED_HOST=${ALLOWED_HOST:-}
       - AUTH_MODE=local_noauth
       - DATAFORSEO_API_KEY=${DATAFORSEO_API_KEY}
       - VITE_SHOW_DEVTOOLS=false

--- a/docs/SELF_HOSTING_DOCKER.md
+++ b/docs/SELF_HOSTING_DOCKER.md
@@ -2,7 +2,7 @@
 
 Run OpenSEO locally with Docker.
 
-In Docker mode, OpenSEO uses `AUTH_MODE=local_noauth` (no auth checks, local admin user `admin@localhost`).
+In Docker mode, OpenSEO uses `AUTH_MODE=local_noauth` (no auth checks, local admin user `admin@localhost`). Only expose it behind your own auth-protected reverse proxy, tunnel, or private network.
 
 The default `compose.yaml` uses the published GHCR image:
 
@@ -26,8 +26,17 @@ Docker Compose passes `.env` values into the container, and `compose.yaml` enabl
 Optional env values:
 
 - `PORT` (defaults to `3001`)
+- `ALLOWED_HOST` (single reverse-proxy hostname to allow in Vite preview)
 - `AUTH_MODE=local_noauth` (already set in compose)
 - `OPEN_SEO_IMAGE` (defaults to `ghcr.io/every-app/open-seo:latest`)
+
+If you are putting Docker behind a reverse proxy or a temporary tunnel, remember that Docker self-hosting runs with app auth disabled. Only expose it behind your own auth-protected reverse proxy, tunnel, or private network, and add the public hostname before restarting:
+
+```bash
+ALLOWED_HOST=yourdomain.com docker compose up -d
+```
+
+You can also persist it in `.env`.
 
 ## Pin to a specific image tag
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,10 +10,15 @@ export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
   const port = env.PORT ? Number(env.PORT) : 3001;
   const showDevtools = env.VITE_SHOW_DEVTOOLS !== "false";
+  const allowedHosts = env.ALLOWED_HOST ? [env.ALLOWED_HOST] : undefined;
 
   return {
     envPrefix: ["VITE_"],
     server: {
+      port,
+    },
+    preview: {
+      allowedHosts,
       port,
     },
     plugins: [

--- a/web/src/routes/index.tsx
+++ b/web/src/routes/index.tsx
@@ -2,9 +2,9 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { useState } from "react";
 import { toCanonicalUrl } from "@/lib/seo";
 
-const homeTitle = "OpenSEO - Own Your SEO";
+const homeTitle = "OpenSEO - Open Source SEO Platform";
 const homeDescription =
-  "Own your SEO. Pay only for what you use. No subscriptions. Open source alternative to Semrush and Ahrefs.";
+  "Own your SEO. OpenSEO helps teams manage keyword research, backlink analysis, competitor monitoring, and site audits without expensive monthly SEO software subscriptions.";
 
 export const Route = createFileRoute("/")({
   head: () => ({

--- a/web/src/routes/js/script[.]js.ts
+++ b/web/src/routes/js/script[.]js.ts
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 
 const PLAUSIBLE_SCRIPT_URL =
-  "https://plausible.io/js/pa-DllmchvGzcNdY2jEy1-Hc.js";
+  "https://plausible.io/js/pa-f6y3kIQsae-ldmIxlnaPu.js";
 
 export const Route = createFileRoute("/js/script.js")({
   server: {

--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -10,6 +10,13 @@
   },
   "workers_dev": true,
   "preview_urls": true,
+  "observability": {
+    "enabled": true,
+    "logs": {
+      "enabled": true,
+      "invocation_logs": true,
+    },
+  },
   "routes": [
     {
       "pattern": "openseo.so",


### PR DESCRIPTION
## Summary
- allow Docker self-hosted deployments to pass a single `ALLOWED_HOST` through Compose into Vite preview
- scope the host override to `preview.allowedHosts` so local dev server behavior stays unchanged
- document the reverse-proxy host setting and clarify that Docker self-hosting should sit behind external auth since app auth is disabled