### PR TITLE
feat: add OpenSEO MCP tools

### DIFF
--- a/src/mcp/handler.ts
+++ b/src/mcp/handler.ts
@@ -5,6 +5,14 @@ import { packAuthInfo } from "@/mcp/context";
 import { deriveBaseUrlFromRequest } from "@/mcp/urls";
 import { whoamiTool } from "@/mcp/tools/whoami";
 import { listProjectsTool } from "@/mcp/tools/list-projects";
+import { listSavedKeywordsTool } from "@/mcp/tools/list-saved-keywords";
+import { researchKeywordsTool } from "@/mcp/tools/research-keywords";
+import { saveKeywordsTool } from "@/mcp/tools/save-keywords";
+import { getDomainOverviewTool } from "@/mcp/tools/get-domain-overview";
+import { getDomainKeywordSuggestionsTool } from "@/mcp/tools/get-domain-keyword-suggestions";
+import { getBacklinksOverviewTool } from "@/mcp/tools/get-backlinks-overview";
+import { dfsSerpLiveTool } from "@/mcp/tools/dfs-serp-live";
+import { getRankTrackerTool } from "@/mcp/tools/get-rank-tracker";
 
 const SERVER_INFO = {
   name: "OpenSEO",
@@ -20,6 +28,46 @@ function buildServer() {
     listProjectsTool.name,
     listProjectsTool.config,
     listProjectsTool.handler,
+  );
+  server.registerTool(
+    listSavedKeywordsTool.name,
+    listSavedKeywordsTool.config,
+    listSavedKeywordsTool.handler,
+  );
+  server.registerTool(
+    researchKeywordsTool.name,
+    researchKeywordsTool.config,
+    researchKeywordsTool.handler,
+  );
+  server.registerTool(
+    saveKeywordsTool.name,
+    saveKeywordsTool.config,
+    saveKeywordsTool.handler,
+  );
+  server.registerTool(
+    getDomainOverviewTool.name,
+    getDomainOverviewTool.config,
+    getDomainOverviewTool.handler,
+  );
+  server.registerTool(
+    getDomainKeywordSuggestionsTool.name,
+    getDomainKeywordSuggestionsTool.config,
+    getDomainKeywordSuggestionsTool.handler,
+  );
+  server.registerTool(
+    getBacklinksOverviewTool.name,
+    getBacklinksOverviewTool.config,
+    getBacklinksOverviewTool.handler,
+  );
+  server.registerTool(
+    dfsSerpLiveTool.name,
+    dfsSerpLiveTool.config,
+    dfsSerpLiveTool.handler,
+  );
+  server.registerTool(
+    getRankTrackerTool.name,
+    getRankTrackerTool.config,
+    getRankTrackerTool.handler,
   );
   return server;
 }

--- a/src/mcp/schemas.ts
+++ b/src/mcp/schemas.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+export const projectIdSchema = z
+  .string()
+  .min(1)
+  .describe(
+    "Required. The OpenSEO project ID to scope this call to. Get one from list_projects.",
+  );
+
+export const locationCodeSchema = z
+  .number()
+  .int()
+  .positive()
+  .describe(
+    "DataForSEO location code. Defaults to 2840 (United States). See dataforseo.com/help-center/locations.",
+  );
+
+export const languageCodeSchema = z
+  .string()
+  .min(2)
+  .describe("Language code (e.g. 'en', 'es', 'fr'). Defaults to 'en'.");

