### PR TITLE
feat: close modals with the Escape key

### DIFF
--- a/src/client/components/Modal.tsx
+++ b/src/client/components/Modal.tsx
@@ -1,12 +1,24 @@
-import type { ReactNode } from "react";
+import { useEffect, type ReactNode } from "react";
 
 export function Modal({
   maxWidth = "max-w-sm",
   children,
+  onClose,
 }: {
   maxWidth?: string;
   children: ReactNode;
+  /** If provided, pressing Escape closes the modal. */
+  onClose?: () => void;
 }) {
+  useEffect(() => {
+    if (!onClose) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [onClose]);
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
       <div

--- a/src/client/features/rank-tracking/CheckConfirmModal.tsx
+++ b/src/client/features/rank-tracking/CheckConfirmModal.tsx
@@ -34,7 +34,7 @@ export function CheckConfirmModal({
     Math.ceil(totalChecks / KEYWORDS_PER_BATCH) * SECONDS_PER_BATCH;
 
   return (
-    <Modal maxWidth="max-w-md">
+    <Modal maxWidth="max-w-md" onClose={onCancel}>
       <div>
         <h3 className="text-lg font-semibold">
           Check {keywordCount} keyword

--- a/src/client/features/rank-tracking/RankTrackingConfigModal.tsx
+++ b/src/client/features/rank-tracking/RankTrackingConfigModal.tsx
@@ -128,7 +128,10 @@ export function RankTrackingConfigModal({
 
   if (step === "keywords" && createdConfigId) {
     return (
-      <Modal maxWidth="max-w-3xl">
+      <Modal
+        maxWidth="max-w-3xl"
+        onClose={() => onSaved(createdConfigId ?? undefined)}
+      >
         <KeywordSuggestionStep
           configId={createdConfigId}
           projectId={projectId}
@@ -143,7 +146,7 @@ export function RankTrackingConfigModal({
   }
 
   return (
-    <Modal maxWidth="max-w-lg">
+    <Modal maxWidth="max-w-lg" onClose={onClose}>
       <div className="flex items-center justify-between">
         <h2 className="text-lg font-semibold">
           {isEdit ? "Edit Domain Config" : "Add Domain"}

--- a/src/client/features/rank-tracking/RankTrackingDomainList.tsx
+++ b/src/client/features/rank-tracking/RankTrackingDomainList.tsx
@@ -103,7 +103,7 @@ export function RankTrackingDomainList({
       </div>
 
       {archiveTarget && (
-        <Modal>
+        <Modal onClose={() => setArchiveTarget(null)}>
           <h3 className="text-lg font-semibold">
             Archive {archiveTarget.domain}?
           </h3>

--- a/src/client/features/rank-tracking/RankTrackingTable.tsx
+++ b/src/client/features/rank-tracking/RankTrackingTable.tsx
@@ -122,7 +122,7 @@ export function RankTrackingTable({
 
       {/* Confirm modal */}
       {showConfirm && (
-        <Modal>
+        <Modal onClose={() => setShowConfirm(false)}>
           <h3 className="text-lg font-semibold">Remove keywords?</h3>
           <p className="text-sm text-base-content/70">
             This will stop tracking {selectedCount} keyword


### PR DESCRIPTION
## Summary
Pressing **Escape** now closes the rank-tracking modals (Add/Edit Domain config, keyword suggestion step, archive confirm, check confirm, remove confirm). Mirrors the behaviour of the Cancel / X button so it also dismisses unsaved input — same trade-off as today's X button.

## Implementation
`Modal` accepts an optional `onClose` prop. When provided, the modal binds a `window` `keydown` listener while mounted and invokes `onClose` on `Escape`. If `onClose` is omitted, behaviour is unchanged (no Escape handling).

Each existing call site forwards its existing dismiss handler:
- `CheckConfirmModal` → `onCancel`
- `RankTrackingDomainList` archive → `setArchiveTarget(null)`
- `RankTrackingConfigModal` (form) → existing `onClose` prop
- `RankTrackingConfigModal` (keyword step wrapper) → same handler used by the X button (`() => onSaved(createdConfigId ?? undefined)`)
- `RankTrackingTable` remove confirm → `setShowConfirm(false)`

## Files
- `src/client/components/Modal.tsx`
- `src/client/features/rank-tracking/CheckConfirmModal.tsx`
- `src/client/features/rank-tracking/RankTrackingConfigModal.tsx`
- `src/client/features/rank-tracking/RankTrackingDomainList.tsx`
- `src/client/features/rank-tracking/RankTrackingTable.tsx`

## Test plan
- [ ] Open Add Domain modal, press Esc → modal closes (form input is discarded, same as clicking X).
- [ ] Open Edit Domain modal, press Esc → closes.
- [ ] In the keyword-suggestion step (after creating a config), press Esc → modal closes via the same `onSaved` path used by the X button.
- [ ] Click "Check Now" with ≥50 keywords to open the cost confirm modal, press Esc → closes.
- [ ] Select keywords → Remove → press Esc → confirm modal closes without removing.
- [ ] On the domains list, click the archive action to open the archive confirm modal, press Esc → closes without archiving.
- [ ] Verify Esc does nothing when no modal is open (no errors in console, no other handlers triggered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)