### PR TITLE
docs: document DCR redirect-URI step for MCP behind Cloudflare Access

### DIFF
--- a/docs/SELF_HOSTING_CLOUDFLARE.md
+++ b/docs/SELF_HOSTING_CLOUDFLARE.md
@@ -68,6 +68,18 @@ Managed OAuth is required for MCP clients and is not enabled by default.
 5. Turn on `Managed OAuth`.
 6. Save.
 
+Managed OAuth alone is not enough: MCP clients register via Dynamic Client
+Registration, and a client whose redirect URI isn't allowlisted can't finish
+registering — so it logs in but exposes no tools. In **Managed OAuth settings**,
+allow the redirect URIs your clients use:
+
+- Allow `localhost` / loopback clients — for CLI and desktop agents (Codex CLI,
+  Claude Code) that register `http://localhost:PORT/callback`.
+- Add HTTPS redirect URIs for web connectors (a path may end in `/*`).
+
+See Cloudflare's [Managed OAuth](https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/managed-oauth/)
+docs for the exact dashboard steps.
+
 MCP clients should connect to:
 
 ```text

--- a/docs/SELF_HOSTING_CLOUDFLARE.md
+++ b/docs/SELF_HOSTING_CLOUDFLARE.md
@@ -66,16 +66,13 @@ Managed OAuth is required for MCP clients and is not enabled by default.
 3. Find your OpenSEO application, then select `Edit`.
 4. Go to `Additional settings` -> `OAuth`.
 5. Turn on `Managed OAuth`.
-6. In `Managed OAuth settings`, allow the redirect URIs your MCP clients use:[^dcr]
+6. In `Managed OAuth settings`, allow the redirect URIs your MCP clients use:
    - Allow `localhost` / loopback clients — for CLI and desktop agents (Codex
      CLI, Claude Code) that register `http://localhost:PORT/callback`.
    - Add HTTPS redirect URIs for web connectors (a path may end in `/*`).
+   - Without this, clients can't finish [Dynamic Client Registration](https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/managed-oauth/)
+     and log in but expose no tools.
 7. Save.
-
-[^dcr]: MCP clients register via Dynamic Client Registration, and a client whose
-    redirect URI isn't allowlisted can't finish registering — so it logs in but
-    exposes no tools. See Cloudflare's [Managed OAuth](https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/managed-oauth/)
-    docs for the exact dashboard steps.
 
 MCP clients should connect to:
 

--- a/docs/SELF_HOSTING_CLOUDFLARE.md
+++ b/docs/SELF_HOSTING_CLOUDFLARE.md
@@ -66,19 +66,16 @@ Managed OAuth is required for MCP clients and is not enabled by default.
 3. Find your OpenSEO application, then select `Edit`.
 4. Go to `Additional settings` -> `OAuth`.
 5. Turn on `Managed OAuth`.
-6. Save.
+6. In `Managed OAuth settings`, allow the redirect URIs your MCP clients use:[^dcr]
+   - Allow `localhost` / loopback clients — for CLI and desktop agents (Codex
+     CLI, Claude Code) that register `http://localhost:PORT/callback`.
+   - Add HTTPS redirect URIs for web connectors (a path may end in `/*`).
+7. Save.
 
-Managed OAuth alone is not enough: MCP clients register via Dynamic Client
-Registration, and a client whose redirect URI isn't allowlisted can't finish
-registering — so it logs in but exposes no tools. In **Managed OAuth settings**,
-allow the redirect URIs your clients use:
-
-- Allow `localhost` / loopback clients — for CLI and desktop agents (Codex CLI,
-  Claude Code) that register `http://localhost:PORT/callback`.
-- Add HTTPS redirect URIs for web connectors (a path may end in `/*`).
-
-See Cloudflare's [Managed OAuth](https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/managed-oauth/)
-docs for the exact dashboard steps.
+[^dcr]: MCP clients register via Dynamic Client Registration, and a client whose
+    redirect URI isn't allowlisted can't finish registering — so it logs in but
+    exposes no tools. See Cloudflare's [Managed OAuth](https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/managed-oauth/)
+    docs for the exact dashboard steps.
 
 MCP clients should connect to:
 


### PR DESCRIPTION
## What

Adds the missing Dynamic Client Registration (DCR) step to the "Connect the MCP server through Cloudflare Access" section of `SELF_HOSTING_CLOUDFLARE.md`.

## Why

Investigating #47 (self-hoster: *"MCP behind Cloudflare Access OAuth logs in but exposes no tools"*). The failure is at the Cloudflare Access OAuth layer, not in OpenSEO:

- In `cloudflare_access` mode OpenSEO delegates auth entirely to Access and validates the `Cf-Access-Jwt-Assertion` header — which Access still injects even for Managed OAuth opaque tokens, so no OpenSEO-side OAuth config is needed.
- But enabling **Managed OAuth alone is not enough**: MCP clients register via Dynamic Client Registration, and a client whose redirect URI isn't allowlisted can't finish registering — so it logs in but exposes no tools. That matches the reported Codex/Claude errors (Access-served metadata 401 + a rejected client registration).

Our docs previously stopped at "Turn on Managed OAuth," omitting the redirect-URI allowlist that's the actual blocker.

## Change

Documents allowing `localhost`/loopback clients (CLI/desktop agents) and adding HTTPS redirect URIs for web connectors, and links to Cloudflare's [Managed OAuth](https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/managed-oauth/) docs for the exact dashboard steps.

Closes #47