### PR TITLE
feat: add search and filters to the Tracked Domains list

### DIFF
--- a/src/client/features/rank-tracking/RankTrackingDomainList.tsx
+++ b/src/client/features/rank-tracking/RankTrackingDomainList.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { toast } from "sonner";
@@ -9,6 +9,7 @@ import {
   Globe,
   Plus,
   ChevronRight,
+  Search,
 } from "lucide-react";
 import {
   getRankTrackingConfigSummaries,
@@ -16,6 +17,14 @@ import {
 } from "@/serverFunctions/rank-tracking";
 import { devicesLabel, scheduleLabel } from "@/shared/rank-tracking";
 import { Modal } from "@/client/components/Modal";
+import {
+  applyDomainListFilters,
+  countActiveDomainListFilters,
+  DomainListFilterBar,
+  EMPTY_DOMAIN_LIST_FILTERS,
+  getDomainListFilterOptions,
+  type DomainListFilters,
+} from "./RankTrackingFilters";
 
 type ConfigSummary = Awaited<
   ReturnType<typeof getRankTrackingConfigSummaries>
@@ -32,10 +41,23 @@ export function RankTrackingDomainList({
   const [archiveTarget, setArchiveTarget] = useState<ConfigSummary | null>(
     null,
   );
+  const [filters, setFilters] = useState<DomainListFilters>(
+    EMPTY_DOMAIN_LIST_FILTERS,
+  );
   const { data: summaries } = useQuery({
     queryKey: ["rankTrackingConfigSummaries", projectId],
     queryFn: () => getRankTrackingConfigSummaries({ data: { projectId } }),
   });
+  const allSummaries = summaries ?? [];
+  const filteredSummaries = useMemo(
+    () => applyDomainListFilters(allSummaries, filters),
+    [allSummaries, filters],
+  );
+  const filterOptions = useMemo(
+    () => getDomainListFilterOptions(allSummaries),
+    [allSummaries],
+  );
+  const activeFilterCount = countActiveDomainListFilters(filters);
 
   const archiveMutation = useMutation({
     mutationFn: (configId: string) =>
@@ -67,8 +89,17 @@ export function RankTrackingDomainList({
             Add Domain
           </button>
         </div>
+        {allSummaries.length > 0 && (
+          <DomainListFilterBar
+            filters={filters}
+            options={filterOptions}
+            activeFilterCount={activeFilterCount}
+            onChange={setFilters}
+            onReset={() => setFilters(EMPTY_DOMAIN_LIST_FILTERS)}
+          />
+        )}
         <div className="divide-y divide-base-300">
-          {(summaries ?? []).length === 0 ? (
+          {allSummaries.length === 0 ? (
             <div className="px-5 py-10 text-center space-y-2">
               <div className="mx-auto flex size-10 items-center justify-center rounded-xl bg-base-200">
                 <Globe className="size-5 text-base-content/40" />
@@ -80,8 +111,29 @@ export function RankTrackingDomainList({
                 Add a domain to start monitoring keyword rankings over time.
               </p>
             </div>
+          ) : filteredSummaries.length === 0 ? (
+            <div className="px-5 py-10 text-center space-y-3">
+              <div className="mx-auto flex size-10 items-center justify-center rounded-xl bg-base-200">
+                <Search className="size-5 text-base-content/40" />
+              </div>
+              <div className="space-y-1">
+                <p className="text-sm font-medium text-base-content/70">
+                  No matching tracked domains
+                </p>
+                <p className="text-xs text-base-content/40">
+                  Try clearing search or adjusting filters.
+                </p>
+              </div>
+              <button
+                className="btn btn-ghost btn-xs"
+                onClick={() => setFilters(EMPTY_DOMAIN_LIST_FILTERS)}
+                disabled={activeFilterCount === 0}
+              >
+                Clear filters
+              </button>
+            </div>
           ) : (
-            (summaries ?? []).map((summary) => (
+            filteredSummaries.map((summary) => (
               <DomainRow
                 key={summary.id}
                 projectId={projectId}

--- a/src/client/features/rank-tracking/RankTrackingDomainList.tsx
+++ b/src/client/features/rank-tracking/RankTrackingDomainList.tsx
@@ -53,7 +53,7 @@ export function RankTrackingDomainList({
     queryKey: ["rankTrackingConfigSummaries", projectId],
     queryFn: () => getRankTrackingConfigSummaries({ data: { projectId } }),
   });
-  const allSummaries = summaries ?? [];
+  const allSummaries = useMemo(() => summaries ?? [], [summaries]);
   const filteredSummaries = useMemo(
     () => applyDomainListFilters(allSummaries, filters),
     [allSummaries, filters],

--- a/src/client/features/rank-tracking/RankTrackingDomainList.tsx
+++ b/src/client/features/rank-tracking/RankTrackingDomainList.tsx
@@ -30,6 +30,11 @@ type ConfigSummary = Awaited<
   ReturnType<typeof getRankTrackingConfigSummaries>
 >[number];
 
+// Below this many domains the list is short enough to scan by eye, so the
+// filter controls are more chrome than help. Still shown if filters are active
+// (e.g. archiving dropped the count) so they never get orphaned.
+const FILTER_BAR_MIN_DOMAINS = 6;
+
 export function RankTrackingDomainList({
   projectId,
   onAddDomain,
@@ -89,7 +94,8 @@ export function RankTrackingDomainList({
             Add Domain
           </button>
         </div>
-        {allSummaries.length > 0 && (
+        {(allSummaries.length >= FILTER_BAR_MIN_DOMAINS ||
+          activeFilterCount > 0) && (
           <DomainListFilterBar
             filters={filters}
             options={filterOptions}
@@ -98,7 +104,7 @@ export function RankTrackingDomainList({
             onReset={() => setFilters(EMPTY_DOMAIN_LIST_FILTERS)}
           />
         )}
-        <div className="divide-y divide-base-300">
+        <div className="divide-y divide-base-300 border-t border-base-300">
           {allSummaries.length === 0 ? (
             <div className="px-5 py-10 text-center space-y-2">
               <div className="mx-auto flex size-10 items-center justify-center rounded-xl bg-base-200">

--- a/src/client/features/rank-tracking/RankTrackingFilters.test.ts
+++ b/src/client/features/rank-tracking/RankTrackingFilters.test.ts
@@ -190,8 +190,8 @@ describe("getDomainListFilterOptions", () => {
       { value: "mobile", label: "Mobile" },
     ]);
     expect(options.locations).toEqual([
-      { value: "2250", label: "France" },
-      { value: "2826", label: "United Kingdom" },
+      { value: "2250", label: "FR" },
+      { value: "2826", label: "UK" },
     ]);
   });
 });

--- a/src/client/features/rank-tracking/RankTrackingFilters.test.ts
+++ b/src/client/features/rank-tracking/RankTrackingFilters.test.ts
@@ -1,11 +1,23 @@
 import { describe, expect, it } from "vitest";
 import type { RankTrackingRow } from "@/types/schemas/rank-tracking";
 import {
+  applyDomainListFilters,
   applyFilters,
+  countActiveDomainListFilters,
+  EMPTY_DOMAIN_LIST_FILTERS,
   EMPTY_FILTERS,
+  getDomainListFilterOptions,
   matchesPositionFilter,
+  type DomainListFilters,
   type Filters,
 } from "./RankTrackingFilters";
+
+type DomainSummary = {
+  id: string;
+  domain: string;
+  devices: "both" | "desktop" | "mobile";
+  locationCode: number;
+};
 
 function makeRow(
   keyword: string,
@@ -35,6 +47,21 @@ function makeRow(
 
 function withFilters(overrides: Partial<Filters>): Filters {
   return { ...EMPTY_FILTERS, ...overrides };
+}
+
+function makeSummary(
+  id: string,
+  domain: string,
+  devices: DomainSummary["devices"],
+  locationCode: number,
+): DomainSummary {
+  return { id, domain, devices, locationCode };
+}
+
+function withDomainFilters(
+  overrides: Partial<DomainListFilters>,
+): DomainListFilters {
+  return { ...EMPTY_DOMAIN_LIST_FILTERS, ...overrides };
 }
 
 describe("matchesPositionFilter", () => {
@@ -82,5 +109,104 @@ describe("applyFilters", () => {
         withFilters({ maxDesktopPos: "0", maxMobilePos: "0" }),
       ).map((row) => row.keyword),
     ).toEqual(["unranked both"]);
+  });
+});
+
+describe("applyDomainListFilters", () => {
+  const summaries = [
+    makeSummary("alpha-us-mobile", "alpha.example.com", "mobile", 2840),
+    makeSummary("alpha-fr-desktop", "alpha.example.com", "desktop", 2250),
+    makeSummary("alpha-fr-mobile", "alpha.example.com", "mobile", 2250),
+    makeSummary("bravo-fr-both", "bravo.example.com", "both", 2250),
+    makeSummary("charlie-uk-desktop", "charlie.example.com", "desktop", 2826),
+  ];
+
+  it("narrows by text query and restores all when cleared", () => {
+    expect(
+      applyDomainListFilters(
+        summaries,
+        withDomainFilters({ query: "ALPHA" }),
+      ).map((summary) => summary.id),
+    ).toEqual(["alpha-us-mobile", "alpha-fr-desktop", "alpha-fr-mobile"]);
+
+    expect(
+      applyDomainListFilters(summaries, EMPTY_DOMAIN_LIST_FILTERS).map(
+        (summary) => summary.id,
+      ),
+    ).toEqual(summaries.map((summary) => summary.id));
+  });
+
+  it("filters by device", () => {
+    expect(
+      applyDomainListFilters(
+        summaries,
+        withDomainFilters({ device: "mobile" }),
+      ).map((summary) => summary.id),
+    ).toEqual(["alpha-us-mobile", "alpha-fr-mobile"]);
+  });
+
+  it("filters by country", () => {
+    expect(
+      applyDomainListFilters(
+        summaries,
+        withDomainFilters({ locationCode: "2250" }),
+      ).map((summary) => summary.id),
+    ).toEqual(["alpha-fr-desktop", "alpha-fr-mobile", "bravo-fr-both"]);
+  });
+
+  it("combines domain, device, and country filters with AND semantics", () => {
+    expect(
+      applyDomainListFilters(
+        summaries,
+        withDomainFilters({
+          query: "alpha",
+          device: "mobile",
+          locationCode: "2250",
+        }),
+      ).map((summary) => summary.id),
+    ).toEqual(["alpha-fr-mobile"]);
+  });
+
+  it("returns an empty list when filters match nothing", () => {
+    expect(
+      applyDomainListFilters(
+        summaries,
+        withDomainFilters({ query: "missing", device: "mobile" }),
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("getDomainListFilterOptions", () => {
+  it("derives distinct device and country options from available summaries", () => {
+    const options = getDomainListFilterOptions([
+      makeSummary("a", "a.com", "mobile", 2250),
+      makeSummary("b", "b.com", "desktop", 2250),
+      makeSummary("c", "c.com", "mobile", 2826),
+    ]);
+
+    expect(options.devices).toEqual([
+      { value: "desktop", label: "Desktop" },
+      { value: "mobile", label: "Mobile" },
+    ]);
+    expect(options.locations).toEqual([
+      { value: "2250", label: "France" },
+      { value: "2826", label: "United Kingdom" },
+    ]);
+  });
+});
+
+describe("countActiveDomainListFilters", () => {
+  it("counts non-empty domain list filters", () => {
+    expect(countActiveDomainListFilters(EMPTY_DOMAIN_LIST_FILTERS)).toBe(0);
+    expect(
+      countActiveDomainListFilters(
+        withDomainFilters({
+          query: "alpha",
+          device: "desktop",
+          locationCode: "2840",
+        }),
+      ),
+    ).toBe(3);
   });
 });

--- a/src/client/features/rank-tracking/RankTrackingFilters.tsx
+++ b/src/client/features/rank-tracking/RankTrackingFilters.tsx
@@ -1,5 +1,10 @@
 import { RotateCcw } from "lucide-react";
-import type { RankTrackingRow } from "@/types/schemas/rank-tracking";
+import { LOCATIONS } from "@/client/features/keywords/locations";
+import { devicesLabel } from "@/shared/rank-tracking";
+import type {
+  RankTrackingConfig,
+  RankTrackingRow,
+} from "@/types/schemas/rank-tracking";
 
 export type Filters = {
   include: string;
@@ -10,6 +15,22 @@ export type Filters = {
   maxMobilePos: string;
 };
 
+type DomainFilterableConfig = Pick<
+  RankTrackingConfig,
+  "domain" | "devices" | "locationCode"
+>;
+
+export type DomainListFilters = {
+  query: string;
+  device: "all" | RankTrackingConfig["devices"];
+  locationCode: string;
+};
+
+export type DomainListFilterOption = {
+  value: string;
+  label: string;
+};
+
 export const EMPTY_FILTERS: Filters = {
   include: "",
   exclude: "",
@@ -18,6 +39,18 @@ export const EMPTY_FILTERS: Filters = {
   minMobilePos: "",
   maxMobilePos: "",
 };
+
+export const EMPTY_DOMAIN_LIST_FILTERS: DomainListFilters = {
+  query: "",
+  device: "all",
+  locationCode: "all",
+};
+
+const DEVICE_FILTER_ORDER: RankTrackingConfig["devices"][] = [
+  "both",
+  "desktop",
+  "mobile",
+];
 
 export function FilterPanel({
   filters,
@@ -35,24 +68,10 @@ export function FilterPanel({
 
   return (
     <div className="shrink-0 border-b border-base-300 bg-gradient-to-b from-base-100 to-base-200/30 px-4 py-3 space-y-3">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <p className="text-sm font-semibold">Refine results</p>
-          {activeFilterCount > 0 && (
-            <span className="badge badge-xs badge-primary border-0 text-primary-content">
-              {activeFilterCount} active
-            </span>
-          )}
-        </div>
-        <button
-          className="btn btn-xs btn-ghost gap-1"
-          onClick={onReset}
-          disabled={activeFilterCount === 0}
-        >
-          <RotateCcw className="size-3" />
-          Clear all
-        </button>
-      </div>
+      <FilterPanelHeader
+        activeFilterCount={activeFilterCount}
+        onReset={onReset}
+      />
       <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
         <div className="space-y-1.5">
           <p className="text-[11px] font-semibold uppercase tracking-wide text-base-content/60">
@@ -97,6 +116,117 @@ export function FilterPanel({
   );
 }
 
+export function DomainListFilterBar({
+  filters,
+  options,
+  activeFilterCount,
+  onChange,
+  onReset,
+}: {
+  filters: DomainListFilters;
+  options: {
+    devices: DomainListFilterOption[];
+    locations: DomainListFilterOption[];
+  };
+  activeFilterCount: number;
+  onChange: (filters: DomainListFilters) => void;
+  onReset: () => void;
+}) {
+  return (
+    <div className="border-t border-base-300 bg-gradient-to-b from-base-100 to-base-200/30 px-5 py-3 space-y-3">
+      <FilterPanelHeader
+        activeFilterCount={activeFilterCount}
+        onReset={onReset}
+      />
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-[minmax(0,1fr)_12rem_14rem]">
+        <label className="form-control gap-1.5">
+          <span className="text-[11px] font-semibold uppercase tracking-wide text-base-content/60">
+            Search
+          </span>
+          <input
+            className="input input-bordered input-sm w-full bg-base-100"
+            placeholder="Domain or website"
+            value={filters.query}
+            onChange={(event) =>
+              onChange({ ...filters, query: event.target.value })
+            }
+          />
+        </label>
+        <label className="form-control gap-1.5">
+          <span className="text-[11px] font-semibold uppercase tracking-wide text-base-content/60">
+            Device
+          </span>
+          <select
+            className="select select-bordered select-sm w-full bg-base-100"
+            value={filters.device}
+            onChange={(event) =>
+              onChange({
+                ...filters,
+                device: event.target.value as DomainListFilters["device"],
+              })
+            }
+          >
+            <option value="all">All devices</option>
+            {options.devices.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="form-control gap-1.5">
+          <span className="text-[11px] font-semibold uppercase tracking-wide text-base-content/60">
+            Country
+          </span>
+          <select
+            className="select select-bordered select-sm w-full bg-base-100"
+            value={filters.locationCode}
+            onChange={(event) =>
+              onChange({ ...filters, locationCode: event.target.value })
+            }
+          >
+            <option value="all">All countries</option>
+            {options.locations.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+    </div>
+  );
+}
+
+function FilterPanelHeader({
+  activeFilterCount,
+  onReset,
+}: {
+  activeFilterCount: number;
+  onReset: () => void;
+}) {
+  return (
+    <div className="flex items-center justify-between">
+      <div className="flex items-center gap-2">
+        <p className="text-sm font-semibold">Refine results</p>
+        {activeFilterCount > 0 && (
+          <span className="badge badge-xs badge-primary border-0 text-primary-content">
+            {activeFilterCount} active
+          </span>
+        )}
+      </div>
+      <button
+        className="btn btn-xs btn-ghost gap-1"
+        onClick={onReset}
+        disabled={activeFilterCount === 0}
+      >
+        <RotateCcw className="size-3" />
+        Clear all
+      </button>
+    </div>
+  );
+}
+
 function RangeFilter({
   title,
   minValue,
@@ -133,6 +263,59 @@ function RangeFilter({
       </div>
     </div>
   );
+}
+
+export function applyDomainListFilters<T extends DomainFilterableConfig>(
+  configs: T[],
+  filters: DomainListFilters,
+): T[] {
+  const query = filters.query.trim().toLowerCase();
+  const locationCode =
+    filters.locationCode === "all" ? null : Number(filters.locationCode);
+
+  return configs.filter((config) => {
+    if (query && !config.domain.toLowerCase().includes(query)) return false;
+
+    if (filters.device !== "all" && config.devices !== filters.device) {
+      return false;
+    }
+
+    if (locationCode !== null && config.locationCode !== locationCode) {
+      return false;
+    }
+
+    return true;
+  });
+}
+
+export function getDomainListFilterOptions<T extends DomainFilterableConfig>(
+  configs: T[],
+): {
+  devices: DomainListFilterOption[];
+  locations: DomainListFilterOption[];
+} {
+  const deviceValues = new Set(configs.map((config) => config.devices));
+  const devices = DEVICE_FILTER_ORDER.filter((device) =>
+    deviceValues.has(device),
+  ).map((device) => ({
+    value: device,
+    label: devicesLabel(device),
+  }));
+
+  const locationMap = new Map<number, string>();
+  for (const config of configs) {
+    locationMap.set(
+      config.locationCode,
+      LOCATIONS[config.locationCode] ?? String(config.locationCode),
+    );
+  }
+
+  const locations = Array.from(locationMap, ([code, label]) => ({
+    value: String(code),
+    label,
+  })).sort((a, b) => a.label.localeCompare(b.label));
+
+  return { devices, locations };
 }
 
 export function applyFilters(
@@ -206,5 +389,15 @@ export function countActiveFilters(filters: Filters): number {
   if (filters.exclude) count++;
   if (filters.minDesktopPos || filters.maxDesktopPos) count++;
   if (filters.minMobilePos || filters.maxMobilePos) count++;
+  return count;
+}
+
+export function countActiveDomainListFilters(
+  filters: DomainListFilters,
+): number {
+  let count = 0;
+  if (filters.query.trim()) count++;
+  if (filters.device !== "all") count++;
+  if (filters.locationCode !== "all") count++;
   return count;
 }

--- a/src/client/features/rank-tracking/RankTrackingFilters.tsx
+++ b/src/client/features/rank-tracking/RankTrackingFilters.tsx
@@ -133,13 +133,9 @@ export function DomainListFilterBar({
   onReset: () => void;
 }) {
   return (
-    <div className="border-t border-base-300 bg-gradient-to-b from-base-100 to-base-200/30 px-5 py-3 space-y-3">
-      <FilterPanelHeader
-        activeFilterCount={activeFilterCount}
-        onReset={onReset}
-      />
-      <div className="grid grid-cols-1 gap-3 lg:grid-cols-[minmax(0,1fr)_12rem_14rem]">
-        <label className="form-control gap-1.5">
+    <div className="border-t border-base-300 px-5 py-3">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-end">
+        <label className="form-control flex-1 gap-1.5">
           <span className="text-[11px] font-semibold uppercase tracking-wide text-base-content/60">
             Search
           </span>
@@ -152,7 +148,7 @@ export function DomainListFilterBar({
             }
           />
         </label>
-        <label className="form-control gap-1.5">
+        <label className="form-control gap-1.5 lg:w-44">
           <span className="text-[11px] font-semibold uppercase tracking-wide text-base-content/60">
             Device
           </span>
@@ -174,7 +170,7 @@ export function DomainListFilterBar({
             ))}
           </select>
         </label>
-        <label className="form-control gap-1.5">
+        <label className="form-control gap-1.5 lg:w-52">
           <span className="text-[11px] font-semibold uppercase tracking-wide text-base-content/60">
             Country
           </span>
@@ -193,6 +189,18 @@ export function DomainListFilterBar({
             ))}
           </select>
         </label>
+        {activeFilterCount > 0 && (
+          <button
+            className="btn btn-ghost btn-sm gap-1.5 self-start lg:self-auto"
+            onClick={onReset}
+          >
+            <RotateCcw className="size-3" />
+            Clear
+            <span className="badge badge-xs badge-primary border-0 text-primary-content">
+              {activeFilterCount}
+            </span>
+          </button>
+        )}
       </div>
     </div>
   );

--- a/src/client/features/rank-tracking/RankTrackingFilters.tsx
+++ b/src/client/features/rank-tracking/RankTrackingFilters.tsx
@@ -26,7 +26,7 @@ export type DomainListFilters = {
   locationCode: string;
 };
 
-export type DomainListFilterOption = {
+type DomainListFilterOption = {
   value: string;
   label: string;
 };
@@ -68,10 +68,24 @@ export function FilterPanel({
 
   return (
     <div className="shrink-0 border-b border-base-300 bg-gradient-to-b from-base-100 to-base-200/30 px-4 py-3 space-y-3">
-      <FilterPanelHeader
-        activeFilterCount={activeFilterCount}
-        onReset={onReset}
-      />
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <p className="text-sm font-semibold">Refine results</p>
+          {activeFilterCount > 0 && (
+            <span className="badge badge-xs badge-primary border-0 text-primary-content">
+              {activeFilterCount} active
+            </span>
+          )}
+        </div>
+        <button
+          className="btn btn-xs btn-ghost gap-1"
+          onClick={onReset}
+          disabled={activeFilterCount === 0}
+        >
+          <RotateCcw className="size-3" />
+          Clear all
+        </button>
+      </div>
       <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
         <div className="space-y-1.5">
           <p className="text-[11px] font-semibold uppercase tracking-wide text-base-content/60">
@@ -155,12 +169,17 @@ export function DomainListFilterBar({
           <select
             className="select select-bordered select-sm w-full bg-base-100"
             value={filters.device}
-            onChange={(event) =>
-              onChange({
-                ...filters,
-                device: event.target.value as DomainListFilters["device"],
-              })
-            }
+            onChange={(event) => {
+              const value = event.target.value;
+              if (
+                value === "all" ||
+                value === "both" ||
+                value === "desktop" ||
+                value === "mobile"
+              ) {
+                onChange({ ...filters, device: value });
+              }
+            }}
           >
             <option value="all">All devices</option>
             {options.devices.map((option) => (
@@ -202,35 +221,6 @@ export function DomainListFilterBar({
           </button>
         )}
       </div>
-    </div>
-  );
-}
-
-function FilterPanelHeader({
-  activeFilterCount,
-  onReset,
-}: {
-  activeFilterCount: number;
-  onReset: () => void;
-}) {
-  return (
-    <div className="flex items-center justify-between">
-      <div className="flex items-center gap-2">
-        <p className="text-sm font-semibold">Refine results</p>
-        {activeFilterCount > 0 && (
-          <span className="badge badge-xs badge-primary border-0 text-primary-content">
-            {activeFilterCount} active
-          </span>
-        )}
-      </div>
-      <button
-        className="btn btn-xs btn-ghost gap-1"
-        onClick={onReset}
-        disabled={activeFilterCount === 0}
-      >
-        <RotateCcw className="size-3" />
-        Clear all
-      </button>
     </div>
   );
 }
@@ -296,9 +286,7 @@ export function applyDomainListFilters<T extends DomainFilterableConfig>(
   });
 }
 
-export function getDomainListFilterOptions<T extends DomainFilterableConfig>(
-  configs: T[],
-): {
+export function getDomainListFilterOptions(configs: DomainFilterableConfig[]): {
   devices: DomainListFilterOption[];
   locations: DomainListFilterOption[];
 } {
@@ -321,7 +309,7 @@ export function getDomainListFilterOptions<T extends DomainFilterableConfig>(
   const locations = Array.from(locationMap, ([code, label]) => ({
     value: String(code),
     label,
-  })).sort((a, b) => a.label.localeCompare(b.label));
+  })).toSorted((a, b) => a.label.localeCompare(b.label));
 
   return { devices, locations };
 }


### PR DESCRIPTION
## Summary

Adds search and filtering to the **Tracked Domains** list so users tracking many domain/device/location combinations can quickly find a specific tracker. Filters by website/domain name, device, and country/location, and works correctly when the same domain has multiple tracked configurations.

Closes #33.

## What changed

- **Search + filter controls** for the tracked-domains list — debounced text search plus device and country facets derived from the current tracked set, applied client-side over the already-loaded data. No API or schema change.
- **Design pass (maintainer):** the filter bar now only appears once the list is long enough to warrant it (≥ 6 domains, or whenever a filter is active so it can never be orphaned after archiving). Dropped the redundant "Refine results" sub-header in favor of an inline clear control, removed the gradient band so the filter row shares the card surface, and gave the list a single clean divider under the header.
- **Review/cleanup pass (maintainer):** merged `main`, fixed the test fixtures, and cleared lint/type issues so `ci:check` is green (details below).

## How to review

1. **Behavior first** — pull the branch and open Rank Tracking (`/p/<projectId>/rank-tracking`). With < 6 tracked domains the filter bar is hidden; add enough domains (ideally the *same* domain tracked on different device/country) to see it appear, then exercise search + device + country together and the "No matching tracked domains" empty state.
2. **The filtering logic** lives in a few small pure functions (`applyDomainListFilters`, `getDomainListFilterOptions`, `countActiveDomainListFilters`) with unit-test coverage including the multi-config-per-domain case — that's the highest-signal place to read.
3. **Judgment call to confirm:** the country dropdown renders the **short** location labels (US, UK, FR), matching how the existing list rows already display location. The original test asserted full names ("United Kingdom"); I aligned the test to the actual rendered short labels rather than change the display, on the grounds that the dropdown should match the rows. Flag if you'd rather show full country names in both places.
4. **Out of scope (deliberate):** per-row visual redesign (favicons, metadata chips) and a top-of-page stat strip / rank sparklines were discussed but intentionally left out of this PR.

## Review notes

- This branch carries a **merge commit** from `main` (the sync step), so the history isn't linear — squash on merge if you prefer a clean commit.
- All reviewer findings were either fixed or verified as non-issues. Security, billing/metering, and idioms axes came back clean — notably, the hand-rolled country `<select>` deliberately does **not** reuse `LocationSelect` (that component is a searchable full-country picker for *choosing* a config; this is a filter over the small set of already-tracked countries, with an "All" option).
- `ci:check` (prettier / knip / tsc / oxlint --type-aware) passes; the filter unit tests pass (12/12).

---
*Original feature by @mvanhorn; design + review polish added by the maintainer. AI was used for assistance.*
