### PR TITLE
feat: add check_site_status MCP tool

### DIFF
--- a/src/server/mcp/server.ts
+++ b/src/server/mcp/server.ts
@@ -23,6 +23,7 @@ import {
   inspectUrlsTool,
 } from "@/server/mcp/tools/search-console-tools";
 import { whoamiTool } from "@/server/mcp/tools/whoami";
+import { checkSiteStatusTool } from "@/server/mcp/tools/check-site-status";
 
 // Each handler is wrapped with instrumentMcpToolHandler so failures reach
 // PostHog — the MCP route has no error middleware of its own. Tools are
@@ -37,6 +38,15 @@ export function registerOpenSeoMcpTools(server: McpServer) {
       whoamiTool.name,
       whoamiTool.config.outputSchema,
       whoamiTool.handler,
+    ),
+  );
+  server.registerTool(
+    checkSiteStatusTool.name,
+    checkSiteStatusTool.config,
+    instrumentMcpToolHandler(
+      checkSiteStatusTool.name,
+      checkSiteStatusTool.config.outputSchema,
+      checkSiteStatusTool.handler,
     ),
   );
   server.registerTool(

--- a/src/server/mcp/tools/check-site-status.ts
+++ b/src/server/mcp/tools/check-site-status.ts
@@ -1,0 +1,71 @@
+import { z } from "zod";
+import { mcpResponse } from "@/server/mcp/formatters";
+import { getAuth, type ToolExtra } from "@/server/mcp/context";
+import { optionalMetaOutputSchema } from "@/server/mcp/output-schemas";
+
+const inputSchema = {
+  url: z
+    .string()
+    .url()
+    .describe("Full URL to check (e.g. 'https://example.com/page')."),
+  method: z
+    .enum(["head", "get"])
+    .optional()
+    .default("head")
+    .describe("HTTP method. HEAD is faster and cheaper; GET includes body."),
+} as const;
+
+type Args = z.infer<z.ZodObject<typeof inputSchema>>;
+
+export const checkSiteStatusTool = {
+  name: "check_site_status",
+  config: {
+    title: "Check site status",
+    description:
+      "Checks if a website is reachable and returns its HTTP status code, response time, and content type. Uses no DataForSEO credits. Helpful for verifying a domain is live before running paid SEO tools on it.",
+    inputSchema,
+    outputSchema: {
+      url: z.string(),
+      statusCode: z.number(),
+      statusText: z.string(),
+      responseTimeMs: z.number(),
+      contentType: z.string().nullable(),
+      contentLength: z.number().nullable(),
+      ...optionalMetaOutputSchema,
+    },
+    annotations: {
+      readOnlyHint: true,
+      openWorldHint: false,
+      destructiveHint: false,
+    },
+  },
+  handler: async (args: Args, extra: ToolExtra) => {
+    getAuth(extra);
+    const method = args.method ?? "head";
+
+    const start = performance.now();
+    let response;
+    try {
+      response = await fetch(args.url, { method, signal: AbortSignal.timeout(10_000) });
+    } catch (err) {
+      const text = `Failed to reach ${args.url}: ${err instanceof Error ? err.message : "unknown error"}`;
+      return mcpResponse({ text, meta: {}, structuredContent: null });
+    }
+    const elapsed = Math.round(performance.now() - start);
+
+    return mcpResponse({
+      text: `${args.url}\n  Status: ${response.status} ${response.statusText}\n  Time: ${elapsed}ms\n  Type: ${response.headers.get("content-type") ?? "—"}\n  Size: ${response.headers.get("content-length") ?? "—"}`,
+      meta: {},
+      structuredContent: {
+        url: args.url,
+        statusCode: response.status,
+        statusText: response.statusText,
+        responseTimeMs: elapsed,
+        contentType: response.headers.get("content-type"),
+        contentLength: response.headers.get("content-length")
+          ? Number(response.headers.get("content-length"))
+          : null,
+      },
+    });
+  },
+};


### PR DESCRIPTION
Adds a new MCP tool `check_site_status` that performs a lightweight HTTP HEAD/GET request to check if a website is reachable. Returns status code, response time, content type, and content length.

Uses no DataForSEO credits — useful for verifying a domain is live before running paid SEO tools.

**Input:**
- `url` (required): Full URL to check
- `method` (optional, default `head`): HEAD or GET

**Output:**
- `statusCode`, `statusText`, `responseTimeMs`, `contentType`, `contentLength`