--- a/src/mcp/tools/dfs-serp-live.ts
+++ b/src/mcp/tools/dfs-serp-live.ts
@@ -1,0 +1,111 @@
+import { z } from "zod";
+import { ProjectService } from "@/server/features/projects/services/ProjectService";
+import { createDataforseoClient } from "@/server/lib/dataforseoClient";
+import { mcpResponse } from "@/mcp/formatters";
+import {
+  buildBillingCustomer,
+  getAuth,
+  getBaseUrl,
+  type ToolExtra,
+} from "@/mcp/context";
+import { buildDashboardUrl } from "@/mcp/urls";
+import {
+  languageCodeSchema,
+  locationCodeSchema,
+  projectIdSchema,
+} from "@/mcp/schemas";
+
+const querySchema = z.object({
+  keyword: z.string().min(1),
+  locationCode: locationCodeSchema.optional(),
+  languageCode: languageCodeSchema.optional(),
+});
+
+const inputSchema = {
+  projectId: projectIdSchema,
+  queries: z
+    .array(querySchema)
+    .min(1)
+    .max(25)
+    .describe(
+      "1-25 queries. Bulk-friendly — prefer this over multiple single-query calls.",
+    ),
+} as const;
+
+type Args = z.infer<z.ZodObject<typeof inputSchema>>;
+
+export const dfsSerpLiveTool = {
+  name: "dfs_serp_live",
+  config: {
+    title: "Live Google SERP results (raw)",
+    description:
+      "Fetches live Google SERP organic results for 1-25 queries. Pass-through to DataForSEO (the `dfs_` prefix indicates raw access — does not save to OpenSEO state). Charges credits per query (~30-60 each). Per-query errors don't fail the batch.",
+    inputSchema,
+  },
+  handler: async (args: Args, extra: ToolExtra) => {
+    const auth = getAuth(extra);
+    const baseUrl = getBaseUrl(extra);
+    await ProjectService.getProjectForOrganization(
+      auth.organizationId,
+      args.projectId,
+    );
+    const billing = buildBillingCustomer(auth, args.projectId);
+    const client = createDataforseoClient(billing);
+
+    const results = await Promise.all(
+      args.queries.map(async (q) => {
+        try {
+          const items = await client.serp.live({
+            keyword: q.keyword,
+            locationCode: q.locationCode ?? 2840,
+            languageCode: q.languageCode ?? "en",
+          });
+          // Trim noise — return only essentials per item.
+          const trimmed = items.slice(0, 20).map((item) => ({
+            type: item.type,
+            rank: item.rank_absolute ?? item.rank_group ?? null,
+            title: item.title ?? null,
+            url: item.url ?? null,
+            domain: item.domain ?? null,
+            description: item.description ?? null,
+          }));
+          return { keyword: q.keyword, ok: true as const, items: trimmed };
+        } catch (error) {
+          return {
+            keyword: q.keyword,
+            ok: false as const,
+            error: error instanceof Error ? error.message : String(error),
+          };
+        }
+      }),
+    );
+
+    const okCount = results.filter((r) => r.ok).length;
+    const text =
+      results
+        .map((r) => {
+          if (r.ok) {
+            const top = r.items.slice(0, 3);
+            return `"${r.keyword}" (${r.items.length} results):\n${top
+              .map(
+                (it) =>
+                  `  #${it.rank ?? "?"}  ${it.domain ?? "?"} — ${it.title ?? "?"}`,
+              )
+              .join("\n")}`;
+          }
+          return `"${r.keyword}": FAILED — ${r.error}`;
+        })
+        .join("\n\n") +
+      `\n\n${okCount} of ${results.length} queries succeeded.`;
+
+    return mcpResponse({
+      text,
+      meta: {
+        organizationId: auth.organizationId,
+        projectId: args.projectId,
+        url: buildDashboardUrl(baseUrl, `/p/${args.projectId}/keywords`),
+      },
+      structuredContent: { results },
+    });
+  },
+};

--- a/src/mcp/tools/get-backlinks-overview.ts
+++ b/src/mcp/tools/get-backlinks-overview.ts
@@ -1,0 +1,80 @@
+import { z } from "zod";
+import { BacklinksService } from "@/server/features/backlinks/services/BacklinksService";
+import { ProjectService } from "@/server/features/projects/services/ProjectService";
+import { mcpResponse } from "@/mcp/formatters";
+import {
+  buildBillingCustomer,
+  getAuth,
+  getBaseUrl,
+  type ToolExtra,
+} from "@/mcp/context";
+import { buildDashboardUrl } from "@/mcp/urls";
+import { projectIdSchema } from "@/mcp/schemas";
+
+const inputSchema = {
+  projectId: projectIdSchema,
+  target: z
+    .string()
+    .min(1)
+    .describe(
+      "Domain or URL to analyze (e.g. 'example.com' or 'https://example.com/blog').",
+    ),
+  scope: z
+    .enum(["domain", "page"])
+    .optional()
+    .describe(
+      "'domain' analyzes the whole domain; 'page' analyzes a specific URL. Defaults to 'domain'.",
+    ),
+  hideSpam: z
+    .boolean()
+    .optional()
+    .describe("Filter out spammy referring domains. Defaults to true."),
+} as const;
+
+type Args = z.infer<z.ZodObject<typeof inputSchema>>;
+
+export const getBacklinksOverviewTool = {
+  name: "get_backlinks_overview",
+  config: {
+    title: "Get backlinks overview",
+    description:
+      "Returns a backlinks profile summary (total backlinks, referring domains, top referring domains). Charges credits (~200-500 typical). Requires that the user's DataForSEO account has Backlinks enabled.",
+    inputSchema,
+  },
+  handler: async (args: Args, extra: ToolExtra) => {
+    const auth = getAuth(extra);
+    const baseUrl = getBaseUrl(extra);
+    await ProjectService.getProjectForOrganization(
+      auth.organizationId,
+      args.projectId,
+    );
+    const billing = buildBillingCustomer(auth, args.projectId);
+    const lookup = { target: args.target, scope: args.scope };
+    const spamOptions = { hideSpam: args.hideSpam ?? true };
+    const [overview, refDomains] = await Promise.all([
+      BacklinksService.profileOverview(lookup, billing, spamOptions),
+      BacklinksService.profileReferringDomains(lookup, billing, spamOptions),
+    ]);
+    const topDomains = refDomains.rows ?? [];
+    const text = [
+      `Backlinks profile for ${args.target} (${args.scope ?? "domain"}):`,
+      JSON.stringify(overview, null, 2).slice(0, 800),
+      "",
+      `Top referring domains (${Math.min(topDomains.length, 10)} shown):`,
+      ...topDomains
+        .slice(0, 10)
+        .map((d) => `- ${d.domain ?? "?"}  backlinks:${d.backlinks ?? "?"}`),
+    ].join("\n");
+    return mcpResponse({
+      text,
+      meta: {
+        organizationId: auth.organizationId,
+        projectId: args.projectId,
+        url: buildDashboardUrl(baseUrl, `/p/${args.projectId}/backlinks`, {
+          target: args.target,
+        }),
+      },
+      structuredContent: { overview, referringDomains: refDomains },
+    });
+  },
+};

--- a/src/mcp/tools/get-domain-keyword-suggestions.ts
+++ b/src/mcp/tools/get-domain-keyword-suggestions.ts
@@ -1,0 +1,77 @@
+import { z } from "zod";
+import { DomainService } from "@/server/features/domain/services/DomainService";
+import { ProjectService } from "@/server/features/projects/services/ProjectService";
+import { mcpResponse } from "@/mcp/formatters";
+import {
+  buildBillingCustomer,
+  getAuth,
+  getBaseUrl,
+  type ToolExtra,
+} from "@/mcp/context";
+import { buildDashboardUrl } from "@/mcp/urls";
+import {
+  languageCodeSchema,
+  locationCodeSchema,
+  projectIdSchema,
+} from "@/mcp/schemas";
+
+const inputSchema = {
+  projectId: projectIdSchema,
+  domain: z
+    .string()
+    .min(1)
+    .describe("Competitor or reference domain to extract keywords from."),
+  locationCode: locationCodeSchema.optional(),
+  languageCode: languageCodeSchema.optional(),
+} as const;
+
+type Args = z.infer<z.ZodObject<typeof inputSchema>>;
+
+export const getDomainKeywordSuggestionsTool = {
+  name: "get_domain_keyword_suggestions",
+  config: {
+    title: "Get keyword suggestions for a domain",
+    description:
+      "Returns the top organic keywords a domain ranks for. Useful for competitor analysis. Charges credits (~100-300 typical). Cached for 12 hours.",
+    inputSchema,
+  },
+  handler: async (args: Args, extra: ToolExtra) => {
+    const auth = getAuth(extra);
+    const baseUrl = getBaseUrl(extra);
+    await ProjectService.getProjectForOrganization(
+      auth.organizationId,
+      args.projectId,
+    );
+    const billing = buildBillingCustomer(auth, args.projectId);
+    const keywords = await DomainService.getSuggestedKeywords(
+      {
+        domain: args.domain,
+        locationCode: args.locationCode ?? 2840,
+        languageCode: args.languageCode ?? "en",
+        organizationId: auth.organizationId,
+        projectId: args.projectId,
+      },
+      billing,
+    );
+    const text = [
+      `Top keywords for ${args.domain} (${keywords.length}):`,
+      ...keywords
+        .slice(0, 25)
+        .map(
+          (kw) =>
+            `- "${kw.keyword}" #${kw.position ?? "?"} vol:${kw.searchVolume ?? "?"} kd:${kw.keywordDifficulty ?? "?"}`,
+        ),
+    ].join("\n");
+    return mcpResponse({
+      text,
+      meta: {
+        organizationId: auth.organizationId,
+        projectId: args.projectId,
+        url: buildDashboardUrl(baseUrl, `/p/${args.projectId}/domain`, {
+          domain: args.domain,
+        }),
+      },
+      structuredContent: { keywords },
+    });
+  },
+};

