### PR TITLE
fix: treat rank-tracking max position 0 as "show only unranked"

### DIFF
--- a/src/client/features/rank-tracking/RankTrackingFilters.tsx
+++ b/src/client/features/rank-tracking/RankTrackingFilters.tsx
@@ -163,22 +163,31 @@ export function applyFilters(
     if (excludeTerms.some((t) => kw.includes(t))) return false;
 
     if (filters.minDesktopPos || filters.maxDesktopPos) {
-      const min = filters.minDesktopPos ? Number(filters.minDesktopPos) : 0;
-      const max = filters.maxDesktopPos
-        ? Number(filters.maxDesktopPos)
-        : Infinity;
-      if (row.desktop.position === null) return false;
-      if (row.desktop.position < min || row.desktop.position > max)
-        return false;
+      if (filters.maxDesktopPos !== "" && Number(filters.maxDesktopPos) === 0) {
+        if (row.desktop.position !== null) return false;
+      } else {
+        const min = filters.minDesktopPos ? Number(filters.minDesktopPos) : 0;
+        const max = filters.maxDesktopPos
+          ? Number(filters.maxDesktopPos)
+          : Infinity;
+        if (row.desktop.position === null) return false;
+        if (row.desktop.position < min || row.desktop.position > max)
+          return false;
+      }
     }
 
     if (filters.minMobilePos || filters.maxMobilePos) {
-      const min = filters.minMobilePos ? Number(filters.minMobilePos) : 0;
-      const max = filters.maxMobilePos
-        ? Number(filters.maxMobilePos)
-        : Infinity;
-      if (row.mobile.position === null) return false;
-      if (row.mobile.position < min || row.mobile.position > max) return false;
+      if (filters.maxMobilePos !== "" && Number(filters.maxMobilePos) === 0) {
+        if (row.mobile.position !== null) return false;
+      } else {
+        const min = filters.minMobilePos ? Number(filters.minMobilePos) : 0;
+        const max = filters.maxMobilePos
+          ? Number(filters.maxMobilePos)
+          : Infinity;
+        if (row.mobile.position === null) return false;
+        if (row.mobile.position < min || row.mobile.position > max)
+          return false;
+      }
     }
 
     return true;


### PR DESCRIPTION
## Summary
- In Rank Tracking → Filters, setting **Desktop position max** or **Mobile position max** to `0` previously returned an empty list (because `position > 0` excluded everything and null positions were dropped first).
- Treat an explicit max of `0` as a sentinel meaning "show only rows where the corresponding position is null (unranked)". Min is ignored in that case.
- Behavior for any non-zero range is unchanged.

## Files
- `src/client/features/rank-tracking/RankTrackingFilters.tsx` — `applyFilters` only.

## Test plan
- [ ] Open a domain with a mix of ranked and unranked keywords.
- [ ] Set Desktop position max = `0` → only rows with `—` for desktop position remain.
- [ ] Set Mobile position max = `0` → only rows with `—` for mobile position remain.
- [ ] Set both to `0` → only rows where both desktop and mobile are `—` remain.
- [ ] Set max = `10` (or any non-zero) → range filter behaves as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)