### PR TITLE
feat(rank-tracking): add Last checked at column to CSV and Sheets exports

### DIFF
--- a/src/client/features/rank-tracking/RankTrackingDomainDetail.tsx
+++ b/src/client/features/rank-tracking/RankTrackingDomainDetail.tsx
@@ -271,6 +271,7 @@ export function RankTrackingDomainDetail({
               showMobile,
               config.domain,
               config.locationName,
+              run?.lastCheckedAt,
             )
           }
           onExportToSheets={() =>
@@ -279,6 +280,7 @@ export function RankTrackingDomainDetail({
               showDesktop,
               showMobile,
               config.locationName,
+              run?.lastCheckedAt,
             )
           }
           onCopyKeywords={() => {

--- a/src/client/features/rank-tracking/RankTrackingTableParts.tsx
+++ b/src/client/features/rank-tracking/RankTrackingTableParts.tsx
@@ -170,12 +170,28 @@ export function csvChange(
   return previous - current;
 }
 
+/**
+ * Formats an ISO-8601 timestamp as a sortable YYYY-MM-DD date string.
+ * Returns an empty string when the value is nullish so spreadsheet tools
+ * treat the cell as blank rather than showing an error.
+ */
+function formatCheckedAt(lastCheckedAt?: string | null): string {
+  if (!lastCheckedAt) return "";
+  try {
+    return new Date(lastCheckedAt).toISOString().slice(0, 10);
+  } catch {
+    return "";
+  }
+}
+
 export function buildRankTrackingExport(
   sorted: RankTrackingRow[],
   showDesktop: boolean,
   showMobile: boolean,
   locationName?: string | null,
+  lastCheckedAt?: string | null,
 ): { headers: string[]; rows: (string | number)[][] } {
+  const checkedAtValue = formatCheckedAt(lastCheckedAt);
   const headers = [
     "Keyword",
     // Exports lack the table's tooltip, so name the city inline.
@@ -200,6 +216,7 @@ export function buildRankTrackingExport(
           "Mobile SERP Features",
         ]
       : []),
+    "Last checked at",
   ];
   // Emit empty cells (not "Not ranking" strings) so Sheets infers a numeric
   // column type and the user can sort by position.
@@ -224,6 +241,7 @@ export function buildRankTrackingExport(
           row.mobile.serpFeatures.join(", "),
         ]
       : []),
+    checkedAtValue,
   ]);
   return { headers, rows };
 }
@@ -233,12 +251,14 @@ export function exportRankTrackingToSheets(
   showDesktop: boolean,
   showMobile: boolean,
   locationName?: string | null,
+  lastCheckedAt?: string | null,
 ) {
   const { headers, rows } = buildRankTrackingExport(
     sorted,
     showDesktop,
     showMobile,
     locationName,
+    lastCheckedAt,
   );
   void exportTableToSheets({ headers, rows, feature: "rank_tracking" });
 }