--- a/src/mcp/tools/get-domain-overview.ts
+++ b/src/mcp/tools/get-domain-overview.ts
@@ -1,0 +1,73 @@
+import { z } from "zod";
+import { DomainService } from "@/server/features/domain/services/DomainService";
+import { ProjectService } from "@/server/features/projects/services/ProjectService";
+import { mcpResponse } from "@/mcp/formatters";
+import {
+  buildBillingCustomer,
+  getAuth,
+  getBaseUrl,
+  type ToolExtra,
+} from "@/mcp/context";
+import { buildDashboardUrl } from "@/mcp/urls";
+import {
+  languageCodeSchema,
+  locationCodeSchema,
+  projectIdSchema,
+} from "@/mcp/schemas";
+
+const inputSchema = {
+  projectId: projectIdSchema,
+  domain: z.string().min(1).describe("Domain to analyze (e.g. 'example.com')."),
+  includeSubdomains: z.boolean().optional().default(false),
+  locationCode: locationCodeSchema.optional(),
+  languageCode: languageCodeSchema.optional(),
+} as const;
+
+type Args = z.infer<z.ZodObject<typeof inputSchema>>;
+
+export const getDomainOverviewTool = {
+  name: "get_domain_overview",
+  config: {
+    title: "Get domain overview",
+    description:
+      "Returns organic traffic, organic keyword count, and the domain's top-ranking keywords. Charges credits (~100-300 typical). Cached for 12 hours per domain.",
+    inputSchema,
+  },
+  handler: async (args: Args, extra: ToolExtra) => {
+    const auth = getAuth(extra);
+    const baseUrl = getBaseUrl(extra);
+    await ProjectService.getProjectForOrganization(
+      auth.organizationId,
+      args.projectId,
+    );
+    const billing = buildBillingCustomer(auth, args.projectId);
+    const result = await DomainService.getOverview(
+      {
+        projectId: args.projectId,
+        domain: args.domain,
+        includeSubdomains: args.includeSubdomains ?? false,
+        locationCode: args.locationCode ?? 2840,
+        languageCode: args.languageCode ?? "en",
+      },
+      billing,
+    );
+    const text = [
+      `Domain: ${result.domain}`,
+      `Organic traffic: ${result.organicTraffic ?? "?"}`,
+      `Organic keywords: ${result.organicKeywords ?? "?"}`,
+      `Backlinks: ${result.backlinks ?? "?"}`,
+      `Referring domains: ${result.referringDomains ?? "?"}`,
+    ].join("\n");
+    return mcpResponse({
+      text,
+      meta: {
+        organizationId: auth.organizationId,
+        projectId: args.projectId,
+        url: buildDashboardUrl(baseUrl, `/p/${args.projectId}/domain`, {
+          domain: args.domain,
+        }),
+      },
+      structuredContent: result,
+    });
+  },
+};

