### PR TITLE
feat: Search Performance page with striking-distance report (GSC data in the UI)

### DIFF
--- a/src/client/components/table/AppDataTable.tsx
+++ b/src/client/components/table/AppDataTable.tsx
@@ -2,6 +2,7 @@ import {
   flexRender,
   getCoreRowModel,
   getExpandedRowModel,
+  getPaginationRowModel,
   getSortedRowModel,
   useReactTable,
   type ColumnDef,
@@ -38,15 +39,20 @@ type UseAppTableOptions<TData> = Omit<
 > & {
   withSorting?: boolean;
   withExpanded?: boolean;
+  withPagination?: boolean;
 };
 
 export function useAppTable<TData>(options: UseAppTableOptions<TData>) {
-  const { withSorting, withExpanded, ...tableOptions } = options;
+  const { withSorting, withExpanded, withPagination, ...tableOptions } =
+    options;
   return useReactTable({
     ...tableOptions,
     getCoreRowModel: getCoreRowModel(),
     ...(withSorting ? { getSortedRowModel: getSortedRowModel() } : {}),
     ...(withExpanded ? { getExpandedRowModel: getExpandedRowModel() } : {}),
+    ...(withPagination
+      ? { getPaginationRowModel: getPaginationRowModel() }
+      : {}),
   });
 }
 

--- a/src/client/features/gsc/SearchConsoleConnectionCard.tsx
+++ b/src/client/features/gsc/SearchConsoleConnectionCard.tsx
@@ -68,6 +68,9 @@ export function SearchConsoleConnectionCard({
       void queryClient.invalidateQueries({
         queryKey: ["searchPerformance", projectId],
       });
+      void queryClient.invalidateQueries({
+        queryKey: ["searchPerformanceTable", projectId],
+      });
     },
     onError: (error) => toast.error(getStandardErrorMessage(error)),
   });
@@ -83,6 +86,9 @@ export function SearchConsoleConnectionCard({
       void queryClient.invalidateQueries({ queryKey: GRANT_STATUS_KEY });
       void queryClient.invalidateQueries({
         queryKey: ["searchPerformance", projectId],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ["searchPerformanceTable", projectId],
       });
     },
     onError: (error) => toast.error(getStandardErrorMessage(error)),

--- a/src/client/features/gsc/SearchConsoleConnectionCard.tsx
+++ b/src/client/features/gsc/SearchConsoleConnectionCard.tsx
@@ -63,6 +63,11 @@ export function SearchConsoleConnectionCard({
       setPicking(false);
       void queryClient.invalidateQueries({ queryKey: connectionKey });
       void queryClient.invalidateQueries({ queryKey: GRANT_STATUS_KEY });
+      // The Search Performance report caches {connected:false}; refresh it so
+      // the page shows data right after connecting instead of the stale card.
+      void queryClient.invalidateQueries({
+        queryKey: ["searchPerformance", projectId],
+      });
     },
     onError: (error) => toast.error(getStandardErrorMessage(error)),
   });
@@ -76,6 +81,9 @@ export function SearchConsoleConnectionCard({
       // Disconnect can drop the account-level grant server-side; keep the
       // shared grant-status cache (onboarding step + re-engagement nudge) honest.
       void queryClient.invalidateQueries({ queryKey: GRANT_STATUS_KEY });
+      void queryClient.invalidateQueries({
+        queryKey: ["searchPerformance", projectId],
+      });
     },
     onError: (error) => toast.error(getStandardErrorMessage(error)),
   });

--- a/src/client/features/search-performance/SearchPerformanceColumns.tsx
+++ b/src/client/features/search-performance/SearchPerformanceColumns.tsx
@@ -3,13 +3,20 @@ import type { MutableRefObject } from "react";
 import { makeSelectionColumn } from "@/client/components/table/AppDataTable";
 import { SortableHeader } from "@/client/components/table/SortableHeader";
 import type { SelectionAnchor } from "@/client/components/table/tableSelection";
-import type { getSearchPerformanceReport } from "@/serverFunctions/searchPerformance";
+import type {
+  getSearchPerformanceReport,
+  getSearchPerformanceTable,
+} from "@/serverFunctions/searchPerformance";
 
 export type Report = Extract<
   Awaited<ReturnType<typeof getSearchPerformanceReport>>,
   { connected: true }
 >;
-type DimensionRow = Report["queries"][number];
+export type SearchPerformanceTableRow = Extract<
+  Awaited<ReturnType<typeof getSearchPerformanceTable>>,
+  { connected: true }
+>["rows"][number];
+type DimensionRow = SearchPerformanceTableRow;
 type StrikingRow = Report["strikingDistance"][number];
 
 const numberFormat = new Intl.NumberFormat("en-US");