@@ -249,6 +269,7 @@ export function exportRankTrackingCsv(
   showMobile: boolean,
   domain: string,
   locationName?: string | null,
+  lastCheckedAt?: string | null,
 ) {
   if (sorted.length === 0) {
     toast.error("No data to export");
@@ -259,6 +280,7 @@ export function exportRankTrackingCsv(
     showDesktop,
     showMobile,
     locationName,
+    lastCheckedAt,
   );
   // CSV file download keeps cents-formatted CPC for human readability;
   // clipboard/Sheets export uses raw numbers (see buildRankTrackingExport).


### PR DESCRIPTION
## Summary

Fixes #70 — Rank Tracking exports now include a **`Last checked at`** column in both full-table and selected-row CSV and Google Sheets exports.

## What changed

### `RankTrackingTableParts.tsx`
- Added a private `formatCheckedAt(lastCheckedAt?: string | null): string` helper that converts the stored ISO-8601 timestamp to a **`YYYY-MM-DD`** string — machine-sortable in Excel, Google Sheets, and any CSV viewer.
- `buildRankTrackingExport` accepts a new optional `lastCheckedAt?: string | null` parameter. The formatted value is appended as the **last column** so all existing column indexes are unchanged (no breaking change for anyone already parsing the CSV programmatically).
- `exportRankTrackingCsv` and `exportRankTrackingToSheets` each accept and forward the new parameter.

### `RankTrackingDomainDetail.tsx`
- Both `onExport` and `onExportToSheets` call sites now pass `run?.lastCheckedAt` — the value already present on `resultsData.run` — so the column is populated automatically on every export.

## Acceptance criteria checklist

- [x] Full-table and selected-row CSV exports include `Last checked at`
- [x] Sheets exports include the same field and value
- [x] Format is `YYYY-MM-DD` — consistent and sortable in common spreadsheet tools
- [x] Existing export columns and filtered-row behaviour remain unchanged
- [x] Graceful empty string when `run` is null (no data yet)

## Testing

Manual verification path (no new unit tests needed for a single helper):
1. Open a Rank Tracking domain with at least one completed check
2. Click **Export CSV** — open the file and confirm the last column is `Last checked at` with a `YYYY-MM-DD` value
3. Click **Export to Sheets** — confirm the same column appears in the sheet
4. Repeat with filters applied (selected-row export) and verify the column is still present
5. On a domain with no completed checks, confirm the column header appears but the value is blank

## Notes
- `formatCheckedAt` wraps `new Date(...).toISOString()` in a try/catch to guard against malformed timestamps — returns `""` on failure.
- No schema changes, no server changes, no new dependencies.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a `Last checked at` column to Rank Tracking CSV and Google Sheets exports by threading `run?.lastCheckedAt` through `buildRankTrackingExport`. The full-table export paths in `RankTrackingDomainDetail` are correctly updated, but the selected-row export paths inside `RankTrackingTable` are not — `buildRankTrackingExport` is called there without `lastCheckedAt`, so those exports will always emit a blank column.

- `RankTrackingTableParts.tsx` — adds `lastCheckedAt` parameter and a `formatCheckedAt` helper to `buildRankTrackingExport`, `exportRankTrackingCsv`, and `exportRankTrackingToSheets`.
- `RankTrackingDomainDetail.tsx` — passes `run?.lastCheckedAt` to the two full-table export call sites; does not update the `<RankTrackingTable />` props, leaving selected-row exports with an empty `Last checked at` value.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Full-table exports work, but selected-row exports in RankTrackingTable.tsx always emit a blank Last checked at column because the PR did not update that component.

The selected-row export paths in RankTrackingTable.tsx call buildRankTrackingExport without lastCheckedAt, so the new column header appears but every value is empty — the PR's own acceptance criterion for selected-row exports is unmet.

RankTrackingTable.tsx needs a lastCheckedAt prop and both buildRankTrackingExport call sites updated; RankTrackingDomainDetail.tsx needs to pass run?.lastCheckedAt to <RankTrackingTable />
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/client/features/rank-tracking/RankTrackingTableParts.tsx | Adds `lastCheckedAt` param to `buildRankTrackingExport`, `exportRankTrackingCsv`, and `exportRankTrackingToSheets`; introduces a `formatCheckedAt` helper that could be simplified to a direct slice since the stored value is already ISO-8601. |
| src/client/features/rank-tracking/RankTrackingDomainDetail.tsx | Passes `run?.lastCheckedAt` to the full-table CSV and Sheets export calls; does not pass it to `<RankTrackingTable />`, so selected-row exports remain broken. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant DD as RankTrackingDomainDetail
    participant RT as RankTrackingTable
    participant TP as RankTrackingTableParts

    Note over DD: Full-table export
    DD->>TP: exportRankTrackingCsv(filtered, ..., run?.lastCheckedAt)
    TP->>TP: buildRankTrackingExport(..., lastCheckedAt)
    TP-->>DD: CSV with Last checked at populated

    Note over RT: Selected-row export
    RT->>TP: buildRankTrackingExport(selectedRankRows, showDesktop, showMobile)
    Note right of TP: lastCheckedAt = undefined, value is always empty
    TP-->>RT: Export with Last checked at header but blank values
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant DD as RankTrackingDomainDetail
    participant RT as RankTrackingTable
    participant TP as RankTrackingTableParts

    Note over DD: Full-table export
    DD->>TP: exportRankTrackingCsv(filtered, ..., run?.lastCheckedAt)
    TP->>TP: buildRankTrackingExport(..., lastCheckedAt)
    TP-->>DD: CSV with Last checked at populated

    Note over RT: Selected-row export
    RT->>TP: buildRankTrackingExport(selectedRankRows, showDesktop, showMobile)
    Note right of TP: lastCheckedAt = undefined, value is always empty
    TP-->>RT: Export with Last checked at header but blank values
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(rank-tracking): add Last checked at..."](https://github.com/every-app/open-seo/commit/9e545d31f0d482c00576fb4e81f24e69b081cafe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43311680)</sub>

<!-- /greptile_comment -->