--- a/src/mcp/tools/get-rank-tracker.ts
+++ b/src/mcp/tools/get-rank-tracker.ts
@@ -1,0 +1,102 @@
+import { z } from "zod";
+import { ProjectService } from "@/server/features/projects/services/ProjectService";
+import { RankTrackingRepository } from "@/server/features/rank-tracking/repositories/RankTrackingRepository";
+import { getLatestResults } from "@/server/features/rank-tracking/services/rankTrackingResults";
+import { mcpResponse } from "@/mcp/formatters";
+import { getAuth, getBaseUrl, type ToolExtra } from "@/mcp/context";
+import { buildDashboardUrl } from "@/mcp/urls";
+import { projectIdSchema } from "@/mcp/schemas";
+
+const inputSchema = {
+  projectId: projectIdSchema,
+  trackerId: z
+    .string()
+    .optional()
+    .describe(
+      "Rank tracker config ID. If omitted, lists all rank trackers in the project.",
+    ),
+} as const;
+
+type Args = z.infer<z.ZodObject<typeof inputSchema>>;
+
+export const getRankTrackerTool = {
+  name: "get_rank_tracker",
+  config: {
+    title: "Get rank tracker",
+    description:
+      "Read-only access to rank tracker configs and their latest results. With `trackerId`, returns config + latest snapshot per keyword. Without it, lists all trackers in the project. Free — reads from OpenSEO state, no DataForSEO call. To trigger a new check, use the dashboard.",
+    inputSchema,
+  },
+  handler: async (args: Args, extra: ToolExtra) => {
+    const auth = getAuth(extra);
+    const baseUrl = getBaseUrl(extra);
+    await ProjectService.getProjectForOrganization(
+      auth.organizationId,
+      args.projectId,
+    );
+
+    if (!args.trackerId) {
+      const configs = await RankTrackingRepository.getConfigsForProject(
+        args.projectId,
+      );
+      const text =
+        configs.length === 0
+          ? "No rank trackers configured for this project."
+          : `Rank trackers (${configs.length}):\n` +
+            configs
+              .map(
+                (c) =>
+                  `- ${c.id}  ${c.domain}  loc:${c.locationCode}  schedule:${c.scheduleInterval}  active:${c.isActive ?? true}`,
+              )
+              .join("\n");
+      return mcpResponse({
+        text,
+        meta: {
+          organizationId: auth.organizationId,
+          projectId: args.projectId,
+          url: buildDashboardUrl(baseUrl, `/p/${args.projectId}/rank-tracking`),
+        },
+        structuredContent: { configs },
+      });
+    }
+
+    const config = await RankTrackingRepository.getConfigById({
+      configId: args.trackerId,
+      projectId: args.projectId,
+    });
+    if (!config) {
+      return mcpResponse({
+        text: `Rank tracker ${args.trackerId} not found in project ${args.projectId}.`,
+        meta: {
+          organizationId: auth.organizationId,
+          projectId: args.projectId,
+        },
+      });
+    }
+    const results = await getLatestResults(args.trackerId, args.projectId);
+    const text = [
+      `Tracker ${config.id} (${config.domain}):`,
+      `Schedule: ${config.scheduleInterval}, devices: ${config.devices}, depth: ${config.serpDepth}`,
+      `Latest run: ${results.run?.lastCheckedAt ?? "never"}`,
+      `Keywords (${results.rows.length}):`,
+      ...results.rows
+        .slice(0, 25)
+        .map(
+          (r) =>
+            `- "${r.keyword}"  desktop:#${r.desktop.position ?? "-"} (was ${r.desktop.previousPosition ?? "-"})  mobile:#${r.mobile.position ?? "-"}`,
+        ),
+    ].join("\n");
+    return mcpResponse({
+      text,
+      meta: {
+        organizationId: auth.organizationId,
+        projectId: args.projectId,
+        url: buildDashboardUrl(
+          baseUrl,
+          `/p/${args.projectId}/rank-tracking/${args.trackerId}`,
+        ),
+      },
+      structuredContent: { config, results },
+    });
+  },
+};

