### PR TITLE
feat: add personal access tokens

### DIFF
--- a/drizzle/0011_nebulous_psynapse.sql
+++ b/drizzle/0011_nebulous_psynapse.sql
@@ -1,0 +1,18 @@
+CREATE TABLE `mcp_tokens` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`organization_id` text NOT NULL,
+	`name` text NOT NULL,
+	`token_hash` text NOT NULL,
+	`token_prefix` text NOT NULL,
+	`scopes` text DEFAULT '["mcp"]' NOT NULL,
+	`last_used_at` text,
+	`expires_at` text,
+	`revoked_at` text,
+	`created_at` text DEFAULT (current_timestamp) NOT NULL,
+	FOREIGN KEY (`organization_id`) REFERENCES `organization`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `mcp_tokens_token_hash_unique` ON `mcp_tokens` (`token_hash`);--> statement-breakpoint
+CREATE INDEX `mcp_tokens_user_idx` ON `mcp_tokens` (`user_id`);--> statement-breakpoint
+CREATE INDEX `mcp_tokens_org_idx` ON `mcp_tokens` (`organization_id`);

--- a/drizzle/meta/0011_snapshot.json
+++ b/drizzle/meta/0011_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "23436739-8687-4515-96f9-26c79db71c35",
+  "id": "cf77c563-36e5-4feb-bf86-97a08a8813bf",
   "prevId": "c5ffffad-fce7-44dd-9009-c9880c7cb8c0",
   "tables": {
     "audit_lighthouse_results": {
@@ -727,6 +727,131 @@
       "uniqueConstraints": {},
       "checkConstraints": {}
     },
+    "mcp_tokens": {
+      "name": "mcp_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[\"mcp\"]'"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "mcp_tokens_token_hash_unique": {
+          "name": "mcp_tokens_token_hash_unique",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "mcp_tokens_user_idx": {
+          "name": "mcp_tokens_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "mcp_tokens_org_idx": {
+          "name": "mcp_tokens_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "mcp_tokens_organization_id_organization_id_fk": {
+          "name": "mcp_tokens_organization_id_organization_id_fk",
+          "tableFrom": "mcp_tokens",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
     "projects": {
       "name": "projects",
       "columns": {
@@ -775,6 +900,60 @@
           "tableTo": "organization",
           "columnsFrom": [
             "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rank_check_locks": {
+      "name": "rank_check_locks",
+      "columns": {
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "rank_check_locks_run_idx": {
+          "name": "rank_check_locks_run_idx",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "rank_check_locks_config_id_rank_tracking_configs_id_fk": {
+          "name": "rank_check_locks_config_id_rank_tracking_configs_id_fk",
+          "tableFrom": "rank_check_locks",
+          "tableTo": "rank_tracking_configs",
+          "columnsFrom": [
+            "config_id"
           ],
           "columnsTo": [
             "id"
@@ -882,14 +1061,6 @@
             "started_at"
           ],
           "isUnique": false
-        },
-        "rank_check_runs_one_active_per_config_idx": {
-          "name": "rank_check_runs_one_active_per_config_idx",
-          "columns": [
-            "config_id"
-          ],
-          "isUnique": true,
-          "where": "\"rank_check_runs\".\"status\" IN ('pending', 'running')"
         }
       },
       "foreignKeys": {

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -82,8 +82,8 @@
     {
       "idx": 11,
       "version": "6",
-      "when": 1778031161783,
-      "tag": "0011_colorful_dark_beast",
+      "when": 1777922833918,
+      "tag": "0011_nebulous_psynapse",
       "breakpoints": true
     }
   ]

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -15,6 +15,9 @@
   ],
   "project": ["**/*.{js,mjs,ts,tsx}", "!src/routeTree.gen.ts", "!web/**"],
   "ignore": ["drizzle-prod.config.ts"],
+  "ignoreIssues": {
+    "src/db/app.schema.ts": ["exports"],
+  },
   // Disable Drizzle plugin - it tries to load drizzle.config.ts which imports cloudflare:workers
   "drizzle": false,
   "ignoreDependencies": [

--- a/src/client/layout/AppShell.tsx
+++ b/src/client/layout/AppShell.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { Link, useLocation } from "@tanstack/react-router";
-import { useQuery } from "@tanstack/react-query";
 import {
   ChevronDown,
   ChevronsUpDown,
   CircleHelp,
   CreditCard,
+  Key,
   Menu,
   Settings,
   User,
@@ -36,40 +36,47 @@ export function AuthenticatedAppLayout({
   const location = useLocation();
   const [drawerOpen, setDrawerOpen] = React.useState(false);
   const setupModalRef = React.useRef<HTMLDivElement | null>(null);
+  const [isSeoApiKeyConfigured, setIsSeoApiKeyConfigured] = React.useState<
+    boolean | null
+  >(null);
+  const [seoApiKeyStatusError, setSeoApiKeyStatusError] = React.useState(false);
   const [showMissingSeoApiKeyModal, setShowMissingSeoApiKeyModal] =
     React.useState(false);
-  const shouldCheckSeoApiKeyStatus = location.pathname !== BILLING_ROUTE;
-  const seoApiKeyStatusQuery = useQuery({
-    queryKey: ["seoApiKeyStatus"],
-    queryFn: () => getSeoApiKeyStatus(),
-    enabled: shouldCheckSeoApiKeyStatus,
-  });
-  const isSeoApiKeyConfigured = shouldCheckSeoApiKeyStatus
-    ? (seoApiKeyStatusQuery.data?.configured ?? null)
-    : null;
-  const seoApiKeyStatusError =
-    shouldCheckSeoApiKeyStatus && seoApiKeyStatusQuery.isError;
 
   React.useEffect(() => {
-    if (!shouldCheckSeoApiKeyStatus) {
+    if (location.pathname === BILLING_ROUTE) {
+      setSeoApiKeyStatusError(false);
+      setIsSeoApiKeyConfigured(null);
       setShowMissingSeoApiKeyModal(false);
       return;
     }
 
-    if (seoApiKeyStatusQuery.isError) {
-      setShowMissingSeoApiKeyModal(false);
-      return;
-    }
+    let cancelled = false;
 
-    if (!seoApiKeyStatusQuery.isSuccess) return;
-    setShowMissingSeoApiKeyModal(!seoApiKeyStatusQuery.data.configured);
-  }, [
-    location.pathname,
-    seoApiKeyStatusQuery.data,
-    seoApiKeyStatusQuery.isError,
-    seoApiKeyStatusQuery.isSuccess,
-    shouldCheckSeoApiKeyStatus,
-  ]);
+    const checkSeoApiKeyStatus = async () => {
+      try {
+        const result = await getSeoApiKeyStatus();
+        if (cancelled) return;
+
+        setSeoApiKeyStatusError(false);
+        setIsSeoApiKeyConfigured(result.configured);
+        if (!result.configured) {
+          setShowMissingSeoApiKeyModal(true);
+        }
+      } catch {
+        if (cancelled) return;
+        setSeoApiKeyStatusError(true);
+        setIsSeoApiKeyConfigured(null);
+        setShowMissingSeoApiKeyModal(false);
+      }
+    };
+
+    void checkSeoApiKeyStatus();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [location.pathname]);
 
   const shouldShowMissingSeoApiKeyModal =
     showMissingSeoApiKeyModal && location.pathname !== DATAFORSEO_HELP_PATH;
@@ -341,6 +348,12 @@ function AccountMenu({ mobileOnly = false }: { mobileOnly?: boolean }) {
             <Link to="/settings" className="flex items-center gap-2">
               <Settings className="h-4 w-4" />
               Settings
+            </Link>
+          </li>
+          <li>
+            <Link to="/tokens" className="flex items-center gap-2">
+              <Key className="h-4 w-4" />
+              API Tokens
             </Link>
           </li>
           {isHostedMode && email ? (

--- a/src/db/app.schema.ts
+++ b/src/db/app.schema.ts
@@ -168,11 +168,7 @@ export const rankTrackingKeywords = sqliteTable(
   ],
 );
 
-// One row per check execution (manual or scheduled).
-// A partial unique index on `config_id WHERE status IN ('pending','running')`
-// enforces at most one in-flight run per config at the DB level, which is how
-// duplicate-trigger protection is implemented — INSERT of a second pending run
-// for the same config fails with a unique-constraint violation.
+// One row per check execution (manual or scheduled)
 export const rankCheckRuns = sqliteTable(
   "rank_check_runs",
   {
@@ -202,10 +198,22 @@ export const rankCheckRuns = sqliteTable(
   (table) => [
     index("rank_check_runs_config_idx").on(table.configId, table.startedAt),
     index("rank_check_runs_project_idx").on(table.projectId, table.startedAt),
-    uniqueIndex("rank_check_runs_one_active_per_config_idx")
-      .on(table.configId)
-      .where(sql`${table.status} IN ('pending', 'running')`),
   ],
+);
+
+// One active lock per rank tracking config to prevent overlapping runs
+export const rankCheckLocks = sqliteTable(
+  "rank_check_locks",
+  {
+    configId: text("config_id")
+      .primaryKey()
+      .references(() => rankTrackingConfigs.id, { onDelete: "cascade" }),
+    runId: text("run_id").notNull(),
+    acquiredAt: text("acquired_at")
+      .notNull()
+      .default(sql`(current_timestamp)`),
+  },
+  (table) => [index("rank_check_locks_run_idx").on(table.runId)],
 );
 
 // One row per keyword per device per check run
@@ -362,4 +370,33 @@ export const auditLighthouseResults = sqliteTable(
     payloadSizeBytes: integer("payload_size_bytes"),
   },
   (table) => [index("audit_lighthouse_results_audit_id_idx").on(table.auditId)],
+);
+
+// Personal access tokens for MCP / future general API access.
+// userId is plain text (not FK) because the user identifier comes from
+// different sources across auth modes (better-auth user.id, delegated_users.id,
+// or a synthesized "local" id for local_noauth Docker).
+export const mcpTokens = sqliteTable(
+  "mcp_tokens",
+  {
+    id: text("id").primaryKey(),
+    userId: text("user_id").notNull(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    name: text("name").notNull(),
+    tokenHash: text("token_hash").notNull().unique(),
+    tokenPrefix: text("token_prefix").notNull(),
+    scopes: text("scopes").notNull().default('["mcp"]'),
+    lastUsedAt: text("last_used_at"),
+    expiresAt: text("expires_at"),
+    revokedAt: text("revoked_at"),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(current_timestamp)`),
+  },
+  (table) => [
+    index("mcp_tokens_user_idx").on(table.userId),
+    index("mcp_tokens_org_idx").on(table.organizationId),
+  ],
 );

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -20,6 +20,7 @@ import { Route as AppIndexRouteImport } from './routes/_app/index'
 import { Route as AuthenticatedSubscribeRouteImport } from './routes/_authenticated.subscribe'
 import { Route as AuthSignUpRouteImport } from './routes/_auth.sign-up'
 import { Route as AuthSignInRouteImport } from './routes/_auth.sign-in'
+import { Route as AppTokensRouteImport } from './routes/_app/tokens'
 import { Route as AppSupportRouteImport } from './routes/_app/support'
 import { Route as AppSettingsRouteImport } from './routes/_app/settings'
 import { Route as AppBillingRouteImport } from './routes/_app/billing'
@@ -92,6 +93,11 @@ const AuthSignInRoute = AuthSignInRouteImport.update({
   id: '/sign-in',
   path: '/sign-in',
   getParentRoute: () => AuthRoute,
+} as any)
+const AppTokensRoute = AppTokensRouteImport.update({
+  id: '/tokens',
+  path: '/tokens',
+  getParentRoute: () => AppRouteRoute,
 } as any)
 const AppSupportRoute = AppSupportRouteImport.update({
   id: '/support',
@@ -216,6 +222,7 @@ export interface FileRoutesByFullPath {
   '/billing': typeof AppBillingRoute
   '/settings': typeof AppSettingsRoute
   '/support': typeof AppSupportRoute
+  '/tokens': typeof AppTokensRoute
   '/sign-in': typeof AuthSignInRoute
   '/sign-up': typeof AuthSignUpRoute
   '/subscribe': typeof AuthenticatedSubscribeRoute
@@ -246,6 +253,7 @@ export interface FileRoutesByTo {
   '/billing': typeof AppBillingRoute
   '/settings': typeof AppSettingsRoute
   '/support': typeof AppSupportRoute
+  '/tokens': typeof AppTokensRoute
   '/sign-in': typeof AuthSignInRoute
   '/sign-up': typeof AuthSignUpRoute
   '/subscribe': typeof AuthenticatedSubscribeRoute
@@ -277,6 +285,7 @@ export interface FileRoutesById {
   '/_app/billing': typeof AppBillingRoute
   '/_app/settings': typeof AppSettingsRoute
   '/_app/support': typeof AppSupportRoute
+  '/_app/tokens': typeof AppTokensRoute
   '/_auth/sign-in': typeof AuthSignInRoute
   '/_auth/sign-up': typeof AuthSignUpRoute
   '/_authenticated/subscribe': typeof AuthenticatedSubscribeRoute
@@ -310,6 +319,7 @@ export interface FileRouteTypes {
     | '/billing'
     | '/settings'
     | '/support'
+    | '/tokens'
     | '/sign-in'
     | '/sign-up'
     | '/subscribe'
@@ -340,6 +350,7 @@ export interface FileRouteTypes {
     | '/billing'
     | '/settings'
     | '/support'
+    | '/tokens'
     | '/sign-in'
     | '/sign-up'
     | '/subscribe'
@@ -370,6 +381,7 @@ export interface FileRouteTypes {
     | '/_app/billing'
     | '/_app/settings'
     | '/_app/support'
+    | '/_app/tokens'
     | '/_auth/sign-in'
     | '/_auth/sign-up'
     | '/_authenticated/subscribe'
@@ -484,6 +496,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/sign-in'
       preLoaderRoute: typeof AuthSignInRouteImport
       parentRoute: typeof AuthRoute
+    }
+    '/_app/tokens': {
+      id: '/_app/tokens'
+      path: '/tokens'
+      fullPath: '/tokens'
+      preLoaderRoute: typeof AppTokensRouteImport
+      parentRoute: typeof AppRouteRoute
     }
     '/_app/support': {
       id: '/_app/support'
@@ -639,6 +658,7 @@ interface AppRouteRouteChildren {
   AppBillingRoute: typeof AppBillingRoute
   AppSettingsRoute: typeof AppSettingsRoute
   AppSupportRoute: typeof AppSupportRoute
+  AppTokensRoute: typeof AppTokensRoute
   AppIndexRoute: typeof AppIndexRoute
   AppHelpDataforseoApiKeyRoute: typeof AppHelpDataforseoApiKeyRoute
 }
@@ -647,6 +667,7 @@ const AppRouteRouteChildren: AppRouteRouteChildren = {
   AppBillingRoute: AppBillingRoute,
   AppSettingsRoute: AppSettingsRoute,
   AppSupportRoute: AppSupportRoute,
+  AppTokensRoute: AppTokensRoute,
   AppIndexRoute: AppIndexRoute,
   AppHelpDataforseoApiKeyRoute: AppHelpDataforseoApiKeyRoute,
 }

--- a/src/routes/_app/tokens.tsx
+++ b/src/routes/_app/tokens.tsx
@@ -1,0 +1,192 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { toast } from "sonner";
+import { Copy, Trash2 } from "lucide-react";
+import {
+  createMcpToken,
+  listMcpTokens,
+  revokeMcpToken,
+} from "@/serverFunctions/tokens";
+
+export const Route = createFileRoute("/_app/tokens")({
+  component: TokensPage,
+});
+
+function TokensPage() {
+  const queryClient = useQueryClient();
+  const [name, setName] = useState("");
+  const [createdToken, setCreatedToken] = useState<string | null>(null);
+
+  const tokensQuery = useQuery({
+    queryKey: ["mcpTokens"],
+    queryFn: () => listMcpTokens({ data: undefined }),
+  });
+
+  const createMutation = useMutation({
+    mutationFn: (newName: string) =>
+      createMcpToken({ data: { name: newName } }),
+    onSuccess: (token) => {
+      setCreatedToken(token.token);
+      setName("");
+      void queryClient.invalidateQueries({ queryKey: ["mcpTokens"] });
+    },
+    onError: () => toast.error("Failed to create token"),
+  });
+
+  const revokeMutation = useMutation({
+    mutationFn: (id: string) => revokeMcpToken({ data: { id } }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["mcpTokens"] });
+      toast.success("Token revoked");
+    },
+    onError: () => toast.error("Failed to revoke token"),
+  });
+
+  async function copyToken(token: string) {
+    try {
+      await navigator.clipboard.writeText(token);
+      toast.success("Token copied to clipboard");
+    } catch {
+      toast.error("Couldn't copy — copy manually");
+    }
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!name.trim()) return;
+    createMutation.mutate(name.trim());
+  }
+
+  const tokens = tokensQuery.data ?? [];
+
+  return (
+    <div className="h-full overflow-auto bg-base-100 px-4 py-8 pb-24 md:px-6 md:py-12 md:pb-8">
+      <div className="mx-auto max-w-2xl space-y-8">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">API Tokens</h1>
+          <p className="mt-2 text-sm text-base-content/70">
+            Personal access tokens for OpenSEO API access. Create a token for
+            each external client you connect.
+          </p>
+        </div>
+
+        {createdToken ? (
+          <section className="rounded-lg border border-warning/40 bg-warning/5 p-4 space-y-3">
+            <h2 className="text-sm font-semibold">
+              Copy your token now — it won't be shown again
+            </h2>
+            <div className="flex items-center gap-2">
+              <code className="flex-1 truncate rounded bg-base-200 px-3 py-2 text-xs font-mono">
+                {createdToken}
+              </code>
+              <button
+                type="button"
+                className="btn btn-sm btn-ghost"
+                onClick={() => void copyToken(createdToken)}
+              >
+                <Copy className="h-4 w-4" />
+              </button>
+            </div>
+            <button
+              type="button"
+              className="btn btn-sm btn-ghost"
+              onClick={() => setCreatedToken(null)}
+            >
+              I've copied it
+            </button>
+          </section>
+        ) : null}
+
+        <section className="space-y-3">
+          <h2 className="text-sm font-medium text-base-content/50">
+            Create a new token
+          </h2>
+          <form onSubmit={handleSubmit} className="flex gap-2">
+            <input
+              type="text"
+              className="input input-bordered flex-1"
+              placeholder="e.g. 'Claude Desktop'"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              maxLength={100}
+              disabled={createMutation.isPending}
+            />
+            <button
+              type="submit"
+              className="btn btn-primary"
+              disabled={!name.trim() || createMutation.isPending}
+            >
+              {createMutation.isPending ? "Creating…" : "Create token"}
+            </button>
+          </form>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-sm font-medium text-base-content/50">
+            Active tokens ({tokens.length})
+          </h2>
+          {tokensQuery.isLoading ? (
+            <p className="text-sm text-base-content/50">Loading…</p>
+          ) : tokens.length === 0 ? (
+            <p className="text-sm text-base-content/50">
+              No tokens yet. Create one to get started.
+            </p>
+          ) : (
+            <ul className="divide-y divide-base-300 rounded-lg border border-base-300">
+              {tokens.map((token) => (
+                <li
+                  key={token.id}
+                  className="flex items-center gap-3 px-4 py-3"
+                >
+                  <div className="flex-1 min-w-0">
+                    <div className="font-medium text-sm">{token.name}</div>
+                    <div className="text-xs text-base-content/50 font-mono">
+                      {token.prefix}…{" "}
+                      <span className="font-sans">
+                        · created {formatDate(token.createdAt)}
+                        {token.lastUsedAt
+                          ? ` · last used ${formatDate(token.lastUsedAt)}`
+                          : " · never used"}
+                      </span>
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    className="btn btn-sm btn-ghost text-error"
+                    onClick={() => {
+                      if (
+                        confirm(
+                          `Revoke "${token.name}"? Clients using this token will stop working immediately.`,
+                        )
+                      ) {
+                        revokeMutation.mutate(token.id);
+                      }
+                    }}
+                    disabled={revokeMutation.isPending}
+                    aria-label="Revoke"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+      </div>
+    </div>
+  );
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  } catch {
+    return iso;
+  }
+}

--- a/src/server/features/tokens/repositories/TokenRepository.ts
+++ b/src/server/features/tokens/repositories/TokenRepository.ts
@@ -1,0 +1,76 @@
+import { and, desc, eq, isNull } from "drizzle-orm";
+import { db } from "@/db";
+import { mcpTokens } from "@/db/schema";
+
+type TokenRow = typeof mcpTokens.$inferSelect;
+
+async function findByHash(tokenHash: string): Promise<TokenRow | undefined> {
+  return db.query.mcpTokens.findFirst({
+    where: and(eq(mcpTokens.tokenHash, tokenHash), isNull(mcpTokens.revokedAt)),
+  });
+}
+
+async function listForUser(userId: string, organizationId: string) {
+  return db.query.mcpTokens.findMany({
+    where: and(
+      eq(mcpTokens.userId, userId),
+      eq(mcpTokens.organizationId, organizationId),
+    ),
+    orderBy: desc(mcpTokens.createdAt),
+  });
+}
+
+async function getById(
+  id: string,
+  userId: string,
+  organizationId: string,
+): Promise<TokenRow | undefined> {
+  return db.query.mcpTokens.findFirst({
+    where: and(
+      eq(mcpTokens.id, id),
+      eq(mcpTokens.userId, userId),
+      eq(mcpTokens.organizationId, organizationId),
+    ),
+  });
+}
+
+async function insert(row: {
+  id: string;
+  userId: string;
+  organizationId: string;
+  name: string;
+  tokenHash: string;
+  tokenPrefix: string;
+  scopes: string;
+}) {
+  await db.insert(mcpTokens).values(row);
+}
+
+async function revoke(id: string, userId: string, organizationId: string) {
+  await db
+    .update(mcpTokens)
+    .set({ revokedAt: new Date().toISOString() })
+    .where(
+      and(
+        eq(mcpTokens.id, id),
+        eq(mcpTokens.userId, userId),
+        eq(mcpTokens.organizationId, organizationId),
+      ),
+    );
+}
+
+async function touchLastUsed(id: string) {
+  await db
+    .update(mcpTokens)
+    .set({ lastUsedAt: new Date().toISOString() })
+    .where(eq(mcpTokens.id, id));
+}
+
+export const TokenRepository = {
+  findByHash,
+  listForUser,
+  getById,
+  insert,
+  revoke,
+  touchLastUsed,
+} as const;

--- a/src/server/features/tokens/services/TokenService.test.ts
+++ b/src/server/features/tokens/services/TokenService.test.ts
@@ -1,0 +1,195 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  findByHashMock,
+  insertMock,
+  listForUserMock,
+  getByIdMock,
+  revokeMock,
+  touchLastUsedMock,
+} = vi.hoisted(() => ({
+  findByHashMock: vi.fn(),
+  insertMock: vi.fn(),
+  listForUserMock: vi.fn(),
+  getByIdMock: vi.fn(),
+  revokeMock: vi.fn(),
+  touchLastUsedMock: vi.fn(),
+}));
+
+vi.mock("@/server/features/tokens/repositories/TokenRepository", () => ({
+  TokenRepository: {
+    findByHash: findByHashMock,
+    insert: insertMock,
+    listForUser: listForUserMock,
+    getById: getByIdMock,
+    revoke: revokeMock,
+    touchLastUsed: touchLastUsedMock,
+  },
+}));
+
+import { TokenService } from "./TokenService";
+
+describe("TokenService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("create", () => {
+    it("generates a token with the op_live_ prefix and inserts a hashed row", async () => {
+      let captured: { tokenHash: string; scopes: string } | null = null;
+      insertMock.mockImplementation(
+        (row: { tokenHash: string; scopes: string }) => {
+          captured = row;
+          return Promise.resolve();
+        },
+      );
+      const result = await TokenService.create({
+        userId: "user_1",
+        organizationId: "org_1",
+        name: "Claude Desktop",
+      });
+      expect(result.token).toMatch(/^op_live_/);
+      expect(result.token.length).toBeGreaterThan(20);
+      expect(result.prefix).toBe(result.token.slice(0, 12));
+      expect(result.scopes).toEqual(["mcp"]);
+      expect(insertMock).toHaveBeenCalledTimes(1);
+      expect(captured).not.toBeNull();
+      // Hash is stored, not the plaintext token. SHA-256 hex is 64 chars.
+      expect(captured!.tokenHash).toMatch(/^[0-9a-f]{64}$/);
+      expect(captured!.tokenHash).not.toBe(result.token);
+      expect(captured!.scopes).toBe(JSON.stringify(["mcp"]));
+    });
+
+    it("rejects empty or oversized names", async () => {
+      await expect(
+        TokenService.create({
+          userId: "u",
+          organizationId: "o",
+          name: "",
+        }),
+      ).rejects.toThrow();
+      await expect(
+        TokenService.create({
+          userId: "u",
+          organizationId: "o",
+          name: "x".repeat(101),
+        }),
+      ).rejects.toThrow();
+      expect(insertMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("validate", () => {
+    it("returns null for malformed tokens", async () => {
+      await expect(TokenService.validate("not_a_token")).resolves.toBeNull();
+      await expect(TokenService.validate("op_live_")).resolves.toBeNull();
+      expect(findByHashMock).not.toHaveBeenCalled();
+    });
+
+    it("returns null when no row matches", async () => {
+      findByHashMock.mockResolvedValue(undefined);
+      await expect(
+        TokenService.validate("op_live_abcdefgh"),
+      ).resolves.toBeNull();
+    });
+
+    it("returns null for expired tokens", async () => {
+      findByHashMock.mockResolvedValue({
+        id: "t1",
+        userId: "u1",
+        organizationId: "o1",
+        scopes: '["mcp"]',
+        expiresAt: new Date(Date.now() - 1000).toISOString(),
+        revokedAt: null,
+      });
+      await expect(
+        TokenService.validate("op_live_abcdefgh"),
+      ).resolves.toBeNull();
+    });
+
+    it("returns the row for a valid token and touches lastUsed", async () => {
+      findByHashMock.mockResolvedValue({
+        id: "t1",
+        userId: "u1",
+        organizationId: "o1",
+        scopes: '["mcp","api:read"]',
+        expiresAt: null,
+        revokedAt: null,
+      });
+      const result = await TokenService.validate("op_live_abcdefgh");
+      expect(result).toEqual({
+        id: "t1",
+        userId: "u1",
+        organizationId: "o1",
+        scopes: ["mcp", "api:read"],
+      });
+      expect(touchLastUsedMock).toHaveBeenCalledWith("t1");
+    });
+  });
+
+  describe("list", () => {
+    it("filters out revoked tokens and parses scopes", async () => {
+      listForUserMock.mockResolvedValue([
+        {
+          id: "t1",
+          name: "active",
+          tokenPrefix: "op_live_aaa",
+          scopes: '["mcp"]',
+          lastUsedAt: null,
+          expiresAt: null,
+          revokedAt: null,
+          createdAt: "2026-05-04",
+        },
+        {
+          id: "t2",
+          name: "revoked",
+          tokenPrefix: "op_live_bbb",
+          scopes: '["mcp"]',
+          lastUsedAt: null,
+          expiresAt: null,
+          revokedAt: "2026-05-03",
+          createdAt: "2026-05-01",
+        },
+      ]);
+      const result = await TokenService.list("u1", "o1");
+      expect(result).toHaveLength(1);
+      expect(result[0]?.id).toBe("t1");
+    });
+  });
+
+  describe("revoke", () => {
+    it("calls the repo when the token exists", async () => {
+      getByIdMock.mockResolvedValue({ id: "t1", revokedAt: null });
+      await TokenService.revoke({
+        id: "t1",
+        userId: "u1",
+        organizationId: "o1",
+      });
+      expect(revokeMock).toHaveBeenCalledWith("t1", "u1", "o1");
+    });
+
+    it("is a no-op for already-revoked tokens", async () => {
+      getByIdMock.mockResolvedValue({
+        id: "t1",
+        revokedAt: "2026-05-01",
+      });
+      await TokenService.revoke({
+        id: "t1",
+        userId: "u1",
+        organizationId: "o1",
+      });
+      expect(revokeMock).not.toHaveBeenCalled();
+    });
+
+    it("throws when the token doesn't exist", async () => {
+      getByIdMock.mockResolvedValue(undefined);
+      await expect(
+        TokenService.revoke({
+          id: "missing",
+          userId: "u",
+          organizationId: "o",
+        }),
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/src/server/features/tokens/services/TokenService.ts
+++ b/src/server/features/tokens/services/TokenService.ts
@@ -1,0 +1,173 @@
+import { TokenRepository } from "@/server/features/tokens/repositories/TokenRepository";
+import { AppError } from "@/server/lib/errors";
+
+const TOKEN_PREFIX = "op_live_";
+const RANDOM_BYTES = 32;
+const PREVIEW_LENGTH = 12;
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+async function sha256Hex(value: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const buffer = await crypto.subtle.digest("SHA-256", encoder.encode(value));
+  return Array.from(new Uint8Array(buffer))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function generateToken(): string {
+  const random = new Uint8Array(RANDOM_BYTES);
+  crypto.getRandomValues(random);
+  return TOKEN_PREFIX + bytesToBase64Url(random);
+}
+
+function isValidTokenShape(token: string): boolean {
+  return token.startsWith(TOKEN_PREFIX) && token.length > TOKEN_PREFIX.length;
+}
+
+type CreatedToken = {
+  id: string;
+  name: string;
+  prefix: string;
+  scopes: string[];
+  createdAt: string;
+  // Plaintext token, only returned at creation time.
+  token: string;
+};
+
+type ListedToken = {
+  id: string;
+  name: string;
+  prefix: string;
+  scopes: string[];
+  lastUsedAt: string | null;
+  expiresAt: string | null;
+  createdAt: string;
+};
+
+type ValidatedToken = {
+  id: string;
+  userId: string;
+  organizationId: string;
+  scopes: string[];
+};
+
+async function create(input: {
+  userId: string;
+  organizationId: string;
+  name: string;
+}): Promise<CreatedToken> {
+  const trimmedName = input.name.trim();
+  if (trimmedName.length === 0 || trimmedName.length > 100) {
+    throw new AppError("VALIDATION_ERROR");
+  }
+
+  const token = generateToken();
+  const tokenHash = await sha256Hex(token);
+  const tokenPrefix = token.slice(0, PREVIEW_LENGTH);
+  const id = crypto.randomUUID();
+  const scopes = ["mcp"] as const;
+
+  await TokenRepository.insert({
+    id,
+    userId: input.userId,
+    organizationId: input.organizationId,
+    name: trimmedName,
+    tokenHash,
+    tokenPrefix,
+    scopes: JSON.stringify(scopes),
+  });
+
+  return {
+    id,
+    name: trimmedName,
+    prefix: tokenPrefix,
+    scopes: [...scopes],
+    createdAt: new Date().toISOString(),
+    token,
+  };
+}
+
+function parseScopes(raw: string): string[] {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((s): s is string => typeof s === "string");
+  } catch {
+    return [];
+  }
+}
+
+async function list(
+  userId: string,
+  organizationId: string,
+): Promise<ListedToken[]> {
+  const rows = await TokenRepository.listForUser(userId, organizationId);
+  return rows
+    .filter((row) => row.revokedAt == null)
+    .map((row) => ({
+      id: row.id,
+      name: row.name,
+      prefix: row.tokenPrefix,
+      scopes: parseScopes(row.scopes),
+      lastUsedAt: row.lastUsedAt,
+      expiresAt: row.expiresAt,
+      createdAt: row.createdAt,
+    }));
+}
+
+async function revoke(input: {
+  id: string;
+  userId: string;
+  organizationId: string;
+}) {
+  const existing = await TokenRepository.getById(
+    input.id,
+    input.userId,
+    input.organizationId,
+  );
+  if (!existing) {
+    throw new AppError("NOT_FOUND");
+  }
+  if (existing.revokedAt != null) {
+    return; // already revoked, idempotent
+  }
+  await TokenRepository.revoke(input.id, input.userId, input.organizationId);
+}
+
+async function validate(token: string): Promise<ValidatedToken | null> {
+  if (!isValidTokenShape(token)) return null;
+  const tokenHash = await sha256Hex(token);
+  const row = await TokenRepository.findByHash(tokenHash);
+  if (!row) return null;
+  if (row.expiresAt != null && new Date(row.expiresAt) < new Date()) {
+    return null;
+  }
+  // Best-effort touch — don't await failure path since the validate call
+  // shouldn't fail on a write hiccup. (Background-write debouncing could be
+  // added later via KV if D1 write volume becomes a concern.)
+  void TokenRepository.touchLastUsed(row.id);
+
+  return {
+    id: row.id,
+    userId: row.userId,
+    organizationId: row.organizationId,
+    scopes: parseScopes(row.scopes),
+  };
+}
+
+export const TokenService = {
+  create,
+  list,
+  revoke,
+  validate,
+} as const;

--- a/src/serverFunctions/tokens.ts
+++ b/src/serverFunctions/tokens.ts
@@ -1,0 +1,37 @@
+import { createServerFn } from "@tanstack/react-start";
+import { z } from "zod";
+import { TokenService } from "@/server/features/tokens/services/TokenService";
+import { requireAuthenticatedContext } from "@/serverFunctions/middleware";
+
+export const listMcpTokens = createServerFn({ method: "POST" })
+  .middleware(requireAuthenticatedContext)
+  .handler(async ({ context }) =>
+    TokenService.list(context.userId, context.organizationId),
+  );
+
+export const createMcpToken = createServerFn({ method: "POST" })
+  .middleware(requireAuthenticatedContext)
+  .inputValidator((data: unknown) =>
+    z.object({ name: z.string().min(1).max(100) }).parse(data),
+  )
+  .handler(async ({ data, context }) =>
+    TokenService.create({
+      userId: context.userId,
+      organizationId: context.organizationId,
+      name: data.name,
+    }),
+  );
+
+export const revokeMcpToken = createServerFn({ method: "POST" })
+  .middleware(requireAuthenticatedContext)
+  .inputValidator((data: unknown) =>
+    z.object({ id: z.string().min(1) }).parse(data),
+  )
+  .handler(async ({ data, context }) => {
+    await TokenService.revoke({
+      id: data.id,
+      userId: context.userId,
+      organizationId: context.organizationId,
+    });
+    return { success: true };
+  });


### PR DESCRIPTION
Adds hashed personal access tokens with create/list/revoke server functions, a /tokens management page, navigation entry, D1 schema/migration, and TokenService tests.\n\nStack: 1/3. Base for the MCP server skeleton PR.