### PR TITLE
feat: rescan selected rank-tracking keywords with custom depth

### DIFF
--- a/src/client/features/rank-tracking/RankTrackingDomainDetail.tsx
+++ b/src/client/features/rank-tracking/RankTrackingDomainDetail.tsx
@@ -404,6 +404,12 @@ function RankTrackingDomainDetailInner({
             domain={config.domain}
             configId={config.id}
             projectId={projectId}
+            devices={config.devices}
+            defaultSerpDepth={config.serpDepth}
+            onRescanSelected={(keywordIds, serpDepth) =>
+              startCheck({ keywordIds, serpDepth })
+            }
+            rescanDisabled={isBusy || isFreePlan}
           />
         </div>
       </div>

--- a/src/client/features/rank-tracking/RankTrackingTable.tsx
+++ b/src/client/features/rank-tracking/RankTrackingTable.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { toast } from "sonner";
-import { Loader2, Trash2 } from "lucide-react";
+import { Loader2, RefreshCw, Trash2 } from "lucide-react";
 import {
   flexRender,
   getCoreRowModel,
@@ -11,7 +11,15 @@ import { Modal } from "@/client/components/Modal";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { removeTrackingKeywords } from "@/serverFunctions/rank-tracking";
 import { getStandardErrorMessage } from "@/client/lib/error-messages";
-import type { RankTrackingRow } from "@/types/schemas/rank-tracking";
+import type {
+  RankTrackingConfig,
+  RankTrackingRow,
+} from "@/types/schemas/rank-tracking";
+import {
+  depthToPages,
+  estimateRankCheckCredits,
+  pagesToDepth,
+} from "@/shared/rank-tracking";
 import { useRankTrackingColumns } from "./RankTrackingColumns";
 
 export function RankTrackingTable({
@@ -24,6 +32,10 @@ export function RankTrackingTable({
   domain,
   configId,
   projectId,
+  devices,
+  defaultSerpDepth,
+  onRescanSelected,
+  rescanDisabled,
 }: {
   totalCount: number;
   rows: RankTrackingRow[];
@@ -34,9 +46,15 @@ export function RankTrackingTable({
   domain: string;
   configId: string;
   projectId: string;
+  devices: RankTrackingConfig["devices"];
+  defaultSerpDepth: number;
+  onRescanSelected: (keywordIds: string[], serpDepth: number) => void;
+  rescanDisabled: boolean;
 }) {
   const queryClient = useQueryClient();
   const [showConfirm, setShowConfirm] = useState(false);
+  const [showRescan, setShowRescan] = useState(false);
+  const [rescanDepth, setRescanDepth] = useState(defaultSerpDepth);
 
   const columns = useRankTrackingColumns(showDesktop, showMobile, domain);
 
@@ -105,6 +123,22 @@ export function RankTrackingTable({
             {selectedCount !== 1 ? "s" : ""} selected
           </span>
           <button
+            className="btn btn-primary btn-xs gap-1"
+            onClick={() => {
+              setRescanDepth(defaultSerpDepth);
+              setShowRescan(true);
+            }}
+            disabled={rescanDisabled}
+            title={
+              rescanDisabled
+                ? "A rank check is already running"
+                : "Rescan selected keywords"
+            }
+          >
+            <RefreshCw className="size-3" />
+            Rescan selected
+          </button>
+          <button
             className="btn btn-error btn-xs gap-1"
             onClick={() => setShowConfirm(true)}
           >
@@ -118,6 +152,71 @@ export function RankTrackingTable({
             Clear
           </button>
         </div>
+      )}
+
+      {/* Rescan depth modal */}
+      {showRescan && (
+        <Modal maxWidth="max-w-md">
+          <h3 className="text-lg font-semibold">
+            Rescan {selectedCount} keyword
+            {selectedCount !== 1 ? "s" : ""}
+          </h3>
+          <p className="text-sm text-base-content/60 -mt-2">
+            Choose how many SERP pages to fetch for this run. The saved domain
+            depth ({depthToPages(defaultSerpDepth)} page
+            {depthToPages(defaultSerpDepth) !== 1 ? "s" : ""}) is not changed.
+          </p>
+          <div className="form-control">
+            <label className="label">
+              <span className="label-text font-medium">Search depth</span>
+            </label>
+            <select
+              className="select select-bordered w-full"
+              value={depthToPages(rescanDepth)}
+              onChange={(e) =>
+                setRescanDepth(pagesToDepth(Number(e.target.value)))
+              }
+            >
+              {Array.from({ length: 10 }, (_, i) => i + 1).map((pages) => (
+                <option key={pages} value={pages}>
+                  {pages} {pages === 1 ? "page" : "pages"} (top {pages * 10}{" "}
+                  results)
+                </option>
+              ))}
+            </select>
+            <div className="mt-1.5 text-xs text-base-content/60">
+              Estimated cost: ~$
+              {estimateRankCheckCredits(
+                selectedCount,
+                devices,
+                rescanDepth,
+              ).costUsd.toFixed(2)}
+            </div>
+          </div>
+          <div className="flex justify-end gap-2">
+            <button
+              className="btn btn-ghost btn-sm"
+              onClick={() => setShowRescan(false)}
+            >
+              Cancel
+            </button>
+            <button
+              className="btn btn-primary btn-sm gap-1"
+              onClick={() => {
+                onRescanSelected(
+                  selectedRows.map((r) => r.id),
+                  rescanDepth,
+                );
+                setShowRescan(false);
+                table.resetRowSelection();
+              }}
+              disabled={rescanDisabled}
+            >
+              <RefreshCw className="size-3" />
+              Run rescan
+            </button>
+          </div>
+        </Modal>
       )}
 
       {/* Confirm modal */}

--- a/src/client/features/rank-tracking/useRankCheckTrigger.ts
+++ b/src/client/features/rank-tracking/useRankCheckTrigger.ts
@@ -18,12 +18,13 @@ export function useRankCheckTrigger({
   const queryClient = useQueryClient();
 
   const triggerMutation = useMutation({
-    mutationFn: (opts: { keywordIds?: string[] }) =>
+    mutationFn: (opts: { keywordIds?: string[]; serpDepth?: number }) =>
       triggerRankCheck({
         data: {
           projectId,
           configId,
           keywordIds: opts.keywordIds,
+          serpDepth: opts.serpDepth,
         },
       }),
     onSuccess: (result) => {
@@ -44,7 +45,7 @@ export function useRankCheckTrigger({
     },
   });
 
-  const startCheck = (opts: { keywordIds?: string[] }) => {
+  const startCheck = (opts: { keywordIds?: string[]; serpDepth?: number }) => {
     if (triggerMutation.isPending || isRunning) return;
     triggerMutation.mutate(opts);
   };

--- a/src/server/features/rank-tracking/services/RankTrackingService.ts
+++ b/src/server/features/rank-tracking/services/RankTrackingService.ts
@@ -184,6 +184,7 @@ async function triggerCheck(input: {
   projectId: string;
   billingCustomer: BillingCustomerContext;
   keywordIds?: string[];
+  serpDepth?: number;
 }): Promise<RankCheckTriggerResult> {
   const config = await getValidatedConfig(input.configId, input.projectId);
 
@@ -195,9 +196,14 @@ async function triggerCheck(input: {
     );
   }
 
+  const effectiveConfig =
+    input.serpDepth !== undefined
+      ? { ...config, serpDepth: input.serpDepth }
+      : config;
+
   return beginRankCheckRun({
     workflow: env.RANK_CHECK_WORKFLOW,
-    config,
+    config: effectiveConfig,
     projectId: input.projectId,
     billingCustomer: {
       userId: input.billingCustomer.userId,

--- a/src/serverFunctions/rank-tracking.ts
+++ b/src/serverFunctions/rank-tracking.ts
@@ -99,6 +99,7 @@ export const triggerRankCheck = createServerFn({ method: "POST" })
       projectId: context.projectId,
       billingCustomer: context,
       keywordIds: data.keywordIds,
+      serpDepth: data.serpDepth,
     });
 
     if (result.ok) {

--- a/src/types/schemas/rank-tracking.ts
+++ b/src/types/schemas/rank-tracking.ts
@@ -77,6 +77,7 @@ export const triggerCheckSchema = z.object({
   projectId: z.string().uuid(),
   configId: z.string().uuid(),
   keywordIds: z.array(z.string().uuid()).max(2000).optional(),
+  serpDepth: z.number().int().min(10).max(100).multipleOf(10).optional(),
 });
 
 export const comparePeriodSchema = z.enum(["1d", "7d", "30d", "90d"]);


### PR DESCRIPTION
## Summary
Adds a **Rescan selected** bulk action next to **Remove** in the rank-tracking table. Clicking it opens a small dialog where the user picks a one-off SERP depth (1–10 pages, same control as the config modal) and confirms; the selected keywords are then rescanned at that depth.

The saved `serpDepth` on the config is **not** changed — the override only applies to that single workflow run, so scheduled checks continue with the original depth.

Useful when you want to verify ranks deeper for a specific subset (e.g. unranked keywords) without paying the higher cost on every scheduled check.

## Implementation
- `triggerCheckSchema` accepts an optional `serpDepth` (10..100, multipleOf 10 — same constraints as `createConfig`/`updateConfig`).
- `triggerRankCheck` passes `serpDepth` to `RankTrackingService.triggerCheck`.
- `RankTrackingService.triggerCheck` builds an `effectiveConfig = { ...config, serpDepth }` only for `beginRankCheckRun` when an override is provided. Nothing is written back to the DB.
- Client hook `useRankCheckTrigger.startCheck` accepts `serpDepth?` and forwards it.
- `RankTrackingTable` renders the new bulk action button + a depth-selection modal (with cost estimate via `estimateRankCheckCredits`) and calls a new `onRescanSelected(keywordIds, serpDepth)` prop.
- `RankTrackingDomainDetail` wires the new prop to `startCheck({ keywordIds, serpDepth })`. The button is disabled while another check is running and on the free plan.

Existing billing checks remain authoritative: the paid-plan gate in `triggerRankCheck`, and `serpDepth` is bounded by the same min/max as the config schema.

## Files
- `src/types/schemas/rank-tracking.ts`
- `src/serverFunctions/rank-tracking.ts`
- `src/server/features/rank-tracking/services/RankTrackingService.ts`
- `src/client/features/rank-tracking/useRankCheckTrigger.ts`
- `src/client/features/rank-tracking/RankTrackingTable.tsx`
- `src/client/features/rank-tracking/RankTrackingDomainDetail.tsx`

## Test plan
- [ ] On a config with `serpDepth = 40` (4 pages), select a few keywords. Click **Rescan selected**, choose `1 page`, confirm.
- [ ] Verify a new run starts (subset run, only the selected keywords). Cost shown in the dialog matches `estimateRankCheckCredits(selectedCount, devices, depth)`.
- [ ] After the run completes, the saved config still shows `serpDepth = 40` (Configure modal unchanged).
- [ ] While a check is running, **Rescan selected** is disabled with the right tooltip.
- [ ] On the free plan, the button is disabled and the existing paid-plan gate on the server fires if bypassed.
- [ ] Bounds: schema rejects `serpDepth` < 10, > 100, or not a multiple of 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)