### PR TITLE
feat: shift-click range selection for keyword tables

### DIFF
--- a/src/client/features/rank-tracking/KeywordSuggestionStep.tsx
+++ b/src/client/features/rank-tracking/KeywordSuggestionStep.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import {
   useReactTable,
@@ -15,6 +15,7 @@ import { getDomainKeywordSuggestions } from "@/serverFunctions/domain";
 import { addTrackingKeywords } from "@/serverFunctions/rank-tracking";
 import { getStandardErrorMessage } from "@/client/lib/error-messages";
 import { SortableHeader } from "./RankTrackingColumns";
+import { applyShiftRangeSelection } from "./tableSelection";
 
 type SuggestedKeyword = {
   keyword: string;
@@ -25,29 +26,7 @@ type SuggestedKeyword = {
 
 const PRE_SELECT_COUNT = 20;
 
-const columns: ColumnDef<SuggestedKeyword>[] = [
-  {
-    id: "select",
-    size: 32,
-    enableSorting: false,
-    header: ({ table }) => (
-      <input
-        type="checkbox"
-        className="checkbox checkbox-xs"
-        checked={table.getIsAllRowsSelected()}
-        onChange={table.getToggleAllRowsSelectedHandler()}
-      />
-    ),
-    cell: ({ row }) => (
-      <input
-        type="checkbox"
-        className="checkbox checkbox-xs"
-        checked={row.getIsSelected()}
-        onClick={(e) => e.stopPropagation()}
-        onChange={row.getToggleSelectedHandler()}
-      />
-    ),
-  },
+const baseColumns: ColumnDef<SuggestedKeyword>[] = [
   {
     id: "keyword",
     accessorKey: "keyword",
@@ -165,6 +144,39 @@ export function KeywordSuggestionStep({
   const [sorting, setSorting] = useState<SortingState>([
     { id: "position", desc: false },
   ]);
+  const selectAnchorRef = useRef<string | null>(null);
+
+  const columns = useMemo<ColumnDef<SuggestedKeyword>[]>(
+    () => [
+      {
+        id: "select",
+        size: 32,
+        enableSorting: false,
+        header: ({ table }) => (
+          <input
+            type="checkbox"
+            className="checkbox checkbox-xs"
+            checked={table.getIsAllRowsSelected()}
+            onChange={table.getToggleAllRowsSelectedHandler()}
+          />
+        ),
+        cell: ({ row, table }) => (
+          <input
+            type="checkbox"
+            className="checkbox checkbox-xs"
+            checked={row.getIsSelected()}
+            onClick={(e) => {
+              e.stopPropagation();
+              applyShiftRangeSelection(e, row, table, selectAnchorRef);
+            }}
+            onChange={row.getToggleSelectedHandler()}
+          />
+        ),
+      },
+      ...baseColumns,
+    ],
+    [],
+  );
 
   const suggestionsQuery = useQuery({
     queryKey: [
@@ -342,7 +354,14 @@ export function KeywordSuggestionStep({
               <tr
                 key={row.id}
                 className="hover:bg-base-200/50 cursor-pointer"
-                onClick={row.getToggleSelectedHandler()}
+                onClick={(e) => {
+                  if (
+                    applyShiftRangeSelection(e, row, table, selectAnchorRef)
+                  ) {
+                    return;
+                  }
+                  row.toggleSelected();
+                }}
               >
                 {row.getVisibleCells().map((cell) => (
                   <td key={cell.id}>

--- a/src/client/features/rank-tracking/RankTrackingColumns.tsx
+++ b/src/client/features/rank-tracking/RankTrackingColumns.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, type MutableRefObject } from "react";
 import { ArrowUp, ArrowDown } from "lucide-react";
 import type { ColumnDef, SortingFn } from "@tanstack/react-table";
 import type { RankTrackingRow } from "@/types/schemas/rank-tracking";
@@ -11,6 +11,7 @@ import {
   SerpFeatureTags,
   VolumeCell,
 } from "./RankTrackingTableParts";
+import { applyShiftRangeSelection } from "./tableSelection";
 
 const HEADER_TOOLTIPS: Record<string, string> = {
   keyword: "The search term being tracked in Google",
@@ -107,27 +108,32 @@ const positionSort: SortingFn<RankTrackingRow> = (rowA, rowB, columnId) => {
   );
 };
 
-const selectColumn: ColumnDef<RankTrackingRow> = {
-  id: "select",
-  size: 32,
-  enableSorting: false,
-  header: ({ table }) => (
-    <input
-      type="checkbox"
-      className="checkbox checkbox-xs"
-      checked={table.getIsAllRowsSelected()}
-      onChange={table.getToggleAllRowsSelectedHandler()}
-    />
-  ),
-  cell: ({ row }) => (
-    <input
-      type="checkbox"
-      className="checkbox checkbox-xs"
-      checked={row.getIsSelected()}
-      onChange={row.getToggleSelectedHandler()}
-    />
-  ),
-};
+function makeSelectColumn(
+  anchorRef: MutableRefObject<string | null>,
+): ColumnDef<RankTrackingRow> {
+  return {
+    id: "select",
+    size: 32,
+    enableSorting: false,
+    header: ({ table }) => (
+      <input
+        type="checkbox"
+        className="checkbox checkbox-xs"
+        checked={table.getIsAllRowsSelected()}
+        onChange={table.getToggleAllRowsSelectedHandler()}
+      />
+    ),
+    cell: ({ row, table }) => (
+      <input
+        type="checkbox"
+        className="checkbox checkbox-xs"
+        checked={row.getIsSelected()}
+        onClick={(e) => applyShiftRangeSelection(e, row, table, anchorRef)}
+        onChange={row.getToggleSelectedHandler()}
+      />
+    ),
+  };
+}
 
 const keywordColumn: ColumnDef<RankTrackingRow> = {
   id: "keyword",
@@ -206,9 +212,13 @@ export function useRankTrackingColumns(
   showDesktop: boolean,
   showMobile: boolean,
   domain: string,
+  selectAnchorRef: MutableRefObject<string | null>,
 ): ColumnDef<RankTrackingRow>[] {
   return useMemo(() => {
-    const cols: ColumnDef<RankTrackingRow>[] = [selectColumn, keywordColumn];
+    const cols: ColumnDef<RankTrackingRow>[] = [
+      makeSelectColumn(selectAnchorRef),
+      keywordColumn,
+    ];
     if (showDesktop) {
       cols.push(makeDeviceColumn("desktop"));
       cols.push(makeUrlColumn("desktop", domain));
@@ -225,5 +235,5 @@ export function useRankTrackingColumns(
       cols.push(makeSerpColumn("mobile"));
     }
     return cols;
-  }, [showDesktop, showMobile, domain]);
+  }, [showDesktop, showMobile, domain, selectAnchorRef]);
 }

--- a/src/client/features/rank-tracking/RankTrackingTable.tsx
+++ b/src/client/features/rank-tracking/RankTrackingTable.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { toast } from "sonner";
 import { Loader2, Trash2 } from "lucide-react";
 import {
@@ -37,8 +37,14 @@ export function RankTrackingTable({
 }) {
   const queryClient = useQueryClient();
   const [showConfirm, setShowConfirm] = useState(false);
+  const selectAnchorRef = useRef<string | null>(null);
 
-  const columns = useRankTrackingColumns(showDesktop, showMobile, domain);
+  const columns = useRankTrackingColumns(
+    showDesktop,
+    showMobile,
+    domain,
+    selectAnchorRef,
+  );
 
   const table = useReactTable({
     data: rows,

--- a/src/client/features/rank-tracking/tableSelection.ts
+++ b/src/client/features/rank-tracking/tableSelection.ts
@@ -1,0 +1,56 @@
+import type { MouseEvent, MutableRefObject } from "react";
+import type { Row, Table } from "@tanstack/react-table";
+
+/**
+ * Shift-click range selection helper for TanStack Table rows.
+ *
+ * Pass through every click that toggles row selection. Tracks the last
+ * clicked row id in `anchorRef`; on Shift+click, applies the anchor row's
+ * current selection state to every row between the anchor and the clicked
+ * row (in the table's current sort/filter order).
+ *
+ * Returns `true` if the event was handled as a range action (caller should
+ * skip its default toggle); `false` otherwise (caller should toggle as
+ * usual). The anchor is always updated to the most recently clicked row.
+ */
+export function applyShiftRangeSelection<T>(
+  e: MouseEvent<HTMLElement>,
+  row: Row<T>,
+  table: Table<T>,
+  anchorRef: MutableRefObject<string | null>,
+): boolean {
+  const anchorId = anchorRef.current;
+
+  if (!e.shiftKey || !anchorId || anchorId === row.id) {
+    anchorRef.current = row.id;
+    return false;
+  }
+
+  const rows = table.getRowModel().rows;
+  const anchorIdx = rows.findIndex((r) => r.id === anchorId);
+  const currentIdx = rows.findIndex((r) => r.id === row.id);
+
+  if (anchorIdx === -1 || currentIdx === -1) {
+    anchorRef.current = row.id;
+    return false;
+  }
+
+  // Prevent default browser toggle (for checkbox clicks) and avoid the
+  // caller's own toggle path — we apply selection directly.
+  e.preventDefault();
+
+  const [from, to] =
+    anchorIdx < currentIdx
+      ? [anchorIdx, currentIdx]
+      : [currentIdx, anchorIdx];
+
+  // Apply same state as the anchor (last clicked) row, so shift-click can
+  // both extend and contract a selection symmetrically.
+  const targetState = rows[anchorIdx].getIsSelected();
+  for (let i = from; i <= to; i++) {
+    rows[i].toggleSelected(targetState);
+  }
+
+  anchorRef.current = row.id;
+  return true;
+}


### PR DESCRIPTION
## Summary
Click a checkbox or row to set an anchor, then **Shift+click** another checkbox/row to apply the anchor's selection state to every row between them in the table's current sort/filter order. Same gesture used in Gmail, Finder, and most file managers — saves a lot of clicking when you want to remove or operate on a contiguous block of keywords.

The behaviour is symmetric:
- If the anchor is selected, Shift+click extends the selection to the target.
- If the anchor was just deselected, Shift+click clears the selection across the range.

## Implementation
- New helper `tableSelection.ts → applyShiftRangeSelection(e, row, table, anchorRef)` for TanStack Table rows. Returns `true` if it applied a range action (caller skips its default toggle); otherwise just updates the anchor and returns `false`.
- Anchor is a `useRef<string | null>` lifted to each table-host component.
- Wired into:
  - **Rank tracking results table** — checkbox column in `RankTrackingColumns.tsx` (`makeSelectColumn(anchorRef)`), anchor created in `RankTrackingTable.tsx`.
  - **Keyword suggestion step** — checkbox column and full-row click in `KeywordSuggestionStep.tsx`.

Range is computed against `table.getRowModel().rows`, so it respects the user's current sort and any filters — Shift+click between two visible rows always selects what they see between them, regardless of the underlying data order.

## Files
- `src/client/features/rank-tracking/tableSelection.ts` (new)
- `src/client/features/rank-tracking/RankTrackingColumns.tsx`
- `src/client/features/rank-tracking/RankTrackingTable.tsx`
- `src/client/features/rank-tracking/KeywordSuggestionStep.tsx`

## Test plan
- [ ] In the rank-tracking results table: click first keyword's checkbox, scroll, Shift+click another keyword → all in between get selected.
- [ ] Re-sort the table (e.g. by Position desc), repeat Shift+click → range follows the visible order.
- [ ] Apply a filter, then Shift+click → only visible/filtered rows in the range get toggled.
- [ ] Click an already-selected checkbox to deselect (anchor now unselected), Shift+click another → range gets deselected.
- [ ] In the **Add Domain → Keyword suggestions** step: same gesture works on the checkbox column and on Shift+click anywhere on the row.
- [ ] Plain click (no Shift) toggles a single row exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)