--- a/src/mcp/tools/list-saved-keywords.ts
+++ b/src/mcp/tools/list-saved-keywords.ts
@@ -1,0 +1,54 @@
+import type { z } from "zod";
+import { KeywordResearchService } from "@/server/features/keywords/services/KeywordResearchService";
+import { ProjectService } from "@/server/features/projects/services/ProjectService";
+import { mcpResponse } from "@/mcp/formatters";
+import { getAuth, getBaseUrl, type ToolExtra } from "@/mcp/context";
+import { buildDashboardUrl } from "@/mcp/urls";
+import { projectIdSchema } from "@/mcp/schemas";
+
+const inputSchema = {
+  projectId: projectIdSchema,
+} as const;
+
+export const listSavedKeywordsTool = {
+  name: "list_saved_keywords",
+  config: {
+    title: "List saved keywords",
+    description:
+      "Lists keywords saved to a project (with cached metrics like search volume, difficulty, CPC if available). Free — reads from OpenSEO's database, no DataForSEO call.",
+    inputSchema,
+  },
+  handler: async (
+    args: z.infer<z.ZodObject<typeof inputSchema>>,
+    extra: ToolExtra,
+  ) => {
+    const auth = getAuth(extra);
+    const baseUrl = getBaseUrl(extra);
+    await ProjectService.getProjectForOrganization(
+      auth.organizationId,
+      args.projectId,
+    );
+    const { rows } = await KeywordResearchService.getSavedKeywords({
+      projectId: args.projectId,
+    });
+    const text =
+      rows.length === 0
+        ? "No saved keywords yet."
+        : `Saved keywords (${rows.length}):\n` +
+          rows
+            .map(
+              (r) =>
+                `- ${r.keyword}  vol:${r.searchVolume ?? "?"}  kd:${r.keywordDifficulty ?? "?"}  cpc:${r.cpc != null ? `$${r.cpc.toFixed(2)}` : "?"}`,
+            )
+            .join("\n");
+    return mcpResponse({
+      text,
+      meta: {
+        organizationId: auth.organizationId,
+        projectId: args.projectId,
+        url: buildDashboardUrl(baseUrl, `/p/${args.projectId}/saved`),
+      },
+      structuredContent: { rows },
+    });
+  },
+};