--- a/src/client/features/search-performance/SearchPerformanceColumns.tsx
+++ b/src/client/features/search-performance/SearchPerformanceColumns.tsx
@@ -96,17 +96,24 @@ export function buildStrikingColumns(
     strikingHelper.accessor("page", {
       enableSorting: false,
       header: () => "Page",
-      cell: ({ getValue }) => (
-        <a
-          href={getValue()}
-          target="_blank"
-          rel="noreferrer"
-          className="link link-hover block max-w-sm truncate"
-          title={getValue()}
-        >
-          {getValue()}
-        </a>
-      ),
+      // GSC page keys are canonical http(s) URLs of the verified property;
+      // the scheme check is defense-in-depth before rendering an href.
+      cell: ({ getValue }) =>
+        /^https?:\/\//.test(getValue()) ? (
+          <a
+            href={getValue()}
+            target="_blank"
+            rel="noreferrer"
+            className="link link-hover block max-w-sm truncate"
+            title={getValue()}
+          >
+            {getValue()}
+          </a>
+        ) : (
+          <span className="block max-w-sm truncate" title={getValue()}>
+            {getValue()}
+          </span>
+        ),
     }),
     strikingHelper.accessor("impressions", {
       header: ({ column }) => (

--- a/src/client/features/search-performance/SearchPerformanceColumns.tsx
+++ b/src/client/features/search-performance/SearchPerformanceColumns.tsx
@@ -1,0 +1,133 @@
+import { createColumnHelper, type ColumnDef } from "@tanstack/react-table";
+import type { MutableRefObject } from "react";
+import { makeSelectionColumn } from "@/client/components/table/AppDataTable";
+import { SortableHeader } from "@/client/components/table/SortableHeader";
+import type { SelectionAnchor } from "@/client/components/table/tableSelection";
+import type { getSearchPerformanceReport } from "@/serverFunctions/searchPerformance";
+
+export type Report = Extract<
+  Awaited<ReturnType<typeof getSearchPerformanceReport>>,
+  { connected: true }
+>;
+type DimensionRow = Report["queries"][number];
+type StrikingRow = Report["strikingDistance"][number];
+
+const numberFormat = new Intl.NumberFormat("en-US");
+
+export function formatCount(value: number): string {
+  return numberFormat.format(Math.round(value));
+}
+
+export function formatCtr(value: number): string {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+export function formatPosition(value: number): string {
+  return value.toFixed(1);
+}
+
+const rightAligned = {
+  headerClassName: "text-right",
+  cellClassName: "text-right tabular-nums",
+} as const;
+
+const dimensionHelper = createColumnHelper<DimensionRow>();
+
+export function buildDimensionColumns(
+  keyLabel: string,
+): ColumnDef<DimensionRow>[] {
+  return [
+    dimensionHelper.accessor("key", {
+      enableSorting: false,
+      header: () => keyLabel,
+      cell: ({ getValue }) => (
+        <span className="block max-w-xl truncate" title={getValue()}>
+          {getValue()}
+        </span>
+      ),
+    }),
+    dimensionHelper.accessor("clicks", {
+      header: ({ column }) => (
+        <SortableHeader column={column} label="Clicks" align="right" />
+      ),
+      cell: ({ getValue }) => formatCount(getValue()),
+      meta: rightAligned,
+    }),
+    dimensionHelper.accessor("impressions", {
+      header: ({ column }) => (
+        <SortableHeader column={column} label="Impressions" align="right" />
+      ),
+      cell: ({ getValue }) => formatCount(getValue()),
+      meta: rightAligned,
+    }),
+    dimensionHelper.accessor("ctr", {
+      header: ({ column }) => (
+        <SortableHeader column={column} label="CTR" align="right" />
+      ),
+      cell: ({ getValue }) => formatCtr(getValue()),
+      meta: rightAligned,
+    }),
+    dimensionHelper.accessor("position", {
+      header: ({ column }) => (
+        <SortableHeader column={column} label="Position" align="right" />
+      ),
+      cell: ({ getValue }) => formatPosition(getValue()),
+      meta: rightAligned,
+    }),
+  ];
+}
+
+const strikingHelper = createColumnHelper<StrikingRow>();
+
+export function buildStrikingColumns(
+  anchorRef: MutableRefObject<SelectionAnchor | null>,
+): ColumnDef<StrikingRow>[] {
+  return [
+    makeSelectionColumn<StrikingRow>(anchorRef),
+    strikingHelper.accessor("query", {
+      enableSorting: false,
+      header: () => "Query",
+      cell: ({ getValue }) => (
+        <span className="block max-w-xs truncate" title={getValue()}>
+          {getValue()}
+        </span>
+      ),
+    }),
+    strikingHelper.accessor("page", {
+      enableSorting: false,
+      header: () => "Page",
+      cell: ({ getValue }) => (
+        <a
+          href={getValue()}
+          target="_blank"
+          rel="noreferrer"
+          className="link link-hover block max-w-sm truncate"
+          title={getValue()}
+        >
+          {getValue()}
+        </a>
+      ),
+    }),
+    strikingHelper.accessor("impressions", {
+      header: ({ column }) => (
+        <SortableHeader column={column} label="Impressions" align="right" />
+      ),
+      cell: ({ getValue }) => formatCount(getValue()),
+      meta: rightAligned,
+    }),
+    strikingHelper.accessor("clicks", {
+      header: ({ column }) => (
+        <SortableHeader column={column} label="Clicks" align="right" />
+      ),
+      cell: ({ getValue }) => formatCount(getValue()),
+      meta: rightAligned,
+    }),
+    strikingHelper.accessor("position", {
+      header: ({ column }) => (
+        <SortableHeader column={column} label="Position" align="right" />
+      ),
+      cell: ({ getValue }) => formatPosition(getValue()),
+      meta: rightAligned,
+    }),
+  ];
+}

--- a/src/client/features/search-performance/SearchPerformancePage.tsx
+++ b/src/client/features/search-performance/SearchPerformancePage.tsx
@@ -1,10 +1,12 @@
 import { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
-import { Download, Loader2 } from "lucide-react";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { Download, Loader2, Sheet } from "lucide-react";
+import { TableExportMenu } from "@/client/components/table/TableBulkActionBar";
 import { SearchConsoleConnectionCard } from "@/client/features/gsc/SearchConsoleConnectionCard";
 import {
   DimensionTable,
   exportCurrentTab,
+  exportCurrentTabToSheets,
   StrikingDistanceTable,
   TabButton,
   TotalsCards,
@@ -12,36 +14,50 @@ import {
 } from "@/client/features/search-performance/SearchPerformanceParts";
 import { getStandardErrorMessage } from "@/client/lib/error-messages";
 import { getSearchPerformanceReport } from "@/serverFunctions/searchPerformance";
+import {
+  GSC_DEVICES,
+  SEARCH_PERFORMANCE_RANGES,
+  type SearchPerformanceDateRange,
+  type SearchPerformanceDevice,
+} from "@/types/schemas/search-performance";
 
-type DateRange = "last_7_days" | "last_28_days" | "last_3_months";
-type Device = "DESKTOP" | "MOBILE" | "TABLET";
+const RANGE_LABELS: Record<SearchPerformanceDateRange, string> = {
+  last_7_days: "Last 7 days",
+  last_28_days: "Last 28 days",
+  last_3_months: "Last 3 months",
+};
+const RANGE_OPTIONS = SEARCH_PERFORMANCE_RANGES.map((value) => ({
+  value,
+  label: RANGE_LABELS[value],
+}));
 
-const RANGE_OPTIONS: Array<{ value: DateRange; label: string }> = [
-  { value: "last_7_days", label: "Last 7 days" },
-  { value: "last_28_days", label: "Last 28 days" },
-  { value: "last_3_months", label: "Last 3 months" },
-];
-
-const DEVICE_OPTIONS: Array<{ value: Device; label: string }> = [
-  { value: "DESKTOP", label: "Desktop" },
-  { value: "MOBILE", label: "Mobile" },
-  { value: "TABLET", label: "Tablet" },
-];
+const DEVICE_LABELS: Record<SearchPerformanceDevice, string> = {
+  DESKTOP: "Desktop",
+  MOBILE: "Mobile",
+  TABLET: "Tablet",
+};
+const DEVICE_OPTIONS = GSC_DEVICES.map((value) => ({
+  value,
+  label: DEVICE_LABELS[value],
+}));
 
 // Sentinel for "no filter" in the selects; never sent to the server.
 const ALL = "ALL";
 
-function isDateRange(value: string): value is DateRange {
-  return RANGE_OPTIONS.some((option) => option.value === value);
+function isDateRange(value: string): value is SearchPerformanceDateRange {
+  return SEARCH_PERFORMANCE_RANGES.some((option) => option === value);
 }
 
-function isDevice(value: string): value is Device {
-  return DEVICE_OPTIONS.some((option) => option.value === value);
+function isDevice(value: string): value is SearchPerformanceDevice {
+  return GSC_DEVICES.some((option) => option === value);
 }
 
 export function SearchPerformancePage({ projectId }: { projectId: string }) {
-  const [range, setRange] = useState<DateRange>("last_28_days");
-  const [device, setDevice] = useState<Device | typeof ALL>(ALL);
+  const [range, setRange] =
+    useState<SearchPerformanceDateRange>("last_28_days");
+  const [device, setDevice] = useState<SearchPerformanceDevice | typeof ALL>(
+    ALL,
+  );
   const [country, setCountry] = useState<string>(ALL);
   const [tab, setTab] = useState<Tab>("striking");
 
@@ -56,128 +72,143 @@ export function SearchPerformancePage({ projectId }: { projectId: string }) {
           ...(country === ALL ? {} : { country }),
         },
       }),
+    placeholderData: keepPreviousData,
   });
 
   const report = reportQuery.data;
 
   return (
-    <div className="space-y-4">
-      <div className="flex flex-wrap items-end justify-between gap-3">
-        <div>
-          <h1 className="text-2xl font-semibold">Search Performance</h1>
-          <p className="text-sm text-base-content/60">
-            Your site&apos;s real Google Search data, free from Search Console.
-          </p>
-        </div>
-        {report?.connected ? (
-          <div className="flex flex-wrap items-center gap-2">
-            <select
-              className="select select-bordered select-sm"
-              value={device}
-              onChange={(event) => {
-                setDevice(
-                  isDevice(event.target.value) ? event.target.value : ALL,
-                );
-              }}
-              aria-label="Device filter"
-            >
-              <option value={ALL}>All devices</option>
-              {DEVICE_OPTIONS.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
-            <select
-              className="select select-bordered select-sm"
-              value={country}
-              onChange={(event) => setCountry(event.target.value)}
-              aria-label="Country filter"
-            >
-              <option value={ALL}>All countries</option>
-              {report.countries.map((row) => (
-                <option key={row.key} value={row.key}>
-                  {row.key.toUpperCase()}
-                </option>
-              ))}
-            </select>
-            <select
-              className="select select-bordered select-sm"
-              value={range}
-              onChange={(event) => {
-                if (isDateRange(event.target.value)) {
-                  setRange(event.target.value);
-                }
-              }}
-              aria-label="Date range"
-            >
-              {RANGE_OPTIONS.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
+    <div className="px-4 py-4 pb-24 overflow-auto md:px-6 md:py-6 md:pb-8">
+      <div className="mx-auto max-w-7xl space-y-4">
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <h1 className="text-2xl font-semibold">Search Performance</h1>
+            <p className="text-sm text-base-content/70">
+              See your site&apos;s clicks, impressions, CTR, and position from
+              Google Search Console.
+            </p>
           </div>
-        ) : null}
-      </div>
+          {report?.connected ? (
+            <div className="flex flex-wrap items-center gap-2">
+              {reportQuery.isFetching && !reportQuery.isPending ? (
+                <Loader2 className="size-4 animate-spin text-base-content/40" />
+              ) : null}
+              <select
+                className="select select-bordered select-sm"
+                value={device}
+                onChange={(event) => {
+                  setDevice(
+                    isDevice(event.target.value) ? event.target.value : ALL,
+                  );
+                }}
+                aria-label="Device filter"
+              >
+                <option value={ALL}>All devices</option>
+                {DEVICE_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+              <select
+                className="select select-bordered select-sm"
+                value={country}
+                onChange={(event) => setCountry(event.target.value)}
+                aria-label="Country filter"
+              >
+                <option value={ALL}>All countries</option>
+                {report.countries.map((row) => (
+                  <option key={row.key} value={row.key}>
+                    {row.key.toUpperCase()}
+                  </option>
+                ))}
+              </select>
+              <select
+                className="select select-bordered select-sm"
+                value={range}
+                onChange={(event) => {
+                  if (isDateRange(event.target.value)) {
+                    setRange(event.target.value);
+                  }
+                }}
+                aria-label="Date range"
+              >
+                {RANGE_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          ) : null}
+        </div>
 
-      {reportQuery.isPending ? (
-        <div className="flex items-center gap-2 p-8 text-sm text-base-content/60">
-          <Loader2 className="size-4 animate-spin" /> Loading Search Console
-          data…
-        </div>
-      ) : reportQuery.isError ? (
-        <div className="alert alert-error">
-          <span className="text-sm">
-            {getStandardErrorMessage(reportQuery.error)}
-          </span>
-        </div>
-      ) : !report?.connected ? (
-        <div className="max-w-2xl">
-          <SearchConsoleConnectionCard projectId={projectId} />
-        </div>
-      ) : (
-        <>
-          <TotalsCards report={report} />
-          <div className="flex flex-wrap items-center justify-between gap-2">
-            <div role="tablist" className="tabs tabs-border">
-              <TabButton
-                active={tab === "striking"}
-                onClick={() => setTab("striking")}
-                label={`Striking distance (${report.strikingDistance.length})`}
-              />
-              <TabButton
-                active={tab === "queries"}
-                onClick={() => setTab("queries")}
-                label={`Queries (${report.queries.length})`}
-              />
-              <TabButton
-                active={tab === "pages"}
-                onClick={() => setTab("pages")}
-                label={`Pages (${report.pages.length})`}
+        {reportQuery.isPending ? (
+          <div className="flex items-center gap-2 p-8 text-sm text-base-content/60">
+            <Loader2 className="size-4 animate-spin" /> Loading Search Console
+            data…
+          </div>
+        ) : reportQuery.isError ? (
+          <div className="alert alert-error">
+            <span className="text-sm">
+              {getStandardErrorMessage(reportQuery.error)}
+            </span>
+          </div>
+        ) : !report?.connected ? (
+          <div className="max-w-2xl">
+            <SearchConsoleConnectionCard projectId={projectId} />
+          </div>
+        ) : (
+          <>
+            <TotalsCards report={report} />
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div role="tablist" className="tabs tabs-border">
+                <TabButton
+                  active={tab === "striking"}
+                  onClick={() => setTab("striking")}
+                  label={`Striking distance (${report.strikingDistance.length})`}
+                />
+                <TabButton
+                  active={tab === "queries"}
+                  onClick={() => setTab("queries")}
+                  label={`Queries (${report.queries.length})`}
+                />
+                <TabButton
+                  active={tab === "pages"}
+                  onClick={() => setTab("pages")}
+                  label={`Pages (${report.pages.length})`}
+                />
+              </div>
+              <TableExportMenu
+                buttonClassName="btn btn-ghost btn-sm gap-1"
+                actions={[
+                  {
+                    label: "Export to Sheets",
+                    icon: <Sheet className="size-4" />,
+                    onClick: () => exportCurrentTabToSheets(report, tab),
+                  },
+                  {
+                    label: "Download CSV",
+                    icon: <Download className="size-4" />,
+                    onClick: () => exportCurrentTab(report, tab),
+                  },
+                ]}
               />
             </div>
-            <button
-              type="button"
-              className="btn btn-ghost btn-sm"
-              onClick={() => exportCurrentTab(report, tab)}
-            >
-              <Download className="size-4" /> Export CSV
-            </button>
-          </div>
-          {tab === "striking" ? (
-            <StrikingDistanceTable
-              projectId={projectId}
-              rows={report.strikingDistance}
-            />
-          ) : (
-            <DimensionTable
-              rows={tab === "queries" ? report.queries : report.pages}
-              keyLabel={tab === "queries" ? "Query" : "Page"}
-            />
-          )}
-        </>
-      )}
+            {tab === "striking" ? (
+              <StrikingDistanceTable
+                projectId={projectId}
+                rows={report.strikingDistance}
+              />
+            ) : (
+              <DimensionTable
+                rows={tab === "queries" ? report.queries : report.pages}
+                keyLabel={tab === "queries" ? "Query" : "Page"}
+              />
+            )}
+          </>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/client/features/search-performance/SearchPerformancePage.tsx
+++ b/src/client/features/search-performance/SearchPerformancePage.tsx
@@ -1,24 +1,39 @@
-import { useState } from "react";
-import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import {
+  keepPreviousData,
+  queryOptions,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { Download, Loader2, Sheet } from "lucide-react";
+import { toast } from "sonner";
 import { TableExportMenu } from "@/client/components/table/TableBulkActionBar";
+import { TablePagination } from "@/client/components/table/TablePagination";
 import { SearchConsoleConnectionCard } from "@/client/features/gsc/SearchConsoleConnectionCard";
 import {
   DimensionTable,
-  exportCurrentTab,
-  exportCurrentTabToSheets,
+  exportDimensionRows,
+  exportStriking,
   StrikingDistanceTable,
   TabButton,
   TotalsCards,
+  type ExportTarget,
   type Tab,
 } from "@/client/features/search-performance/SearchPerformanceParts";
 import { getStandardErrorMessage } from "@/client/lib/error-messages";
-import { getSearchPerformanceReport } from "@/serverFunctions/searchPerformance";
+import {
+  exportSearchPerformanceTable,
+  getSearchPerformanceReport,
+  getSearchPerformanceTable,
+} from "@/serverFunctions/searchPerformance";
 import {
   GSC_DEVICES,
+  SEARCH_PERFORMANCE_DEFAULT_PAGE_SIZE,
+  SEARCH_PERFORMANCE_PAGE_SIZES,
   SEARCH_PERFORMANCE_RANGES,
   type SearchPerformanceDateRange,
   type SearchPerformanceDevice,
+  type SearchPerformanceTableDimension,
 } from "@/types/schemas/search-performance";
 
 const RANGE_LABELS: Record<SearchPerformanceDateRange, string> = {
@@ -52,7 +67,56 @@ function isDevice(value: string): value is SearchPerformanceDevice {
   return GSC_DEVICES.some((option) => option === value);
 }
 
+function tabDimension(tab: Tab): SearchPerformanceTableDimension {
+  return tab === "pages" ? "page" : "query";
+}
+
+type FilterInput = {
+  dateRange: SearchPerformanceDateRange;
+  device?: SearchPerformanceDevice;
+  country?: string;
+};
+
+// The server filter payload: drop device/country when set to the "ALL" sentinel.
+function buildFilterInput(
+  range: SearchPerformanceDateRange,
+  device: SearchPerformanceDevice | typeof ALL,
+  country: string,
+): FilterInput {
+  return {
+    dateRange: range,
+    ...(device === ALL ? {} : { device }),
+    ...(country === ALL ? {} : { country }),
+  };
+}
+
+// Single source for the paginated table query, shared by the live query and the
+// warm-on-connect prefetch so their key + fn can never drift apart.
+function tableQueryOptions(
+  projectId: string,
+  dimension: SearchPerformanceTableDimension,
+  page: number,
+  pageSize: number,
+  filterInput: FilterInput,
+) {
+  return queryOptions({
+    queryKey: [
+      "searchPerformanceTable",
+      projectId,
+      dimension,
+      page,
+      pageSize,
+      filterInput,
+    ],
+    queryFn: () =>
+      getSearchPerformanceTable({
+        data: { projectId, dimension, page, pageSize, ...filterInput },
+      }),
+  });
+}
+
 export function SearchPerformancePage({ projectId }: { projectId: string }) {
+  const queryClient = useQueryClient();
   const [range, setRange] =
     useState<SearchPerformanceDateRange>("last_28_days");
   const [device, setDevice] = useState<SearchPerformanceDevice | typeof ALL>(
@@ -60,87 +124,77 @@ export function SearchPerformancePage({ projectId }: { projectId: string }) {
   );
   const [country, setCountry] = useState<string>(ALL);
   const [tab, setTab] = useState<Tab>("striking");
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState<number>(
+    SEARCH_PERFORMANCE_DEFAULT_PAGE_SIZE,
+  );
+
+  // Any change to the query set (tab, filters, page size) restarts at page 1.
+  useEffect(() => {
+    setPage(1);
+  }, [tab, range, device, country, pageSize]);
+
+  const filterInput = buildFilterInput(range, device, country);
 
   const reportQuery = useQuery({
     queryKey: ["searchPerformance", projectId, range, device, country],
     queryFn: () =>
-      getSearchPerformanceReport({
-        data: {
-          projectId,
-          dateRange: range,
-          ...(device === ALL ? {} : { device }),
-          ...(country === ALL ? {} : { country }),
-        },
-      }),
+      getSearchPerformanceReport({ data: { projectId, ...filterInput } }),
     placeholderData: keepPreviousData,
   });
-
   const report = reportQuery.data;
+
+  const isTableTab = tab === "queries" || tab === "pages";
+  const dimension = tabDimension(tab);
+  const tableQuery = useQuery({
+    ...tableQueryOptions(projectId, dimension, page, pageSize, filterInput),
+    enabled: report?.connected === true && isTableTab,
+    placeholderData: keepPreviousData,
+  });
+  const tableData = tableQuery.data;
+  const tableRows = tableData?.connected ? tableData.rows : [];
+  const hasNextPage = tableData?.connected ? tableData.hasNextPage : false;
+
+  // Warm the Queries tab (first page) as soon as the report connects so the tab
+  // opens instantly instead of showing a spinner. Free first-party GSC data.
+  useEffect(() => {
+    if (report?.connected !== true) return;
+    void queryClient.prefetchQuery(
+      tableQueryOptions(
+        projectId,
+        "query",
+        1,
+        SEARCH_PERFORMANCE_DEFAULT_PAGE_SIZE,
+        buildFilterInput(range, device, country),
+      ),
+    );
+  }, [report?.connected, projectId, range, device, country, queryClient]);
+
+  const handleExport = async (target: ExportTarget) => {
+    if (!report?.connected) return;
+    try {
+      if (tab === "striking") {
+        exportStriking(report, target);
+        return;
+      }
+      const data = await exportSearchPerformanceTable({
+        data: { projectId, dimension, ...filterInput },
+      });
+      exportDimensionRows(dimension, data.rows, report.range, target);
+    } catch (error) {
+      toast.error(getStandardErrorMessage(error, "Export failed"));
+    }
+  };
 
   return (
     <div className="px-4 py-4 pb-24 overflow-auto md:px-6 md:py-6 md:pb-8">
       <div className="mx-auto max-w-7xl space-y-4">
-        <div className="flex flex-wrap items-end justify-between gap-3">
-          <div>
-            <h1 className="text-2xl font-semibold">Search Performance</h1>
-            <p className="text-sm text-base-content/70">
-              See your site&apos;s clicks, impressions, CTR, and position from
-              Google Search Console.
-            </p>
-          </div>
-          {report?.connected ? (
-            <div className="flex flex-wrap items-center gap-2">
-              {reportQuery.isFetching && !reportQuery.isPending ? (
-                <Loader2 className="size-4 animate-spin text-base-content/40" />
-              ) : null}
-              <select
-                className="select select-bordered select-sm"
-                value={device}
-                onChange={(event) => {
-                  setDevice(
-                    isDevice(event.target.value) ? event.target.value : ALL,
-                  );
-                }}
-                aria-label="Device filter"
-              >
-                <option value={ALL}>All devices</option>
-                {DEVICE_OPTIONS.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-              <select
-                className="select select-bordered select-sm"
-                value={country}
-                onChange={(event) => setCountry(event.target.value)}
-                aria-label="Country filter"
-              >
-                <option value={ALL}>All countries</option>
-                {report.countries.map((row) => (
-                  <option key={row.key} value={row.key}>
-                    {row.key.toUpperCase()}
-                  </option>
-                ))}
-              </select>
-              <select
-                className="select select-bordered select-sm"
-                value={range}
-                onChange={(event) => {
-                  if (isDateRange(event.target.value)) {
-                    setRange(event.target.value);
-                  }
-                }}
-                aria-label="Date range"
-              >
-                {RANGE_OPTIONS.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-            </div>
-          ) : null}
+        <div>
+          <h1 className="text-2xl font-semibold">Search Performance</h1>
+          <p className="text-sm text-base-content/70">
+            See your site&apos;s clicks, impressions, CTR, and position from
+            Google Search Console.
+          </p>
         </div>
 
         {reportQuery.isPending ? (
@@ -155,57 +209,142 @@ export function SearchPerformancePage({ projectId }: { projectId: string }) {
             </span>
           </div>
         ) : !report?.connected ? (
-          <div className="max-w-2xl">
+          <div className="max-w-2xl space-y-4">
+            <p className="text-sm text-base-content/70">
+              Find your striking-distance keywords — queries ranking just off
+              the top of page one, where a small improvement can win the most
+              new clicks. Connect Search Console to see them.
+            </p>
             <SearchConsoleConnectionCard projectId={projectId} />
           </div>
         ) : (
           <>
             <TotalsCards report={report} />
-            <div className="flex flex-wrap items-center justify-between gap-2">
-              <div role="tablist" className="tabs tabs-border">
-                <TabButton
-                  active={tab === "striking"}
-                  onClick={() => setTab("striking")}
-                  label={`Striking distance (${report.strikingDistance.length})`}
-                />
-                <TabButton
-                  active={tab === "queries"}
-                  onClick={() => setTab("queries")}
-                  label={`Queries (${report.queries.length})`}
-                />
-                <TabButton
-                  active={tab === "pages"}
-                  onClick={() => setTab("pages")}
-                  label={`Pages (${report.pages.length})`}
-                />
+            <div className="overflow-hidden rounded-xl border border-base-300 bg-base-100">
+              <div className="flex flex-col gap-3 border-b border-base-300 px-4 py-3 lg:flex-row lg:items-center lg:justify-between">
+                <div role="tablist" className="tabs tabs-box w-fit">
+                  <TabButton
+                    active={tab === "striking"}
+                    onClick={() => setTab("striking")}
+                    label={`Striking distance (${report.strikingDistance.length})`}
+                  />
+                  <TabButton
+                    active={tab === "queries"}
+                    onClick={() => setTab("queries")}
+                    label="Queries"
+                  />
+                  <TabButton
+                    active={tab === "pages"}
+                    onClick={() => setTab("pages")}
+                    label="Pages"
+                  />
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                  {reportQuery.isFetching && !reportQuery.isPending ? (
+                    <Loader2 className="size-4 animate-spin text-base-content/40" />
+                  ) : null}
+                  <select
+                    className="select select-bordered select-sm w-36"
+                    value={device}
+                    onChange={(event) => {
+                      setDevice(
+                        isDevice(event.target.value) ? event.target.value : ALL,
+                      );
+                    }}
+                    aria-label="Device filter"
+                  >
+                    <option value={ALL}>All devices</option>
+                    {DEVICE_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                  <select
+                    className="select select-bordered select-sm w-36"
+                    value={country}
+                    onChange={(event) => setCountry(event.target.value)}
+                    aria-label="Country filter"
+                  >
+                    <option value={ALL}>All countries</option>
+                    {report.countries.map((row) => (
+                      <option key={row.key} value={row.key}>
+                        {row.key.toUpperCase()}
+                      </option>
+                    ))}
+                  </select>
+                  <select
+                    className="select select-bordered select-sm w-36"
+                    value={range}
+                    onChange={(event) => {
+                      if (isDateRange(event.target.value)) {
+                        setRange(event.target.value);
+                      }
+                    }}
+                    aria-label="Date range"
+                  >
+                    {RANGE_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                  <TableExportMenu
+                    buttonClassName="btn btn-ghost btn-sm gap-1"
+                    actions={[
+                      {
+                        label: "Export to Sheets",
+                        icon: <Sheet className="size-4" />,
+                        onClick: () => void handleExport("sheets"),
+                      },
+                      {
+                        label: "Download CSV",
+                        icon: <Download className="size-4" />,
+                        onClick: () => void handleExport("csv"),
+                      },
+                    ]}
+                  />
+                </div>
               </div>
-              <TableExportMenu
-                buttonClassName="btn btn-ghost btn-sm gap-1"
-                actions={[
-                  {
-                    label: "Export to Sheets",
-                    icon: <Sheet className="size-4" />,
-                    onClick: () => exportCurrentTabToSheets(report, tab),
-                  },
-                  {
-                    label: "Download CSV",
-                    icon: <Download className="size-4" />,
-                    onClick: () => exportCurrentTab(report, tab),
-                  },
-                ]}
-              />
+
+              {tab === "striking" ? (
+                <StrikingDistanceTable
+                  projectId={projectId}
+                  rows={report.strikingDistance}
+                />
+              ) : tableQuery.isPending ? (
+                <div className="flex items-center gap-2 p-8 text-sm text-base-content/60">
+                  <Loader2 className="size-4 animate-spin" /> Loading…
+                </div>
+              ) : tableQuery.isError ? (
+                <div className="p-4">
+                  <div className="alert alert-error">
+                    <span className="text-sm">
+                      {getStandardErrorMessage(tableQuery.error)}
+                    </span>
+                  </div>
+                </div>
+              ) : (
+                <>
+                  <div className="p-4">
+                    <DimensionTable
+                      rows={tableRows}
+                      keyLabel={tab === "queries" ? "Query" : "Page"}
+                    />
+                  </div>
+                  <TablePagination
+                    page={page}
+                    pageSize={pageSize}
+                    pageSizes={SEARCH_PERFORMANCE_PAGE_SIZES}
+                    totalCount={null}
+                    hasNextPage={hasNextPage}
+                    isLoading={tableQuery.isFetching}
+                    onPageChange={setPage}
+                    onPageSizeChange={setPageSize}
+                  />
+                </>
+              )}
             </div>
-            {tab === "striking" ? (
-              <StrikingDistanceTable
-                projectId={projectId}
-                rows={report.strikingDistance}
-              />
-            ) : (
-              <DimensionTable
-                rows={tab === "queries" ? report.queries : report.pages}
-                keyLabel={tab === "queries" ? "Query" : "Page"}
-              />
-            )}
           </>
         )}
       </div>

--- a/src/client/features/search-performance/SearchPerformancePage.tsx
+++ b/src/client/features/search-performance/SearchPerformancePage.tsx
@@ -1,0 +1,183 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Download, Loader2 } from "lucide-react";
+import { SearchConsoleConnectionCard } from "@/client/features/gsc/SearchConsoleConnectionCard";
+import {
+  DimensionTable,
+  exportCurrentTab,
+  StrikingDistanceTable,
+  TabButton,
+  TotalsCards,
+  type Tab,
+} from "@/client/features/search-performance/SearchPerformanceParts";
+import { getStandardErrorMessage } from "@/client/lib/error-messages";
+import { getSearchPerformanceReport } from "@/serverFunctions/searchPerformance";
+
+type DateRange = "last_7_days" | "last_28_days" | "last_3_months";
+type Device = "DESKTOP" | "MOBILE" | "TABLET";
+
+const RANGE_OPTIONS: Array<{ value: DateRange; label: string }> = [
+  { value: "last_7_days", label: "Last 7 days" },
+  { value: "last_28_days", label: "Last 28 days" },
+  { value: "last_3_months", label: "Last 3 months" },
+];
+
+const DEVICE_OPTIONS: Array<{ value: Device; label: string }> = [
+  { value: "DESKTOP", label: "Desktop" },
+  { value: "MOBILE", label: "Mobile" },
+  { value: "TABLET", label: "Tablet" },
+];
+
+// Sentinel for "no filter" in the selects; never sent to the server.
+const ALL = "ALL";
+
+function isDateRange(value: string): value is DateRange {
+  return RANGE_OPTIONS.some((option) => option.value === value);
+}
+
+function isDevice(value: string): value is Device {
+  return DEVICE_OPTIONS.some((option) => option.value === value);
+}
+
+export function SearchPerformancePage({ projectId }: { projectId: string }) {
+  const [range, setRange] = useState<DateRange>("last_28_days");
+  const [device, setDevice] = useState<Device | typeof ALL>(ALL);
+  const [country, setCountry] = useState<string>(ALL);
+  const [tab, setTab] = useState<Tab>("striking");
+
+  const reportQuery = useQuery({
+    queryKey: ["searchPerformance", projectId, range, device, country],
+    queryFn: () =>
+      getSearchPerformanceReport({
+        data: {
+          projectId,
+          dateRange: range,
+          ...(device === ALL ? {} : { device }),
+          ...(country === ALL ? {} : { country }),
+        },
+      }),
+  });
+
+  const report = reportQuery.data;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold">Search Performance</h1>
+          <p className="text-sm text-base-content/60">
+            Your site&apos;s real Google Search data, free from Search Console.
+          </p>
+        </div>
+        {report?.connected ? (
+          <div className="flex flex-wrap items-center gap-2">
+            <select
+              className="select select-bordered select-sm"
+              value={device}
+              onChange={(event) => {
+                setDevice(
+                  isDevice(event.target.value) ? event.target.value : ALL,
+                );
+              }}
+              aria-label="Device filter"
+            >
+              <option value={ALL}>All devices</option>
+              {DEVICE_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+            <select
+              className="select select-bordered select-sm"
+              value={country}
+              onChange={(event) => setCountry(event.target.value)}
+              aria-label="Country filter"
+            >
+              <option value={ALL}>All countries</option>
+              {report.countries.map((row) => (
+                <option key={row.key} value={row.key}>
+                  {row.key.toUpperCase()}
+                </option>
+              ))}
+            </select>
+            <select
+              className="select select-bordered select-sm"
+              value={range}
+              onChange={(event) => {
+                if (isDateRange(event.target.value)) {
+                  setRange(event.target.value);
+                }
+              }}
+              aria-label="Date range"
+            >
+              {RANGE_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        ) : null}
+      </div>
+
+      {reportQuery.isPending ? (
+        <div className="flex items-center gap-2 p-8 text-sm text-base-content/60">
+          <Loader2 className="size-4 animate-spin" /> Loading Search Console
+          data…
+        </div>
+      ) : reportQuery.isError ? (
+        <div className="alert alert-error">
+          <span className="text-sm">
+            {getStandardErrorMessage(reportQuery.error)}
+          </span>
+        </div>
+      ) : !report?.connected ? (
+        <div className="max-w-2xl">
+          <SearchConsoleConnectionCard projectId={projectId} />
+        </div>
+      ) : (
+        <>
+          <TotalsCards report={report} />
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div role="tablist" className="tabs tabs-border">
+              <TabButton
+                active={tab === "striking"}
+                onClick={() => setTab("striking")}
+                label={`Striking distance (${report.strikingDistance.length})`}
+              />
+              <TabButton
+                active={tab === "queries"}
+                onClick={() => setTab("queries")}
+                label={`Queries (${report.queries.length})`}
+              />
+              <TabButton
+                active={tab === "pages"}
+                onClick={() => setTab("pages")}
+                label={`Pages (${report.pages.length})`}
+              />
+            </div>
+            <button
+              type="button"
+              className="btn btn-ghost btn-sm"
+              onClick={() => exportCurrentTab(report, tab)}
+            >
+              <Download className="size-4" /> Export CSV
+            </button>
+          </div>
+          {tab === "striking" ? (
+            <StrikingDistanceTable
+              projectId={projectId}
+              rows={report.strikingDistance}
+            />
+          ) : (
+            <DimensionTable
+              rows={tab === "queries" ? report.queries : report.pages}
+              keyLabel={tab === "queries" ? "Query" : "Page"}
+            />
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/client/features/search-performance/SearchPerformanceParts.tsx
+++ b/src/client/features/search-performance/SearchPerformanceParts.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { Link } from "@tanstack/react-router";
-import { Loader2, Save } from "lucide-react";
+import { Copy, Loader2, Save } from "lucide-react";
 import { toast } from "sonner";
 import {
   AppDataTable,
@@ -12,6 +11,7 @@ import {
   TableBulkActionBar,
   TableBulkActionButton,
 } from "@/client/components/table/TableBulkActionBar";
+import { TablePagination } from "@/client/components/table/TablePagination";
 import {
   buildDimensionColumns,
   buildStrikingColumns,
@@ -19,44 +19,54 @@ import {
   formatCtr,
   formatPosition,
   type Report,
+  type SearchPerformanceTableRow,
 } from "@/client/features/search-performance/SearchPerformanceColumns";
 import { buildCsv, downloadCsv, type CsvValue } from "@/client/lib/csv";
 import { getStandardErrorMessage } from "@/client/lib/error-messages";
 import { exportTableToSheets } from "@/client/lib/exportToSheets";
 import { captureClientEvent } from "@/client/lib/posthog";
+import {
+  SEARCH_PERFORMANCE_PAGE_SIZES,
+  type SearchPerformanceTableDimension,
+} from "@/types/schemas/search-performance";
 import { saveKeywords } from "@/serverFunctions/keywords";
 
 export type Tab = "striking" | "queries" | "pages";
+export type ExportTarget = "csv" | "sheets";
 
-function buildTabTable(
-  report: Report,
-  tab: Tab,
-): { filename: string; headers: string[]; rows: CsvValue[][] } {
+type ExportTable = { filename: string; headers: string[]; rows: CsvValue[][] };
+
+function strikingExportTable(report: Report): ExportTable {
   const stamp = `${report.range.startDate}-to-${report.range.endDate}`;
-  if (tab === "striking") {
-    return {
-      filename: `search-performance-striking-distance-${stamp}.csv`,
-      headers: ["Query", "Page", "Impressions", "Clicks", "Position"],
-      rows: report.strikingDistance.map((row) => [
-        row.query,
-        row.page,
-        row.impressions,
-        row.clicks,
-        row.position,
-      ]),
-    };
-  }
-  const source = tab === "queries" ? report.queries : report.pages;
   return {
-    filename: `search-performance-${tab}-${stamp}.csv`,
+    filename: `search-performance-striking-distance-${stamp}.csv`,
+    headers: ["Query", "Page", "Impressions", "Clicks", "Position"],
+    rows: report.strikingDistance.map((row) => [
+      row.query,
+      row.page,
+      row.impressions,
+      row.clicks,
+      row.position,
+    ]),
+  };
+}
+
+function dimensionExportTable(
+  dimension: SearchPerformanceTableDimension,
+  rows: SearchPerformanceTableRow[],
+  stamp: string,
+): ExportTable {
+  const isPage = dimension === "page";
+  return {
+    filename: `search-performance-${isPage ? "pages" : "queries"}-${stamp}.csv`,
     headers: [
-      tab === "queries" ? "Query" : "Page",
+      isPage ? "Page" : "Query",
       "Clicks",
       "Impressions",
       "CTR",
       "Position",
     ],
-    rows: source.map((row) => [
+    rows: rows.map((row) => [
       row.key,
       row.clicks,
       row.impressions,
@@ -66,18 +76,36 @@ function buildTabTable(
   };
 }
 
-export function exportCurrentTab(report: Report, tab: Tab): void {
-  const { filename, headers, rows } = buildTabTable(report, tab);
-  downloadCsv(filename, buildCsv(headers, rows));
-  captureClientEvent("data:export", {
-    source_feature: "search_performance",
-    result_count: rows.length,
+function runExport(table: ExportTable, target: ExportTarget): void {
+  if (target === "csv") {
+    downloadCsv(table.filename, buildCsv(table.headers, table.rows));
+    captureClientEvent("data:export", {
+      source_feature: "search_performance",
+      result_count: table.rows.length,
+    });
+    return;
+  }
+  void exportTableToSheets({
+    headers: table.headers,
+    rows: table.rows,
+    feature: "search_performance",
   });
 }
 
-export function exportCurrentTabToSheets(report: Report, tab: Tab): void {
-  const { headers, rows } = buildTabTable(report, tab);
-  void exportTableToSheets({ headers, rows, feature: "search_performance" });
+export function exportStriking(report: Report, target: ExportTarget): void {
+  runExport(strikingExportTable(report), target);
+}
+
+/** Export the full queries/pages dataset (fetched separately, not the visible
+ *  page) so pagination never truncates a download. */
+export function exportDimensionRows(
+  dimension: SearchPerformanceTableDimension,
+  rows: SearchPerformanceTableRow[],
+  range: Report["range"],
+  target: ExportTarget,
+): void {
+  const stamp = `${range.startDate}-to-${range.endDate}`;
+  runExport(dimensionExportTable(dimension, rows, stamp), target);
 }
 
 export function TabButton({
@@ -189,7 +217,7 @@ export function DimensionTable({
   rows,
   keyLabel,
 }: {
-  rows: Report["queries"];
+  rows: SearchPerformanceTableRow[];
   keyLabel: string;
 }) {
   const columns = useMemo(() => buildDimensionColumns(keyLabel), [keyLabel]);
@@ -203,7 +231,7 @@ export function DimensionTable({
     <AppDataTable
       table={table}
       className="table table-zebra table-sm"
-      wrapperClassName="overflow-x-auto rounded-lg border border-base-300"
+      wrapperClassName="overflow-x-auto"
       empty={
         <p className="p-6 text-sm text-base-content/60">
           No data for this period yet. Search Console data trails by a few days.
@@ -228,17 +256,35 @@ export function StrikingDistanceTable({
     data: rows,
     columns,
     withSorting: true,
+    withPagination: true,
     enableRowSelection: true,
     state: { rowSelection },
     onRowSelectionChange: setRowSelection,
     getRowId: (row) => `${row.query}::${row.page}`,
-    initialState: { sorting: [{ id: "impressions", desc: true }] },
+    initialState: {
+      sorting: [{ id: "impressions", desc: true }],
+      // All rows are already loaded; paginate client-side to keep the table
+      // short. 50/page by default.
+      pagination: { pageIndex: 0, pageSize: 50 },
+    },
   });
+  const pagination = table.getState().pagination;
 
-  // Rows are query x page; saving dedupes to the query strings.
+  // Rows are query x page; saving/copying dedupes to the query strings.
   const selectedQueries = Array.from(
     new Set(table.getSelectedRowModel().rows.map((row) => row.original.query)),
   );
+
+  const copyKeywords = async () => {
+    try {
+      await navigator.clipboard.writeText(selectedQueries.join("\n"));
+      toast.success(
+        `Copied ${selectedQueries.length} ${selectedQueries.length === 1 ? "keyword" : "keywords"}`,
+      );
+    } catch {
+      toast.error("Couldn't copy to clipboard");
+    }
+  };
 
   const save = useMutation({
     mutationFn: (keywords: string[]) =>
@@ -272,31 +318,40 @@ export function StrikingDistanceTable({
   }
 
   return (
-    <div className="space-y-2">
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <p className="text-sm text-base-content/60">
+    <>
+      <div className="p-4">
+        <p className="mb-3 text-sm text-base-content/60">
           Queries ranking at positions 5 to 20, sorted by impressions. Improve
           the listed page to move them into the top results.
         </p>
-        <Link
-          to="/p/$projectId/saved"
-          params={{ projectId }}
-          className="btn btn-ghost btn-sm"
-        >
-          View saved
-        </Link>
+        <AppDataTable
+          table={table}
+          className="table table-zebra table-sm"
+          wrapperClassName="overflow-x-auto"
+        />
       </div>
-      <AppDataTable
-        table={table}
-        className="table table-zebra table-sm"
-        wrapperClassName="overflow-x-auto rounded-lg border border-base-300"
+      <TablePagination
+        page={pagination.pageIndex + 1}
+        pageSize={pagination.pageSize}
+        pageSizes={SEARCH_PERFORMANCE_PAGE_SIZES}
+        totalCount={rows.length}
+        hasNextPage={table.getCanNextPage()}
+        isLoading={false}
+        onPageChange={(nextPage) => table.setPageIndex(nextPage - 1)}
+        onPageSizeChange={(nextSize) => table.setPageSize(nextSize)}
       />
       <TableBulkActionBar
         selectedCount={selectedQueries.length}
         selectedLabel={selectedQueries.length === 1 ? "query" : "queries"}
         onClear={() => setRowSelection({})}
         actions={
-          <div className="flex items-center px-1.5">
+          <div className="flex items-center gap-1 px-1.5">
+            <TableBulkActionButton
+              icon={<Copy className="size-3.5" />}
+              onClick={() => void copyKeywords()}
+            >
+              Copy keywords
+            </TableBulkActionButton>
             <TableBulkActionButton
               icon={
                 save.isPending ? (
@@ -313,6 +368,6 @@ export function StrikingDistanceTable({
           </div>
         }
       />
-    </div>
+    </>
   );
 }

--- a/src/client/features/search-performance/SearchPerformanceParts.tsx
+++ b/src/client/features/search-performance/SearchPerformanceParts.tsx
@@ -1,13 +1,17 @@
 import { useMemo, useState } from "react";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
-import { Loader2 } from "lucide-react";
+import { Loader2, Save } from "lucide-react";
 import { toast } from "sonner";
 import {
   AppDataTable,
   useAppTable,
   useSelectionAnchor,
 } from "@/client/components/table/AppDataTable";
+import {
+  TableBulkActionBar,
+  TableBulkActionButton,
+} from "@/client/components/table/TableBulkActionBar";
 import {
   buildDimensionColumns,
   buildStrikingColumns,
@@ -16,50 +20,64 @@ import {
   formatPosition,
   type Report,
 } from "@/client/features/search-performance/SearchPerformanceColumns";
-import { buildCsv, downloadCsv } from "@/client/lib/csv";
+import { buildCsv, downloadCsv, type CsvValue } from "@/client/lib/csv";
 import { getStandardErrorMessage } from "@/client/lib/error-messages";
+import { exportTableToSheets } from "@/client/lib/exportToSheets";
+import { captureClientEvent } from "@/client/lib/posthog";
 import { saveKeywords } from "@/serverFunctions/keywords";
 
 export type Tab = "striking" | "queries" | "pages";
 
-export function exportCurrentTab(report: Report, tab: Tab): void {
+function buildTabTable(
+  report: Report,
+  tab: Tab,
+): { filename: string; headers: string[]; rows: CsvValue[][] } {
   const stamp = `${report.range.startDate}-to-${report.range.endDate}`;
   if (tab === "striking") {
-    downloadCsv(
-      `search-performance-striking-distance-${stamp}.csv`,
-      buildCsv(
-        ["Query", "Page", "Impressions", "Clicks", "Position"],
-        report.strikingDistance.map((row) => [
-          row.query,
-          row.page,
-          row.impressions,
-          row.clicks,
-          row.position,
-        ]),
-      ),
-    );
-    return;
-  }
-  const rows = tab === "queries" ? report.queries : report.pages;
-  downloadCsv(
-    `search-performance-${tab}-${stamp}.csv`,
-    buildCsv(
-      [
-        tab === "queries" ? "Query" : "Page",
-        "Clicks",
-        "Impressions",
-        "CTR",
-        "Position",
-      ],
-      rows.map((row) => [
-        row.key,
-        row.clicks,
+    return {
+      filename: `search-performance-striking-distance-${stamp}.csv`,
+      headers: ["Query", "Page", "Impressions", "Clicks", "Position"],
+      rows: report.strikingDistance.map((row) => [
+        row.query,
+        row.page,
         row.impressions,
-        row.ctr,
+        row.clicks,
         row.position,
       ]),
-    ),
-  );
+    };
+  }
+  const source = tab === "queries" ? report.queries : report.pages;
+  return {
+    filename: `search-performance-${tab}-${stamp}.csv`,
+    headers: [
+      tab === "queries" ? "Query" : "Page",
+      "Clicks",
+      "Impressions",
+      "CTR",
+      "Position",
+    ],
+    rows: source.map((row) => [
+      row.key,
+      row.clicks,
+      row.impressions,
+      row.ctr,
+      row.position,
+    ]),
+  };
+}
+
+export function exportCurrentTab(report: Report, tab: Tab): void {
+  const { filename, headers, rows } = buildTabTable(report, tab);
+  downloadCsv(filename, buildCsv(headers, rows));
+  captureClientEvent("data:export", {
+    source_feature: "search_performance",
+    result_count: rows.length,
+  });
+}
+
+export function exportCurrentTabToSheets(report: Report, tab: Tab): void {
+  const { headers, rows } = buildTabTable(report, tab);
+  void exportTableToSheets({ headers, rows, feature: "search_performance" });
 }
 
 export function TabButton({
@@ -75,6 +93,7 @@ export function TabButton({
     <button
       type="button"
       role="tab"
+      aria-selected={active}
       className={`tab ${active ? "tab-active" : ""}`}
       onClick={onClick}
     >
@@ -88,7 +107,6 @@ type Delta = { text: string; improved: boolean } | null;
 function percentDelta(current: number, previous: number): Delta {
   if (previous <= 0) return null;
   const change = (current - previous) / previous;
-  if (!Number.isFinite(change)) return null;
   const pct = (change * 100).toFixed(1);
   return { text: `${change >= 0 ? "+" : ""}${pct}%`, improved: change >= 0 };
 }
@@ -104,28 +122,33 @@ function positionDelta(current: number, previous: number): Delta {
 }
 
 export function TotalsCards({ report }: { report: Report }) {
-  const { totals, prevTotals } = report;
+  const { totals, prevTotals, range } = report;
+  const deltaTitle = `vs ${range.prevStartDate} to ${range.prevEndDate}`;
   return (
     <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
       <TotalCard
         label="Clicks"
         value={formatCount(totals.clicks)}
         delta={percentDelta(totals.clicks, prevTotals.clicks)}
+        deltaTitle={deltaTitle}
       />
       <TotalCard
         label="Impressions"
         value={formatCount(totals.impressions)}
         delta={percentDelta(totals.impressions, prevTotals.impressions)}
+        deltaTitle={deltaTitle}
       />
       <TotalCard
         label="CTR"
         value={formatCtr(totals.ctr)}
         delta={percentDelta(totals.ctr, prevTotals.ctr)}
+        deltaTitle={deltaTitle}
       />
       <TotalCard
         label="Avg position"
         value={formatPosition(totals.position)}
         delta={positionDelta(totals.position, prevTotals.position)}
+        deltaTitle={deltaTitle}
       />
     </div>
   );
@@ -135,10 +158,12 @@ function TotalCard({
   label,
   value,
   delta,
+  deltaTitle,
 }: {
   label: string;
   value: string;
   delta: Delta;
+  deltaTitle: string;
 }) {
   return (
     <div className="rounded-lg border border-base-300 bg-base-100 p-4">
@@ -150,7 +175,7 @@ function TotalCard({
         {delta ? (
           <span
             className={`text-xs ${delta.improved ? "text-success" : "text-error"}`}
-            title="vs previous period"
+            title={deltaTitle}
           >
             {delta.text}
           </span>
@@ -195,6 +220,7 @@ export function StrikingDistanceTable({
   projectId: string;
   rows: Report["strikingDistance"];
 }) {
+  const queryClient = useQueryClient();
   const anchorRef = useSelectionAnchor();
   const [rowSelection, setRowSelection] = useState({});
   const columns = useMemo(() => buildStrikingColumns(anchorRef), [anchorRef]);
@@ -218,6 +244,13 @@ export function StrikingDistanceTable({
     mutationFn: (keywords: string[]) =>
       saveKeywords({ data: { projectId, keywords } }),
     onSuccess: (_result, keywords) => {
+      captureClientEvent("keyword:save", {
+        source_feature: "search_performance",
+        keyword_count: keywords.length,
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ["savedKeywords", projectId],
+      });
       toast.success(
         `Saved ${keywords.length} ${keywords.length === 1 ? "keyword" : "keywords"}`,
       );
@@ -245,32 +278,40 @@ export function StrikingDistanceTable({
           Queries ranking at positions 5 to 20, sorted by impressions. Improve
           the listed page to move them into the top results.
         </p>
-        <div className="flex items-center gap-2">
-          <button
-            type="button"
-            className="btn btn-primary btn-sm"
-            disabled={selectedQueries.length === 0 || save.isPending}
-            onClick={() => save.mutate(selectedQueries)}
-          >
-            {save.isPending ? (
-              <Loader2 className="size-4 animate-spin" />
-            ) : null}
-            Save {selectedQueries.length > 0 ? selectedQueries.length : ""} as
-            keywords
-          </button>
-          <Link
-            to="/p/$projectId/saved"
-            params={{ projectId }}
-            className="btn btn-ghost btn-sm"
-          >
-            View saved
-          </Link>
-        </div>
+        <Link
+          to="/p/$projectId/saved"
+          params={{ projectId }}
+          className="btn btn-ghost btn-sm"
+        >
+          View saved
+        </Link>
       </div>
       <AppDataTable
         table={table}
         className="table table-zebra table-sm"
         wrapperClassName="overflow-x-auto rounded-lg border border-base-300"
+      />
+      <TableBulkActionBar
+        selectedCount={selectedQueries.length}
+        selectedLabel={selectedQueries.length === 1 ? "query" : "queries"}
+        onClear={() => setRowSelection({})}
+        actions={
+          <div className="flex items-center px-1.5">
+            <TableBulkActionButton
+              icon={
+                save.isPending ? (
+                  <Loader2 className="size-3.5 animate-spin" />
+                ) : (
+                  <Save className="size-3.5" />
+                )
+              }
+              onClick={() => save.mutate(selectedQueries)}
+              disabled={save.isPending}
+            >
+              Save as keywords
+            </TableBulkActionButton>
+          </div>
+        }
       />
     </div>
   );

--- a/src/client/features/search-performance/SearchPerformanceParts.tsx
+++ b/src/client/features/search-performance/SearchPerformanceParts.tsx
@@ -1,0 +1,277 @@
+import { useMemo, useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import {
+  AppDataTable,
+  useAppTable,
+  useSelectionAnchor,
+} from "@/client/components/table/AppDataTable";
+import {
+  buildDimensionColumns,
+  buildStrikingColumns,
+  formatCount,
+  formatCtr,
+  formatPosition,
+  type Report,
+} from "@/client/features/search-performance/SearchPerformanceColumns";
+import { buildCsv, downloadCsv } from "@/client/lib/csv";
+import { getStandardErrorMessage } from "@/client/lib/error-messages";
+import { saveKeywords } from "@/serverFunctions/keywords";
+
+export type Tab = "striking" | "queries" | "pages";
+
+export function exportCurrentTab(report: Report, tab: Tab): void {
+  const stamp = `${report.range.startDate}-to-${report.range.endDate}`;
+  if (tab === "striking") {
+    downloadCsv(
+      `search-performance-striking-distance-${stamp}.csv`,
+      buildCsv(
+        ["Query", "Page", "Impressions", "Clicks", "Position"],
+        report.strikingDistance.map((row) => [
+          row.query,
+          row.page,
+          row.impressions,
+          row.clicks,
+          row.position,
+        ]),
+      ),
+    );
+    return;
+  }
+  const rows = tab === "queries" ? report.queries : report.pages;
+  downloadCsv(
+    `search-performance-${tab}-${stamp}.csv`,
+    buildCsv(
+      [
+        tab === "queries" ? "Query" : "Page",
+        "Clicks",
+        "Impressions",
+        "CTR",
+        "Position",
+      ],
+      rows.map((row) => [
+        row.key,
+        row.clicks,
+        row.impressions,
+        row.ctr,
+        row.position,
+      ]),
+    ),
+  );
+}
+
+export function TabButton({
+  active,
+  onClick,
+  label,
+}: {
+  active: boolean;
+  onClick: () => void;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      className={`tab ${active ? "tab-active" : ""}`}
+      onClick={onClick}
+    >
+      {label}
+    </button>
+  );
+}
+
+type Delta = { text: string; improved: boolean } | null;
+
+function percentDelta(current: number, previous: number): Delta {
+  if (previous <= 0) return null;
+  const change = (current - previous) / previous;
+  if (!Number.isFinite(change)) return null;
+  const pct = (change * 100).toFixed(1);
+  return { text: `${change >= 0 ? "+" : ""}${pct}%`, improved: change >= 0 };
+}
+
+/** Position falls as rankings improve, so the delta is inverted. */
+function positionDelta(current: number, previous: number): Delta {
+  if (previous <= 0 || current <= 0) return null;
+  const change = previous - current;
+  return {
+    text: `${change >= 0 ? "+" : ""}${change.toFixed(1)}`,
+    improved: change >= 0,
+  };
+}
+
+export function TotalsCards({ report }: { report: Report }) {
+  const { totals, prevTotals } = report;
+  return (
+    <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+      <TotalCard
+        label="Clicks"
+        value={formatCount(totals.clicks)}
+        delta={percentDelta(totals.clicks, prevTotals.clicks)}
+      />
+      <TotalCard
+        label="Impressions"
+        value={formatCount(totals.impressions)}
+        delta={percentDelta(totals.impressions, prevTotals.impressions)}
+      />
+      <TotalCard
+        label="CTR"
+        value={formatCtr(totals.ctr)}
+        delta={percentDelta(totals.ctr, prevTotals.ctr)}
+      />
+      <TotalCard
+        label="Avg position"
+        value={formatPosition(totals.position)}
+        delta={positionDelta(totals.position, prevTotals.position)}
+      />
+    </div>
+  );
+}
+
+function TotalCard({
+  label,
+  value,
+  delta,
+}: {
+  label: string;
+  value: string;
+  delta: Delta;
+}) {
+  return (
+    <div className="rounded-lg border border-base-300 bg-base-100 p-4">
+      <div className="text-xs uppercase tracking-wide text-base-content/60">
+        {label}
+      </div>
+      <div className="mt-1 flex items-baseline gap-2">
+        <span className="text-2xl font-semibold">{value}</span>
+        {delta ? (
+          <span
+            className={`text-xs ${delta.improved ? "text-success" : "text-error"}`}
+            title="vs previous period"
+          >
+            {delta.text}
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export function DimensionTable({
+  rows,
+  keyLabel,
+}: {
+  rows: Report["queries"];
+  keyLabel: string;
+}) {
+  const columns = useMemo(() => buildDimensionColumns(keyLabel), [keyLabel]);
+  const table = useAppTable({
+    data: rows,
+    columns,
+    withSorting: true,
+    initialState: { sorting: [{ id: "clicks", desc: true }] },
+  });
+  return (
+    <AppDataTable
+      table={table}
+      className="table table-zebra table-sm"
+      wrapperClassName="overflow-x-auto rounded-lg border border-base-300"
+      empty={
+        <p className="p-6 text-sm text-base-content/60">
+          No data for this period yet. Search Console data trails by a few days.
+        </p>
+      }
+    />
+  );
+}
+
+export function StrikingDistanceTable({
+  projectId,
+  rows,
+}: {
+  projectId: string;
+  rows: Report["strikingDistance"];
+}) {
+  const anchorRef = useSelectionAnchor();
+  const [rowSelection, setRowSelection] = useState({});
+  const columns = useMemo(() => buildStrikingColumns(anchorRef), [anchorRef]);
+  const table = useAppTable({
+    data: rows,
+    columns,
+    withSorting: true,
+    enableRowSelection: true,
+    state: { rowSelection },
+    onRowSelectionChange: setRowSelection,
+    getRowId: (row) => `${row.query}::${row.page}`,
+    initialState: { sorting: [{ id: "impressions", desc: true }] },
+  });
+
+  // Rows are query x page; saving dedupes to the query strings.
+  const selectedQueries = Array.from(
+    new Set(table.getSelectedRowModel().rows.map((row) => row.original.query)),
+  );
+
+  const save = useMutation({
+    mutationFn: (keywords: string[]) =>
+      saveKeywords({ data: { projectId, keywords } }),
+    onSuccess: (_result, keywords) => {
+      toast.success(
+        `Saved ${keywords.length} ${keywords.length === 1 ? "keyword" : "keywords"}`,
+      );
+      setRowSelection({});
+    },
+    onError: (error) => {
+      toast.error(getStandardErrorMessage(error, "Could not save keywords"));
+    },
+  });
+
+  if (rows.length === 0) {
+    return (
+      <p className="p-6 text-sm text-base-content/60">
+        No striking-distance queries in this period. These are queries ranking
+        at positions 5 to 20, where an improvement is most likely to move
+        traffic.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="text-sm text-base-content/60">
+          Queries ranking at positions 5 to 20, sorted by impressions. Improve
+          the listed page to move them into the top results.
+        </p>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            className="btn btn-primary btn-sm"
+            disabled={selectedQueries.length === 0 || save.isPending}
+            onClick={() => save.mutate(selectedQueries)}
+          >
+            {save.isPending ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : null}
+            Save {selectedQueries.length > 0 ? selectedQueries.length : ""} as
+            keywords
+          </button>
+          <Link
+            to="/p/$projectId/saved"
+            params={{ projectId }}
+            className="btn btn-ghost btn-sm"
+          >
+            View saved
+          </Link>
+        </div>
+      </div>
+      <AppDataTable
+        table={table}
+        className="table table-zebra table-sm"
+        wrapperClassName="overflow-x-auto rounded-lg border border-base-300"
+      />
+    </div>
+  );
+}

--- a/src/client/navigation/items.ts
+++ b/src/client/navigation/items.ts
@@ -1,4 +1,5 @@
 import {
+  BarChart3,
   Bookmark,
   Bot,
   ClipboardCheck,
@@ -29,6 +30,12 @@ const projectNavItems = [
     label: "Rank Tracking",
     icon: TrendingUp,
     matchSegment: "/rank-tracking",
+  },
+  {
+    to: "/p/$projectId/search-performance" as const,
+    label: "Search Performance",
+    icon: BarChart3,
+    matchSegment: "/search-performance",
   },
   {
     to: "/p/$projectId/domain" as const,
@@ -94,6 +101,10 @@ export function getProjectNavGroups(projectId: string) {
         bySegment("/saved"),
         bySegment("/rank-tracking"),
       ],
+    },
+    {
+      type: "standalone" as const,
+      item: bySegment("/search-performance"),
     },
     {
       type: "group" as const,

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -36,6 +36,7 @@ import { Route as ProjectPProjectIdRouteRouteImport } from './routes/_project/p/
 import { Route as ProjectPProjectIdIndexRouteImport } from './routes/_project/p/$projectId/index'
 import { Route as ApiGscOauthCallbackRouteImport } from './routes/api/gsc/oauth/callback'
 import { Route as ProjectPProjectIdSettingsRouteImport } from './routes/_project/p/$projectId/settings'
+import { Route as ProjectPProjectIdSearchPerformanceRouteImport } from './routes/_project/p/$projectId/search-performance'
 import { Route as ProjectPProjectIdSavedRouteImport } from './routes/_project/p/$projectId/saved'
 import { Route as ProjectPProjectIdRankTrackingRouteImport } from './routes/_project/p/$projectId/rank-tracking'
 import { Route as ProjectPProjectIdPromptExplorerRouteImport } from './routes/_project/p/$projectId/prompt-explorer'
@@ -185,6 +186,12 @@ const ProjectPProjectIdSettingsRoute =
     path: '/settings',
     getParentRoute: () => ProjectPProjectIdRouteRoute,
   } as any)
+const ProjectPProjectIdSearchPerformanceRoute =
+  ProjectPProjectIdSearchPerformanceRouteImport.update({
+    id: '/search-performance',
+    path: '/search-performance',
+    getParentRoute: () => ProjectPProjectIdRouteRoute,
+  } as any)
 const ProjectPProjectIdSavedRoute = ProjectPProjectIdSavedRouteImport.update({
   id: '/saved',
   path: '/saved',
@@ -284,6 +291,7 @@ export interface FileRoutesByFullPath {
   '/p/$projectId/prompt-explorer': typeof ProjectPProjectIdPromptExplorerRoute
   '/p/$projectId/rank-tracking': typeof ProjectPProjectIdRankTrackingRouteWithChildren
   '/p/$projectId/saved': typeof ProjectPProjectIdSavedRoute
+  '/p/$projectId/search-performance': typeof ProjectPProjectIdSearchPerformanceRoute
   '/p/$projectId/settings': typeof ProjectPProjectIdSettingsRoute
   '/api/gsc/oauth/callback': typeof ApiGscOauthCallbackRoute
   '/p/$projectId/': typeof ProjectPProjectIdIndexRoute
@@ -318,6 +326,7 @@ export interface FileRoutesByTo {
   '/p/$projectId/keywords': typeof ProjectPProjectIdKeywordsRoute
   '/p/$projectId/prompt-explorer': typeof ProjectPProjectIdPromptExplorerRoute
   '/p/$projectId/saved': typeof ProjectPProjectIdSavedRoute
+  '/p/$projectId/search-performance': typeof ProjectPProjectIdSearchPerformanceRoute
   '/p/$projectId/settings': typeof ProjectPProjectIdSettingsRoute
   '/api/gsc/oauth/callback': typeof ApiGscOauthCallbackRoute
   '/p/$projectId': typeof ProjectPProjectIdIndexRoute
@@ -360,6 +369,7 @@ export interface FileRoutesById {
   '/_project/p/$projectId/prompt-explorer': typeof ProjectPProjectIdPromptExplorerRoute
   '/_project/p/$projectId/rank-tracking': typeof ProjectPProjectIdRankTrackingRouteWithChildren
   '/_project/p/$projectId/saved': typeof ProjectPProjectIdSavedRoute
+  '/_project/p/$projectId/search-performance': typeof ProjectPProjectIdSearchPerformanceRoute
   '/_project/p/$projectId/settings': typeof ProjectPProjectIdSettingsRoute
   '/api/gsc/oauth/callback': typeof ApiGscOauthCallbackRoute
   '/_project/p/$projectId/': typeof ProjectPProjectIdIndexRoute
@@ -399,6 +409,7 @@ export interface FileRouteTypes {
     | '/p/$projectId/prompt-explorer'
     | '/p/$projectId/rank-tracking'
     | '/p/$projectId/saved'
+    | '/p/$projectId/search-performance'
     | '/p/$projectId/settings'
     | '/api/gsc/oauth/callback'
     | '/p/$projectId/'
@@ -433,6 +444,7 @@ export interface FileRouteTypes {
     | '/p/$projectId/keywords'
     | '/p/$projectId/prompt-explorer'
     | '/p/$projectId/saved'
+    | '/p/$projectId/search-performance'
     | '/p/$projectId/settings'
     | '/api/gsc/oauth/callback'
     | '/p/$projectId'
@@ -474,6 +486,7 @@ export interface FileRouteTypes {
     | '/_project/p/$projectId/prompt-explorer'
     | '/_project/p/$projectId/rank-tracking'
     | '/_project/p/$projectId/saved'
+    | '/_project/p/$projectId/search-performance'
     | '/_project/p/$projectId/settings'
     | '/api/gsc/oauth/callback'
     | '/_project/p/$projectId/'
@@ -688,6 +701,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProjectPProjectIdSettingsRouteImport
       parentRoute: typeof ProjectPProjectIdRouteRoute
     }
+    '/_project/p/$projectId/search-performance': {
+      id: '/_project/p/$projectId/search-performance'
+      path: '/search-performance'
+      fullPath: '/p/$projectId/search-performance'
+      preLoaderRoute: typeof ProjectPProjectIdSearchPerformanceRouteImport
+      parentRoute: typeof ProjectPProjectIdRouteRoute
+    }
     '/_project/p/$projectId/saved': {
       id: '/_project/p/$projectId/saved'
       path: '/saved'
@@ -843,6 +863,7 @@ interface ProjectPProjectIdRouteRouteChildren {
   ProjectPProjectIdPromptExplorerRoute: typeof ProjectPProjectIdPromptExplorerRoute
   ProjectPProjectIdRankTrackingRoute: typeof ProjectPProjectIdRankTrackingRouteWithChildren
   ProjectPProjectIdSavedRoute: typeof ProjectPProjectIdSavedRoute
+  ProjectPProjectIdSearchPerformanceRoute: typeof ProjectPProjectIdSearchPerformanceRoute
   ProjectPProjectIdSettingsRoute: typeof ProjectPProjectIdSettingsRoute
   ProjectPProjectIdIndexRoute: typeof ProjectPProjectIdIndexRoute
 }
@@ -858,6 +879,8 @@ const ProjectPProjectIdRouteRouteChildren: ProjectPProjectIdRouteRouteChildren =
     ProjectPProjectIdRankTrackingRoute:
       ProjectPProjectIdRankTrackingRouteWithChildren,
     ProjectPProjectIdSavedRoute: ProjectPProjectIdSavedRoute,
+    ProjectPProjectIdSearchPerformanceRoute:
+      ProjectPProjectIdSearchPerformanceRoute,
     ProjectPProjectIdSettingsRoute: ProjectPProjectIdSettingsRoute,
     ProjectPProjectIdIndexRoute: ProjectPProjectIdIndexRoute,
   }

--- a/src/routes/_project/p/$projectId/search-performance.tsx
+++ b/src/routes/_project/p/$projectId/search-performance.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { SearchPerformancePage } from "@/client/features/search-performance/SearchPerformancePage";
+
+export const Route = createFileRoute(
+  "/_project/p/$projectId/search-performance",
+)({
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  const { projectId } = Route.useParams();
+  return <SearchPerformancePage projectId={projectId} />;
+}

--- a/src/routes/_project/p/$projectId/search-performance.tsx
+++ b/src/routes/_project/p/$projectId/search-performance.tsx
@@ -4,10 +4,10 @@ import { SearchPerformancePage } from "@/client/features/search-performance/Sear
 export const Route = createFileRoute(
   "/_project/p/$projectId/search-performance",
 )({
-  component: RouteComponent,
+  component: SearchPerformanceRoute,
 });
 
-function RouteComponent() {
+function SearchPerformanceRoute() {
   const { projectId } = Route.useParams();
   return <SearchPerformancePage projectId={projectId} />;
 }

--- a/src/server/features/gsc/searchPerformanceReport.test.ts
+++ b/src/server/features/gsc/searchPerformanceReport.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildStrikingDistanceRows,
+  previousPeriod,
+  sumSearchTotals,
+  toDimensionRows,
+} from "@/server/features/gsc/searchPerformanceReport";
+
+describe("sumSearchTotals", () => {
+  it("sums clicks/impressions and impression-weights position", () => {
+    const totals = sumSearchTotals([
+      { clicks: 10, impressions: 100, ctr: 0.1, position: 2 },
+      { clicks: 5, impressions: 300, ctr: 0.016, position: 10 },
+    ]);
+    expect(totals.clicks).toBe(15);
+    expect(totals.impressions).toBe(400);
+    expect(totals.ctr).toBeCloseTo(15 / 400);
+    // (2*100 + 10*300) / 400 = 8
+    expect(totals.position).toBeCloseTo(8);
+  });
+
+  it("returns zeros for no rows instead of NaN", () => {
+    expect(sumSearchTotals([])).toEqual({
+      clicks: 0,
+      impressions: 0,
+      ctr: 0,
+      position: 0,
+    });
+  });
+});
+
+describe("toDimensionRows", () => {
+  it("keeps the first key and drops keyless rows", () => {
+    const rows = toDimensionRows([
+      {
+        keys: ["magento agency"],
+        clicks: 3,
+        impressions: 40,
+        ctr: 0.075,
+        position: 6.2,
+      },
+      { clicks: 1, impressions: 5, ctr: 0.2, position: 1 },
+    ]);
+    expect(rows).toEqual([
+      {
+        key: "magento agency",
+        clicks: 3,
+        impressions: 40,
+        ctr: 0.075,
+        position: 6.2,
+      },
+    ]);
+  });
+});
+
+const row = (query: string, position: number, impressions: number) => ({
+  keys: [query, `https://example.com/${query}`],
+  clicks: 1,
+  impressions,
+  ctr: 0.01,
+  position,
+});
+
+describe("buildStrikingDistanceRows", () => {
+  it("keeps only positions 5..20 and sorts by impressions desc", () => {
+    const rows = buildStrikingDistanceRows([
+      row("top-spot", 2, 900),
+      row("close", 6.4, 100),
+      row("closer", 11, 400),
+      row("page-3", 24, 800),
+    ]);
+    expect(rows.map((r) => r.query)).toEqual(["closer", "close"]);
+  });
+
+  it("includes the boundary positions and respects the limit", () => {
+    const rows = buildStrikingDistanceRows(
+      [row("low-edge", 5, 10), row("high-edge", 20, 20)],
+      1,
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].query).toBe("high-edge");
+  });
+
+  it("drops rows without both query and page keys", () => {
+    const rows = buildStrikingDistanceRows([
+      {
+        keys: ["only-query"],
+        clicks: 1,
+        impressions: 50,
+        ctr: 0.02,
+        position: 8,
+      },
+    ]);
+    expect(rows).toHaveLength(0);
+  });
+});
+
+describe("previousPeriod", () => {
+  it("returns the same-length window ending the day before the start", () => {
+    expect(previousPeriod("2026-06-01", "2026-06-28")).toEqual({
+      startDate: "2026-05-04",
+      endDate: "2026-05-31",
+    });
+  });
+
+  it("handles a single-day range", () => {
+    expect(previousPeriod("2026-06-10", "2026-06-10")).toEqual({
+      startDate: "2026-06-09",
+      endDate: "2026-06-09",
+    });
+  });
+});

--- a/src/server/features/gsc/searchPerformanceReport.test.ts
+++ b/src/server/features/gsc/searchPerformanceReport.test.ts
@@ -61,6 +61,14 @@ const row = (query: string, position: number, impressions: number) => ({
   position,
 });
 
+// Same query can map to multiple pages; this lets a test set distinct pages.
+const pageRow = (
+  query: string,
+  page: string,
+  position: number,
+  impressions: number,
+) => ({ keys: [query, page], clicks: 1, impressions, ctr: 0.01, position });
+
 describe("buildStrikingDistanceRows", () => {
   it("keeps only positions 5..20 and sorts by impressions desc", () => {
     const rows = buildStrikingDistanceRows([
@@ -92,6 +100,26 @@ describe("buildStrikingDistanceRows", () => {
       },
     ]);
     expect(rows).toHaveLength(0);
+  });
+
+  it("drops a query whose top page already ranks above the band", () => {
+    // openseo: homepage ranks #2, a secondary page ranks #6. The site already
+    // ranks near the top, so the query is not a striking-distance opportunity.
+    const rows = buildStrikingDistanceRows([
+      pageRow("openseo", "https://x.com/home", 2, 900),
+      pageRow("openseo", "https://x.com/mcp", 6, 300),
+    ]);
+    expect(rows).toHaveLength(0);
+  });
+
+  it("collapses a query to its best-ranking page when that page is in band", () => {
+    const rows = buildStrikingDistanceRows([
+      pageRow("kw", "https://x.com/a", 14, 100),
+      pageRow("kw", "https://x.com/b", 8, 500),
+    ]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].page).toBe("https://x.com/b");
+    expect(rows[0].position).toBe(8);
   });
 });
 

--- a/src/server/features/gsc/searchPerformanceReport.ts
+++ b/src/server/features/gsc/searchPerformanceReport.ts
@@ -75,24 +75,34 @@ export function toDimensionRows(
   return output;
 }
 
-/** Filter `["query","page"]` rows to positions 5..20, highest impressions
- *  first. These are the improvement candidates the page exists to surface. */
+/** Reduce `["query","page"]` rows to one striking-distance row per query.
+ *
+ *  GSC returns a row per page that ranks for a query, so a query fans out across
+ *  every page it appears on. A query only belongs in "striking distance" when
+ *  the site's BEST-ranking page for it sits in the 5..20 band — if any page
+ *  already ranks above position 5, the site effectively ranks near the top and
+ *  improving a secondary page won't move traffic. So we collapse each query to
+ *  its top page (lowest average position; ties broken by impressions) and keep
+ *  it only when that top page is in band. Result is sorted by impressions. */
 export function buildStrikingDistanceRows(
   rows: GscSearchAnalyticsRow[],
   limit: number = STRIKING_DISTANCE_ROW_LIMIT,
 ): StrikingDistanceRow[] {
-  const candidates: StrikingDistanceRow[] = [];
+  const topPageByQuery = new Map<string, StrikingDistanceRow>();
   for (const row of rows) {
     const query = row.keys?.[0];
     const page = row.keys?.[1];
     if (!query || !page) continue;
-    if (
-      row.position < STRIKING_DISTANCE_MIN_POSITION ||
-      row.position > STRIKING_DISTANCE_MAX_POSITION
-    ) {
-      continue;
-    }
-    candidates.push({
+
+    const current = topPageByQuery.get(query);
+    const isBetter =
+      !current ||
+      row.position < current.position ||
+      (row.position === current.position &&
+        row.impressions > current.impressions);
+    if (!isBetter) continue;
+
+    topPageByQuery.set(query, {
       query,
       page,
       clicks: row.clicks,
@@ -100,7 +110,13 @@ export function buildStrikingDistanceRows(
       position: row.position,
     });
   }
-  return candidates
+
+  return Array.from(topPageByQuery.values())
+    .filter(
+      (row) =>
+        row.position >= STRIKING_DISTANCE_MIN_POSITION &&
+        row.position <= STRIKING_DISTANCE_MAX_POSITION,
+    )
     .toSorted((a, b) => b.impressions - a.impressions)
     .slice(0, limit);
 }

--- a/src/server/features/gsc/searchPerformanceReport.ts
+++ b/src/server/features/gsc/searchPerformanceReport.ts
@@ -1,0 +1,128 @@
+import type { GscSearchAnalyticsRow } from "@/server/lib/gscClient";
+
+/**
+ * Pure shaping helpers for the Search Performance page. Kept separate from the
+ * server function so the aggregation and striking-distance rules are unit
+ * testable without a GSC client.
+ */
+
+type SearchPerformanceTotals = {
+  clicks: number;
+  impressions: number;
+  /** 0..1 (clicks / impressions). */
+  ctr: number;
+  /** Impression-weighted average position; 0 when there were no impressions. */
+  position: number;
+};
+
+type SearchPerformanceDimensionRow = {
+  key: string;
+  clicks: number;
+  impressions: number;
+  ctr: number;
+  position: number;
+};
+
+type StrikingDistanceRow = {
+  query: string;
+  page: string;
+  clicks: number;
+  impressions: number;
+  position: number;
+};
+
+// "Striking distance" = already ranking, not yet in the top spots: the queries
+// where a content improvement most plausibly moves real traffic.
+const STRIKING_DISTANCE_MIN_POSITION = 5;
+const STRIKING_DISTANCE_MAX_POSITION = 20;
+const STRIKING_DISTANCE_ROW_LIMIT = 100;
+
+export function sumSearchTotals(
+  rows: GscSearchAnalyticsRow[],
+): SearchPerformanceTotals {
+  let clicks = 0;
+  let impressions = 0;
+  let weightedPosition = 0;
+  for (const row of rows) {
+    clicks += row.clicks;
+    impressions += row.impressions;
+    weightedPosition += row.position * row.impressions;
+  }
+  return {
+    clicks,
+    impressions,
+    ctr: impressions > 0 ? clicks / impressions : 0,
+    position: impressions > 0 ? weightedPosition / impressions : 0,
+  };
+}
+
+/** Flatten single-dimension rows (query or page) into a keyed table row. */
+export function toDimensionRows(
+  rows: GscSearchAnalyticsRow[],
+): SearchPerformanceDimensionRow[] {
+  const output: SearchPerformanceDimensionRow[] = [];
+  for (const row of rows) {
+    const key = row.keys?.[0];
+    if (!key) continue;
+    output.push({
+      key,
+      clicks: row.clicks,
+      impressions: row.impressions,
+      ctr: row.ctr,
+      position: row.position,
+    });
+  }
+  return output;
+}
+
+/** Filter `["query","page"]` rows to positions 5..20, highest impressions
+ *  first. These are the improvement candidates the page exists to surface. */
+export function buildStrikingDistanceRows(
+  rows: GscSearchAnalyticsRow[],
+  limit: number = STRIKING_DISTANCE_ROW_LIMIT,
+): StrikingDistanceRow[] {
+  const candidates: StrikingDistanceRow[] = [];
+  for (const row of rows) {
+    const query = row.keys?.[0];
+    const page = row.keys?.[1];
+    if (!query || !page) continue;
+    if (
+      row.position < STRIKING_DISTANCE_MIN_POSITION ||
+      row.position > STRIKING_DISTANCE_MAX_POSITION
+    ) {
+      continue;
+    }
+    candidates.push({
+      query,
+      page,
+      clicks: row.clicks,
+      impressions: row.impressions,
+      position: row.position,
+    });
+  }
+  return candidates
+    .toSorted((a, b) => b.impressions - a.impressions)
+    .slice(0, limit);
+}
+
+/** The same-length period immediately before [startDate, endDate], for the
+ *  totals comparison. Dates are YYYY-MM-DD in UTC. */
+export function previousPeriod(
+  startDate: string,
+  endDate: string,
+): { startDate: string; endDate: string } {
+  const dayMs = 24 * 60 * 60 * 1000;
+  const start = Date.parse(`${startDate}T00:00:00Z`);
+  const end = Date.parse(`${endDate}T00:00:00Z`);
+  const lengthMs = Math.max(end - start, 0);
+  const prevEnd = start - dayMs;
+  const prevStart = prevEnd - lengthMs;
+  return {
+    startDate: formatUtcDate(prevStart),
+    endDate: formatUtcDate(prevEnd),
+  };
+}
+
+function formatUtcDate(ms: number): string {
+  return new Date(ms).toISOString().slice(0, 10);
+}

--- a/src/server/features/gsc/services/GscService.ts
+++ b/src/server/features/gsc/services/GscService.ts
@@ -74,7 +74,7 @@ async function listSitesForUser(userId: string): Promise<GscSite[]> {
  *  minted (refresh token revoked or expired), or Google rejected the call
  *  (401/403). These surface a reconnect prompt instead of being routed through
  *  error tracking. Other statuses (429, 5xx) are genuine faults and propagate. */
-function isExpectedGrantFailure(error: unknown): boolean {
+export function isExpectedGrantFailure(error: unknown): boolean {
   if (error instanceof GscTokenError) return true;
   return (
     error instanceof GscApiError &&

--- a/src/serverFunctions/searchPerformance.ts
+++ b/src/serverFunctions/searchPerformance.ts
@@ -1,0 +1,161 @@
+import { createServerFn } from "@tanstack/react-start";
+import { z } from "zod";
+import {
+  GscNotConnectedError,
+  GscService,
+} from "@/server/features/gsc/services/GscService";
+import {
+  resolveDateRange,
+  type GscPerformanceFilter,
+} from "@/server/features/gsc/searchAnalytics";
+import {
+  buildStrikingDistanceRows,
+  previousPeriod,
+  sumSearchTotals,
+  toDimensionRows,
+} from "@/server/features/gsc/searchPerformanceReport";
+import { GscTokenError } from "@/server/lib/gscClient";
+import { requireProjectContext } from "@/serverFunctions/middleware";
+
+const SEARCH_PERFORMANCE_RANGES = [
+  "last_7_days",
+  "last_28_days",
+  "last_3_months",
+] as const;
+
+const GSC_DEVICES = ["DESKTOP", "MOBILE", "TABLET"] as const;
+
+const searchPerformanceInputSchema = z.object({
+  projectId: z.string().min(1),
+  dateRange: z.enum(SEARCH_PERFORMANCE_RANGES).default("last_28_days"),
+  device: z.enum(GSC_DEVICES).optional(),
+  // ISO-3166-1 alpha-3, the code GSC returns in `country` dimension keys.
+  country: z
+    .string()
+    .length(3)
+    .transform((value) => value.toLowerCase())
+    .optional(),
+});
+
+const TABLE_ROW_LIMIT = 250;
+// query x page fan-out needs more rows to find the 5..20 band.
+const STRIKING_DISTANCE_FETCH_LIMIT = 1000;
+// dimensions:["date"] returns one row per day; the longest range is ~92 days.
+const DAILY_ROW_LIMIT = 200;
+const COUNTRY_ROW_LIMIT = 25;
+
+/**
+ * Everything the Search Performance page renders, in one call: current and
+ * previous-period totals, top queries/pages, the striking-distance rows, and
+ * the country list that powers the filter dropdown. The six GSC queries run
+ * in parallel against the project's connected property and cost nothing
+ * (first-party Search Console data).
+ */
+export const getSearchPerformanceReport = createServerFn({ method: "POST" })
+  .middleware(requireProjectContext)
+  .inputValidator((data: unknown) => searchPerformanceInputSchema.parse(data))
+  .handler(async ({ data, context }) => {
+    const { startDate, endDate } = resolveDateRange({
+      dateRange: data.dateRange,
+    });
+    const prev = previousPeriod(startDate, endDate);
+    const projectId = context.projectId;
+
+    // Device applies everywhere; country applies everywhere EXCEPT the
+    // country breakdown itself, so the dropdown keeps every option visible
+    // while one country is selected.
+    const deviceFilters: GscPerformanceFilter[] = data.device
+      ? [{ dimension: "device", operator: "equals", expression: data.device }]
+      : [];
+    const filters: GscPerformanceFilter[] = data.country
+      ? [
+          ...deviceFilters,
+          {
+            dimension: "country",
+            operator: "equals",
+            expression: data.country,
+          },
+        ]
+      : deviceFilters;
+
+    try {
+      const [current, previous, queries, pages, queryPages, countries] =
+        await Promise.all([
+          GscService.getPerformance({
+            projectId,
+            startDate,
+            endDate,
+            dimensions: ["date"],
+            filters,
+            rowLimit: DAILY_ROW_LIMIT,
+          }),
+          GscService.getPerformance({
+            projectId,
+            startDate: prev.startDate,
+            endDate: prev.endDate,
+            dimensions: ["date"],
+            filters,
+            rowLimit: DAILY_ROW_LIMIT,
+          }),
+          GscService.getPerformance({
+            projectId,
+            startDate,
+            endDate,
+            dimensions: ["query"],
+            filters,
+            rowLimit: TABLE_ROW_LIMIT,
+          }),
+          GscService.getPerformance({
+            projectId,
+            startDate,
+            endDate,
+            dimensions: ["page"],
+            filters,
+            rowLimit: TABLE_ROW_LIMIT,
+          }),
+          GscService.getPerformance({
+            projectId,
+            startDate,
+            endDate,
+            dimensions: ["query", "page"],
+            filters,
+            rowLimit: STRIKING_DISTANCE_FETCH_LIMIT,
+          }),
+          GscService.getPerformance({
+            projectId,
+            startDate,
+            endDate,
+            dimensions: ["country"],
+            filters: deviceFilters,
+            rowLimit: COUNTRY_ROW_LIMIT,
+          }),
+        ]);
+
+      return {
+        connected: true as const,
+        siteUrl: current.siteUrl,
+        range: {
+          startDate,
+          endDate,
+          prevStartDate: prev.startDate,
+          prevEndDate: prev.endDate,
+        },
+        totals: sumSearchTotals(current.rows),
+        prevTotals: sumSearchTotals(previous.rows),
+        queries: toDimensionRows(queries.rows),
+        pages: toDimensionRows(pages.rows),
+        strikingDistance: buildStrikingDistanceRows(queryPages.rows),
+        countries: toDimensionRows(countries.rows),
+      };
+    } catch (error) {
+      // Not connected (or a dead grant): the page renders the connect card.
+      // Anything else is a real fault and goes through error handling.
+      if (
+        error instanceof GscNotConnectedError ||
+        error instanceof GscTokenError
+      ) {
+        return { connected: false as const };
+      }
+      throw error;
+    }
+  });

--- a/src/serverFunctions/searchPerformance.ts
+++ b/src/serverFunctions/searchPerformance.ts
@@ -1,8 +1,8 @@
 import { createServerFn } from "@tanstack/react-start";
-import { z } from "zod";
 import {
   GscNotConnectedError,
   GscService,
+  isExpectedGrantFailure,
 } from "@/server/features/gsc/services/GscService";
 import {
   resolveDateRange,
@@ -14,28 +14,8 @@ import {
   sumSearchTotals,
   toDimensionRows,
 } from "@/server/features/gsc/searchPerformanceReport";
-import { GscTokenError } from "@/server/lib/gscClient";
 import { requireProjectContext } from "@/serverFunctions/middleware";
-
-const SEARCH_PERFORMANCE_RANGES = [
-  "last_7_days",
-  "last_28_days",
-  "last_3_months",
-] as const;
-
-const GSC_DEVICES = ["DESKTOP", "MOBILE", "TABLET"] as const;
-
-const searchPerformanceInputSchema = z.object({
-  projectId: z.string().min(1),
-  dateRange: z.enum(SEARCH_PERFORMANCE_RANGES).default("last_28_days"),
-  device: z.enum(GSC_DEVICES).optional(),
-  // ISO-3166-1 alpha-3, the code GSC returns in `country` dimension keys.
-  country: z
-    .string()
-    .length(3)
-    .transform((value) => value.toLowerCase())
-    .optional(),
-});
+import { searchPerformanceInputSchema } from "@/types/schemas/search-performance";
 
 const TABLE_ROW_LIMIT = 250;
 // query x page fan-out needs more rows to find the 5..20 band.
@@ -133,7 +113,6 @@ export const getSearchPerformanceReport = createServerFn({ method: "POST" })
 
       return {
         connected: true as const,
-        siteUrl: current.siteUrl,
         range: {
           startDate,
           endDate,
@@ -148,11 +127,12 @@ export const getSearchPerformanceReport = createServerFn({ method: "POST" })
         countries: toDimensionRows(countries.rows),
       };
     } catch (error) {
-      // Not connected (or a dead grant): the page renders the connect card.
-      // Anything else is a real fault and goes through error handling.
+      // Not connected, or a dead/denied grant (token failure or 401/403): the
+      // page renders the connect card, which surfaces the reconnect prompt.
+      // Other statuses (429, 5xx) are real faults and go through error handling.
       if (
         error instanceof GscNotConnectedError ||
-        error instanceof GscTokenError
+        isExpectedGrantFailure(error)
       ) {
         return { connected: false as const };
       }

--- a/src/serverFunctions/searchPerformance.ts
+++ b/src/serverFunctions/searchPerformance.ts
@@ -15,21 +15,52 @@ import {
   toDimensionRows,
 } from "@/server/features/gsc/searchPerformanceReport";
 import { requireProjectContext } from "@/serverFunctions/middleware";
-import { searchPerformanceInputSchema } from "@/types/schemas/search-performance";
+import {
+  searchPerformanceInputSchema,
+  searchPerformanceTableExportInputSchema,
+  searchPerformanceTableInputSchema,
+} from "@/types/schemas/search-performance";
 
-const TABLE_ROW_LIMIT = 250;
 // query x page fan-out needs more rows to find the 5..20 band.
 const STRIKING_DISTANCE_FETCH_LIMIT = 1000;
 // dimensions:["date"] returns one row per day; the longest range is ~92 days.
 const DAILY_ROW_LIMIT = 200;
 const COUNTRY_ROW_LIMIT = 25;
+// Export pulls the whole dimension in one shot, capped at GSC's per-call max
+// (GSC_MAX_ROW_LIMIT). Large stores get everything up to this ceiling.
+const EXPORT_ROW_LIMIT = 1000;
+
+/** Build GSC filter groups shared by every call. Device applies everywhere;
+ *  country applies everywhere except the country breakdown itself (so the
+ *  dropdown keeps every option visible while one country is selected). */
+function buildGscFilters(data: { device?: string; country?: string }): {
+  deviceFilters: GscPerformanceFilter[];
+  filters: GscPerformanceFilter[];
+} {
+  const deviceFilters: GscPerformanceFilter[] = data.device
+    ? [{ dimension: "device", operator: "equals", expression: data.device }]
+    : [];
+  const filters: GscPerformanceFilter[] = data.country
+    ? [
+        ...deviceFilters,
+        { dimension: "country", operator: "equals", expression: data.country },
+      ]
+    : deviceFilters;
+  return { deviceFilters, filters };
+}
+
+/** Not connected, or a dead/denied grant (token failure or 401/403): the page
+ *  renders the connect card. Other statuses (429, 5xx) are real faults. */
+function isExpectedConnectionFailure(error: unknown): boolean {
+  return error instanceof GscNotConnectedError || isExpectedGrantFailure(error);
+}
 
 /**
- * Everything the Search Performance page renders, in one call: current and
- * previous-period totals, top queries/pages, the striking-distance rows, and
- * the country list that powers the filter dropdown. The six GSC queries run
- * in parallel against the project's connected property and cost nothing
- * (first-party Search Console data).
+ * The Search Performance overview: current + previous-period totals, the
+ * striking-distance rows, and the country list that powers the filter dropdown.
+ * The queries/pages tables paginate separately (getSearchPerformanceTable) so
+ * page-flips never re-run the striking-distance scan. All first-party GSC data,
+ * free.
  */
 export const getSearchPerformanceReport = createServerFn({ method: "POST" })
   .middleware(requireProjectContext)
@@ -40,76 +71,43 @@ export const getSearchPerformanceReport = createServerFn({ method: "POST" })
     });
     const prev = previousPeriod(startDate, endDate);
     const projectId = context.projectId;
-
-    // Device applies everywhere; country applies everywhere EXCEPT the
-    // country breakdown itself, so the dropdown keeps every option visible
-    // while one country is selected.
-    const deviceFilters: GscPerformanceFilter[] = data.device
-      ? [{ dimension: "device", operator: "equals", expression: data.device }]
-      : [];
-    const filters: GscPerformanceFilter[] = data.country
-      ? [
-          ...deviceFilters,
-          {
-            dimension: "country",
-            operator: "equals",
-            expression: data.country,
-          },
-        ]
-      : deviceFilters;
+    const { deviceFilters, filters } = buildGscFilters(data);
 
     try {
-      const [current, previous, queries, pages, queryPages, countries] =
-        await Promise.all([
-          GscService.getPerformance({
-            projectId,
-            startDate,
-            endDate,
-            dimensions: ["date"],
-            filters,
-            rowLimit: DAILY_ROW_LIMIT,
-          }),
-          GscService.getPerformance({
-            projectId,
-            startDate: prev.startDate,
-            endDate: prev.endDate,
-            dimensions: ["date"],
-            filters,
-            rowLimit: DAILY_ROW_LIMIT,
-          }),
-          GscService.getPerformance({
-            projectId,
-            startDate,
-            endDate,
-            dimensions: ["query"],
-            filters,
-            rowLimit: TABLE_ROW_LIMIT,
-          }),
-          GscService.getPerformance({
-            projectId,
-            startDate,
-            endDate,
-            dimensions: ["page"],
-            filters,
-            rowLimit: TABLE_ROW_LIMIT,
-          }),
-          GscService.getPerformance({
-            projectId,
-            startDate,
-            endDate,
-            dimensions: ["query", "page"],
-            filters,
-            rowLimit: STRIKING_DISTANCE_FETCH_LIMIT,
-          }),
-          GscService.getPerformance({
-            projectId,
-            startDate,
-            endDate,
-            dimensions: ["country"],
-            filters: deviceFilters,
-            rowLimit: COUNTRY_ROW_LIMIT,
-          }),
-        ]);
+      const [current, previous, queryPages, countries] = await Promise.all([
+        GscService.getPerformance({
+          projectId,
+          startDate,
+          endDate,
+          dimensions: ["date"],
+          filters,
+          rowLimit: DAILY_ROW_LIMIT,
+        }),
+        GscService.getPerformance({
+          projectId,
+          startDate: prev.startDate,
+          endDate: prev.endDate,
+          dimensions: ["date"],
+          filters,
+          rowLimit: DAILY_ROW_LIMIT,
+        }),
+        GscService.getPerformance({
+          projectId,
+          startDate,
+          endDate,
+          dimensions: ["query", "page"],
+          filters,
+          rowLimit: STRIKING_DISTANCE_FETCH_LIMIT,
+        }),
+        GscService.getPerformance({
+          projectId,
+          startDate,
+          endDate,
+          dimensions: ["country"],
+          filters: deviceFilters,
+          rowLimit: COUNTRY_ROW_LIMIT,
+        }),
+      ]);
 
       return {
         connected: true as const,
@@ -121,21 +119,92 @@ export const getSearchPerformanceReport = createServerFn({ method: "POST" })
         },
         totals: sumSearchTotals(current.rows),
         prevTotals: sumSearchTotals(previous.rows),
-        queries: toDimensionRows(queries.rows),
-        pages: toDimensionRows(pages.rows),
         strikingDistance: buildStrikingDistanceRows(queryPages.rows),
         countries: toDimensionRows(countries.rows),
       };
     } catch (error) {
-      // Not connected, or a dead/denied grant (token failure or 401/403): the
-      // page renders the connect card, which surfaces the reconnect prompt.
-      // Other statuses (429, 5xx) are real faults and go through error handling.
-      if (
-        error instanceof GscNotConnectedError ||
-        isExpectedGrantFailure(error)
-      ) {
+      if (isExpectedConnectionFailure(error)) {
         return { connected: false as const };
       }
       throw error;
     }
+  });
+
+/**
+ * One page of the queries or pages table, paginated server-side against GSC via
+ * `startRow` so it scales to large properties. GSC returns no total count, so we
+ * fetch one extra row to detect a next page. All first-party GSC data, free.
+ */
+export const getSearchPerformanceTable = createServerFn({ method: "POST" })
+  .middleware(requireProjectContext)
+  .inputValidator((data: unknown) =>
+    searchPerformanceTableInputSchema.parse(data),
+  )
+  .handler(async ({ data, context }) => {
+    const { startDate, endDate } = resolveDateRange({
+      dateRange: data.dateRange,
+    });
+    const { filters } = buildGscFilters(data);
+    const offset = (data.page - 1) * data.pageSize;
+
+    try {
+      const result = await GscService.getPerformance({
+        projectId: context.projectId,
+        startDate,
+        endDate,
+        dimensions: [data.dimension],
+        filters,
+        // One extra row tells us whether a further page exists.
+        rowLimit: data.pageSize + 1,
+        startRow: offset,
+      });
+
+      const fetched = toDimensionRows(result.rows);
+      const hasNextPage = fetched.length > data.pageSize;
+      const rows = hasNextPage ? fetched.slice(0, data.pageSize) : fetched;
+
+      return {
+        connected: true as const,
+        dimension: data.dimension,
+        page: data.page,
+        pageSize: data.pageSize,
+        hasNextPage,
+        rows,
+      };
+    } catch (error) {
+      if (isExpectedConnectionFailure(error)) {
+        return { connected: false as const };
+      }
+      throw error;
+    }
+  });
+
+/**
+ * The full queries/pages dataset for CSV/Sheets export (capped at
+ * EXPORT_ROW_LIMIT), rather than only the visible page.
+ */
+export const exportSearchPerformanceTable = createServerFn({ method: "POST" })
+  .middleware(requireProjectContext)
+  .inputValidator((data: unknown) =>
+    searchPerformanceTableExportInputSchema.parse(data),
+  )
+  .handler(async ({ data, context }) => {
+    const { startDate, endDate } = resolveDateRange({
+      dateRange: data.dateRange,
+    });
+    const { filters } = buildGscFilters(data);
+
+    const result = await GscService.getPerformance({
+      projectId: context.projectId,
+      startDate,
+      endDate,
+      dimensions: [data.dimension],
+      filters,
+      rowLimit: EXPORT_ROW_LIMIT,
+    });
+
+    return {
+      dimension: data.dimension,
+      rows: toDimensionRows(result.rows),
+    };
   });

--- a/src/types/schemas/search-performance.ts
+++ b/src/types/schemas/search-performance.ts
@@ -16,7 +16,9 @@ export type SearchPerformanceDateRange =
   (typeof SEARCH_PERFORMANCE_RANGES)[number];
 export type SearchPerformanceDevice = (typeof GSC_DEVICES)[number];
 
-export const searchPerformanceInputSchema = z.object({
+// Shared report/table filters. Spread into each request schema so the overview
+// and the paginated table calls always accept the exact same filter surface.
+const searchPerformanceFilterShape = {
   projectId: z.string().min(1),
   dateRange: z.enum(SEARCH_PERFORMANCE_RANGES).default("last_28_days"),
   device: z.enum(GSC_DEVICES).optional(),
@@ -26,4 +28,36 @@ export const searchPerformanceInputSchema = z.object({
     .length(3)
     .transform((value) => value.toLowerCase())
     .optional(),
+};
+
+export const searchPerformanceInputSchema = z.object(
+  searchPerformanceFilterShape,
+);
+
+/** The dimensions that get their own paginated table (query + page). Striking
+ *  distance is computed from the overview call and never paginates. */
+export const SEARCH_PERFORMANCE_TABLE_DIMENSIONS = ["query", "page"] as const;
+export type SearchPerformanceTableDimension =
+  (typeof SEARCH_PERFORMANCE_TABLE_DIMENSIONS)[number];
+
+export const SEARCH_PERFORMANCE_PAGE_SIZES = [25, 50, 100] as const;
+export const SEARCH_PERFORMANCE_DEFAULT_PAGE_SIZE = 25;
+
+export const searchPerformanceTableInputSchema = z.object({
+  ...searchPerformanceFilterShape,
+  dimension: z.enum(SEARCH_PERFORMANCE_TABLE_DIMENSIONS),
+  page: z.number().int().positive().default(1),
+  pageSize: z
+    .number()
+    .int()
+    .refine((value) =>
+      (SEARCH_PERFORMANCE_PAGE_SIZES as readonly number[]).includes(value),
+    )
+    .default(SEARCH_PERFORMANCE_DEFAULT_PAGE_SIZE),
+});
+
+/** Export pulls the full dataset (capped) rather than a single page. */
+export const searchPerformanceTableExportInputSchema = z.object({
+  ...searchPerformanceFilterShape,
+  dimension: z.enum(SEARCH_PERFORMANCE_TABLE_DIMENSIONS),
 });

--- a/src/types/schemas/search-performance.ts
+++ b/src/types/schemas/search-performance.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+/** Date ranges offered by the Search Performance page. A deliberate subset of
+ *  the GSC agent ranges (GSC_DATE_RANGES in searchAnalytics.ts); assignability
+ *  to GscDateRange is compiler-checked at the resolveDateRange call site. */
+export const SEARCH_PERFORMANCE_RANGES = [
+  "last_7_days",
+  "last_28_days",
+  "last_3_months",
+] as const;
+
+/** Device values exactly as the GSC `device` dimension returns/accepts them. */
+export const GSC_DEVICES = ["DESKTOP", "MOBILE", "TABLET"] as const;
+
+export type SearchPerformanceDateRange =
+  (typeof SEARCH_PERFORMANCE_RANGES)[number];
+export type SearchPerformanceDevice = (typeof GSC_DEVICES)[number];
+
+export const searchPerformanceInputSchema = z.object({
+  projectId: z.string().min(1),
+  dateRange: z.enum(SEARCH_PERFORMANCE_RANGES).default("last_28_days"),
+  device: z.enum(GSC_DEVICES).optional(),
+  // ISO-3166-1 alpha-3, the code GSC returns in `country` dimension keys.
+  country: z
+    .string()
+    .length(3)
+    .transform((value) => value.toLowerCase())
+    .optional(),
+});


### PR DESCRIPTION
Implements the Search Performance proposal from #54 (thanks for the pointers, all three are in).

## What

A **Search Performance** page that puts the project's Google Search Console data in the product for the first time, with a **striking distance** report as the headline view:

- Totals (clicks, impressions, CTR, avg position) with deltas vs the previous same-length period, in the rank-tracking "insights above data" layout.
- **Striking distance**: query x page rows at positions 5 to 20 sorted by impressions, i.e. the queries where a content improvement most plausibly moves traffic. Rows are selectable with a "Save as keywords" bulk action that feeds the saved-keywords list (and from there rank tracking).
- Queries and Pages tables, device/country/date-range filters, CSV and Google Sheets export.
- All first-party GSC data: zero DataForSEO spend. Six `searchAnalytics.query` calls run in parallel per load, comfortably inside GSC quota with the app's 5-minute query cache.
- Disconnected projects render the existing `SearchConsoleConnectionCard` as the empty state; a dead/denied grant (401/403) also routes there via the existing `isExpectedGrantFailure` seam instead of error tracking.
- Standalone nav tab, per your suggestion.

Built on the shared table components (`useAppTable`/`AppDataTable`, `SortableHeader`, `makeSelectionColumn` with shift-range selection, `TableBulkActionBar`, `TableExportMenu`), mirroring the rank-tracking/domain-overview patterns.

## How to review

1. **Server**: `getSearchPerformanceReport` (one server function, six parallel GSC queries) and the pure shaping helpers + unit tests (`searchPerformanceReport.ts`): impression-weighted position, the 5..20 band, previous-period math.
2. **Client**: the feature folder (Page, Parts, Columns). The Columns/Parts split follows the rank-tracking convention.
3. **One shared-file touch**: `SearchConsoleConnectionCard` now also invalidates the `searchPerformance` cache on connect/disconnect, so the page updates immediately after picking a property (also covers connecting from Project Settings).
4. **Judgment calls to sanity-check**:
   - Striking-distance band is fixed at positions 5 to 20 (no UI to tune it in v1).
   - Totals are computed by summing daily rows because `buildSearchAnalyticsRequest` defaults empty dimensions to `["query"]`; a dimensionless aggregate call would mean touching the shared MCP request builder, which I kept out of scope.
   - Filters/range/tab live in `useState` (saved-keywords precedent). If you would rather have them in URL search params like Domain Overview, happy to switch.

## Review notes (known trade-offs left for your judgment)

- The six parallel `getPerformance` calls each resolve the connection and mint a token; a resolve-once batch path in `GscService` would remove that 6x on Google's token endpoint but changes the service surface, so I left it as a possible follow-up.
- React Query's default retry (3) applies to the fan-out on GSC errors; no sibling query overrides retry, so I kept the default. Can add `retry: false` if you prefer being gentler on a 429ing property.
- Country filter labels are raw ISO alpha-3 codes ("USA", "GBR"); the repo has no alpha-3 country-name map today.
- "Save as keywords" uses the schema's default US locale; a saved query surfaced under a non-US country filter would fetch US metrics if later refreshed on the Saved page.
- Tables render up to 250 rows (server-capped) without `TablePagination`.
- A reviewer suggested consolidating the number formatter into a shared util; I checked and the repo has seven feature-local formatters with no shared util or cross-feature imports, so I matched the existing convention instead. A consolidation chore PR could do all seven at once.

## Testing

- Live against a connected `sc-domain:` property: totals + deltas, all three filters (device filter verified to change the data), column sorting, shift-range selection + bulk save (rows verified in the DB), CSV/Sheets export, the connect-card empty state, and the post-connect cache refresh.
- `pnpm ci:check` green (prettier, knip, tsc, oxlint); vitest 416/416 including the new unit tests.

Closes #54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Follow-up changes (Ben's review pass)

One squashed commit on top of the above, refining the page after live testing. All still first-party GSC data — **no DataForSEO spend on this page.**

**What changed & why**
- **Striking-distance algorithm fix.** It was filtering each query×page row independently, so a query the site already ranks #1 for (via one page) still surfaced its *other* pages sitting at position 6–20 as "opportunities." It now collapses each query to its **best-ranking page** and keeps the query only when that top page is in the 5–20 band — one row per query, no false opportunities.
- **Server-side pagination** for the Queries and Pages tables (GSC `startRow`) so the page scales to large properties, instead of a fixed 250-row cap. Includes a separate full-dataset export path so CSV/Sheets downloads aren't truncated to the visible page.
- **Client-side pagination** for striking distance (still computes 100, shows 50/page) so the table isn't a wall.
- **UX:** the tables now sit on their own card surface with filters + export in one toolbar (previously floating); Queries tab is prefetched so it opens without a spinner; a **Copy keywords** bulk action (newline-joined); removed "View saved"; page-specific empty-state copy.

**How to review**
1. `searchPerformanceReport.ts` — `buildStrikingDistanceRows` is the algorithm change; the unit tests cover the "drop a query whose top page ranks above the band" and "collapse to best page" cases.
2. `serverFunctions/searchPerformance.ts` — the overview call is now slimmed to totals/striking/countries; `getSearchPerformanceTable` (paginated, `pageSize+1` next-page probe) and `exportSearchPerformanceTable` (full dataset) are new.
3. `SearchPerformancePage.tsx` — `tableQueryOptions` single-sources the table query for both the live `useQuery` and the prefetch; client pagination + layout live here.

**Note / judgment call**
- GSC returns no total row count, so pagination shows prev/next + "Page N" (not "of M"). Export is capped at GSC's 1,000-rows-per-call max; going higher would need looped `startRow` fetches — left out of scope.
- An earlier iteration added DataForSEO volume + KD columns; that was **removed** before this push (added metered spend for marginal value) and squashed out of the history, so the diff is clean.
