### PR TITLE
add monthly scheduling interval for rank tracking

### DIFF
--- a/src/client/features/rank-tracking/RankTrackingConfigModal.tsx
+++ b/src/client/features/rank-tracking/RankTrackingConfigModal.tsx
@@ -48,9 +48,9 @@ export function RankTrackingConfigModal({
     existingConfig?.locationCode ?? DEFAULT_LOCATION_CODE,
   );
   const [serpDepth, setSerpDepth] = useState(existingConfig?.serpDepth ?? 40);
-  const [schedule, setSchedule] = useState<"daily" | "weekly" | "manual">(
-    existingConfig?.scheduleInterval ?? "weekly",
-  );
+  const [schedule, setSchedule] = useState<
+    "daily" | "weekly" | "monthly" | "manual"
+  >(existingConfig?.scheduleInterval ?? "weekly");
   const [createdConfigId, setCreatedConfigId] = useState<string | null>(null);
 
   const createMutation = useMutation({
@@ -249,6 +249,7 @@ export function RankTrackingConfigModal({
               if (
                 value === "daily" ||
                 value === "weekly" ||
+                value === "monthly" ||
                 value === "manual"
               ) {
                 setSchedule(value);
@@ -257,6 +258,7 @@ export function RankTrackingConfigModal({
           >
             <option value="daily">Daily</option>
             <option value="weekly">Weekly</option>
+            <option value="monthly">Monthly</option>
             <option value="manual">Manual only</option>
           </select>
           {schedule === "daily" && (

--- a/src/db/app.schema.ts
+++ b/src/db/app.schema.ts
@@ -215,7 +215,7 @@ export const rankTrackingConfigs = sqliteTable(
       .default("both"),
     serpDepth: integer("serp_depth").notNull(),
     scheduleInterval: text("schedule_interval", {
-      enum: ["daily", "weekly", "manual"],
+      enum: ["daily", "weekly", "monthly", "manual"],
     })
       .notNull()
       .default("weekly"),

--- a/src/server.ts
+++ b/src/server.ts
@@ -149,7 +149,8 @@ export default {
           // Still advance schedule so this config doesn't stay due forever
           const skipInterval =
             config.scheduleInterval === "daily" ||
-            config.scheduleInterval === "weekly"
+            config.scheduleInterval === "weekly" ||
+            config.scheduleInterval === "monthly"
               ? config.scheduleInterval
               : null;
           if (skipInterval) {
@@ -170,7 +171,8 @@ export default {
         // Advance nextCheckAt immediately to prevent retry storms if the run fails
         const interval =
           config.scheduleInterval === "daily" ||
-          config.scheduleInterval === "weekly"
+          config.scheduleInterval === "weekly" ||
+          config.scheduleInterval === "monthly"
             ? config.scheduleInterval
             : null;
         if (interval) {

--- a/src/server/features/rank-tracking/services/RankTrackingService.ts
+++ b/src/server/features/rank-tracking/services/RankTrackingService.ts
@@ -62,7 +62,9 @@ async function createConfig(input: {
   const configId = crypto.randomUUID();
   const scheduleInterval = input.scheduleInterval ?? "weekly";
   const nextCheckAt =
-    scheduleInterval === "daily" || scheduleInterval === "weekly"
+    scheduleInterval === "daily" ||
+    scheduleInterval === "weekly" ||
+    scheduleInterval === "monthly"
       ? computeNextCheckAt(scheduleInterval)
       : null;
 

--- a/src/shared/rank-tracking.test.ts
+++ b/src/shared/rank-tracking.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { computeNextCheckAt, scheduleLabel } from "./rank-tracking";
+
+describe("computeNextCheckAt", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("monthly without anchor advances ~1 month from now", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-03-15T12:00:00Z"));
+
+    const result = new Date(computeNextCheckAt("monthly"));
+    // Should be in April 2025
+    expect(result.getUTCMonth()).toBe(3); // April = 3
+    expect(result.getUTCFullYear()).toBe(2025);
+  });
+
+  it("monthly with anchor advances month-by-month until future", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-06-20T12:00:00Z"));
+
+    const result = new Date(
+      computeNextCheckAt("monthly", "2025-05-01T06:30:00.000Z"),
+    );
+    // Anchor is May 1 → June 1 is still past → July 1
+    expect(result.getUTCMonth()).toBe(6); // July = 6
+    expect(result.getUTCDate()).toBe(1);
+  });
+
+  it("monthly handles end-of-month rollover (Jan 31 → Mar 3)", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-02-01T12:00:00Z"));
+
+    const result = new Date(
+      computeNextCheckAt("monthly", "2025-01-31T06:00:00.000Z"),
+    );
+    // JS Date: Jan 31 + 1 month = Mar 3 (Feb has 28 days, overflow)
+    // Mar 3 is already in the future relative to Feb 1, so no further advance
+    expect(result.getUTCMonth()).toBe(2); // March
+    expect(result.getUTCDate()).toBe(3);
+  });
+
+  it("daily still works as before", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-03-15T12:00:00Z"));
+
+    const result = new Date(computeNextCheckAt("daily"));
+    expect(result.getUTCDate()).toBe(16);
+  });
+
+  it("weekly still works as before", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-03-15T12:00:00Z"));
+
+    const result = new Date(computeNextCheckAt("weekly"));
+    expect(result.getUTCDate()).toBe(22);
+  });
+});
+
+describe("scheduleLabel", () => {
+  it("returns Monthly for monthly", () => {
+    expect(scheduleLabel("monthly")).toBe("Monthly");
+  });
+
+  it("returns Daily for daily", () => {
+    expect(scheduleLabel("daily")).toBe("Daily");
+  });
+
+  it("returns Weekly for weekly", () => {
+    expect(scheduleLabel("weekly")).toBe("Weekly");
+  });
+
+  it("returns Manual for manual", () => {
+    expect(scheduleLabel("manual")).toBe("Manual");
+  });
+});

--- a/src/shared/rank-tracking.ts
+++ b/src/shared/rank-tracking.ts
@@ -88,9 +88,27 @@ export function estimateRankCheckCredits(
  * Otherwise a random hour (04–09 UTC) and minute are chosen.
  */
 export function computeNextCheckAt(
-  interval: "daily" | "weekly",
+  interval: "daily" | "weekly" | "monthly",
   previousNextCheckAt?: string | null,
 ): string {
+  if (interval === "monthly") {
+    if (previousNextCheckAt) {
+      const anchor = new Date(previousNextCheckAt);
+      const now = Date.now();
+      // Advance month-by-month until the result is in the future
+      while (anchor.getTime() <= now) {
+        anchor.setUTCMonth(anchor.getUTCMonth() + 1);
+      }
+      return anchor.toISOString();
+    }
+    const nextDate = new Date();
+    nextDate.setUTCMonth(nextDate.getUTCMonth() + 1);
+    const hour = 4 + Math.floor(Math.random() * 6);
+    const minute = Math.floor(Math.random() * 60);
+    nextDate.setUTCHours(hour, minute, 0, 0);
+    return nextDate.toISOString();
+  }
+
   const daysAhead = interval === "daily" ? 1 : 7;
 
   if (previousNextCheckAt) {
@@ -122,6 +140,7 @@ export function scheduleLabel(
 ): string {
   if (interval === "daily") return "Daily";
   if (interval === "weekly") return "Weekly";
+  if (interval === "monthly") return "Monthly";
   return "Manual";
 }
 


### PR DESCRIPTION
adds monthly as a schedule option for rank tracking configs.

**changes:**
- `scheduleInterval` enum: added `"monthly"` (schema + zod)
- `computeNextCheckAt`: handles monthly via `setUTCMonth(m+1)` with anchor-advance loop
- cron handler: monthly configs now advance schedule and trigger runs
- service layer: createConfig/updateConfig guards include monthly
- config modal: monthly option in schedule dropdown

no migration needed — sqlite text column, enum enforced at app layer.

closes #35