--- a/src/mcp/tools/research-keywords.ts
+++ b/src/mcp/tools/research-keywords.ts
@@ -1,0 +1,113 @@
+import { z } from "zod";
+import { KeywordResearchService } from "@/server/features/keywords/services/KeywordResearchService";
+import { ProjectService } from "@/server/features/projects/services/ProjectService";
+import { mcpResponse } from "@/mcp/formatters";
+import {
+  buildBillingCustomer,
+  getAuth,
+  getBaseUrl,
+  type ToolExtra,
+} from "@/mcp/context";
+import { buildDashboardUrl } from "@/mcp/urls";
+import {
+  languageCodeSchema,
+  locationCodeSchema,
+  projectIdSchema,
+} from "@/mcp/schemas";
+
+const seedSchema = z.object({
+  seed: z.string().min(1).describe("Seed keyword to research."),
+  locationCode: locationCodeSchema.optional(),
+  languageCode: languageCodeSchema.optional(),
+});
+
+const inputSchema = {
+  projectId: projectIdSchema,
+  seeds: z
+    .array(seedSchema)
+    .min(1)
+    .max(10)
+    .describe(
+      "1-10 seed keywords. Each seed is researched independently and returns related keywords with volume/difficulty/CPC. Bulk-friendly — prefer this over 10 separate calls.",
+    ),
+  resultLimit: z
+    .union([z.literal(150), z.literal(300), z.literal(500)])
+    .optional()
+    .describe("Max keywords returned per seed. Defaults to 150."),
+} as const;
+
+type Args = z.infer<z.ZodObject<typeof inputSchema>>;
+
+export const researchKeywordsTool = {
+  name: "research_keywords",
+  config: {
+    title: "Research keywords (bulk)",
+    description:
+      "Research keyword data (search volume, difficulty, CPC, related ideas) for 1-10 seed keywords in one call. Charges credits per seed (~50-200 credits each, varies by source). Returns per-seed results — a single bad seed won't fail the batch.",
+    inputSchema,
+  },
+  handler: async (args: Args, extra: ToolExtra) => {
+    const auth = getAuth(extra);
+    const baseUrl = getBaseUrl(extra);
+    await ProjectService.getProjectForOrganization(
+      auth.organizationId,
+      args.projectId,
+    );
+    const billing = buildBillingCustomer(auth, args.projectId);
+
+    const results = await Promise.all(
+      args.seeds.map(async (item) => {
+        try {
+          const data = await KeywordResearchService.research(
+            {
+              projectId: args.projectId,
+              keywords: [item.seed],
+              locationCode: item.locationCode ?? 2840,
+              languageCode: item.languageCode ?? "en",
+              resultLimit: args.resultLimit ?? 150,
+              mode: "auto",
+            },
+            billing,
+          );
+          return {
+            seed: item.seed,
+            ok: true as const,
+            rowCount: data.rows.length,
+            source: data.source,
+            usedFallback: data.usedFallback,
+            topRows: data.rows.slice(0, 20),
+          };
+        } catch (error) {
+          return {
+            seed: item.seed,
+            ok: false as const,
+            error: error instanceof Error ? error.message : String(error),
+          };
+        }
+      }),
+    );
+
+    const okCount = results.filter((r) => r.ok).length;
+    const failCount = results.length - okCount;
+    const text =
+      results
+        .map((r) => {
+          if (r.ok) {
+            return `- "${r.seed}": ${r.rowCount} keywords (source: ${r.source})`;
+          }
+          return `- "${r.seed}": FAILED — ${r.error}`;
+        })
+        .join("\n") +
+      `\n\nResearched ${okCount} of ${results.length} seeds${failCount > 0 ? ` (${failCount} failed)` : ""}.`;
+
+    return mcpResponse({
+      text,
+      meta: {
+        organizationId: auth.organizationId,
+        projectId: args.projectId,
+        url: buildDashboardUrl(baseUrl, `/p/${args.projectId}/keywords`),
+      },
+      structuredContent: { results },
+    });
+  },
+};

--- a/src/mcp/tools/save-keywords.ts
+++ b/src/mcp/tools/save-keywords.ts
@@ -1,0 +1,56 @@
+import { z } from "zod";
+import { KeywordResearchService } from "@/server/features/keywords/services/KeywordResearchService";
+import { ProjectService } from "@/server/features/projects/services/ProjectService";
+import { mcpResponse } from "@/mcp/formatters";
+import { getAuth, getBaseUrl, type ToolExtra } from "@/mcp/context";
+import { buildDashboardUrl } from "@/mcp/urls";
+import {
+  languageCodeSchema,
+  locationCodeSchema,
+  projectIdSchema,
+} from "@/mcp/schemas";
+
+const inputSchema = {
+  projectId: projectIdSchema,
+  keywords: z
+    .array(z.string().min(1))
+    .min(1)
+    .max(100)
+    .describe("Keywords to save (1-100)."),
+  locationCode: locationCodeSchema.optional(),
+  languageCode: languageCodeSchema.optional(),
+} as const;
+
+type Args = z.infer<z.ZodObject<typeof inputSchema>>;
+
+export const saveKeywordsTool = {
+  name: "save_keywords",
+  config: {
+    title: "Save keywords",
+    description:
+      "Save keywords to a project's saved-keywords list. Free — does not call DataForSEO. Idempotent: re-saving an existing keyword is a no-op.",
+    inputSchema,
+  },
+  handler: async (args: Args, extra: ToolExtra) => {
+    const auth = getAuth(extra);
+    const baseUrl = getBaseUrl(extra);
+    await ProjectService.getProjectForOrganization(
+      auth.organizationId,
+      args.projectId,
+    );
+    await KeywordResearchService.saveKeywords({
+      projectId: args.projectId,
+      keywords: args.keywords,
+      locationCode: args.locationCode ?? 2840,
+      languageCode: args.languageCode ?? "en",
+    });
+    return mcpResponse({
+      text: `Saved ${args.keywords.length} keyword(s) to project ${args.projectId}.`,
+      meta: {
+        organizationId: auth.organizationId,
+        projectId: args.projectId,
+        url: buildDashboardUrl(baseUrl, `/p/${args.projectId}/saved`),
+      },
+    });
+  },
+};


### PR DESCRIPTION
Adds the product MCP tool surface on top of the server skeleton: keyword research, saved keywords, domain overview/suggestions, backlinks overview, SERP live, and rank tracker tools.\n\nStack: 3/3. Depends on #22.