### PR TITLE
fix: register cache writes with waitUntil so they persist on workerd

### DIFF
--- a/src/server/features/domain/services/DomainService.ts
+++ b/src/server/features/domain/services/DomainService.ts
@@ -1,3 +1,4 @@
+import { waitUntil } from "cloudflare:workers";
 import { buildCacheKey, getCached, setCached } from "@/server/lib/r2-cache";
 import { z } from "zod";
 import type { BillingCustomerContext } from "@/server/billing/subscription";
@@ -90,10 +91,14 @@ async function getOverview(
   };
 
   if (result.hasData) {
-    void setCached(cacheKey, result, DOMAIN_OVERVIEW_TTL_SECONDS).catch(
-      (error) => {
-        console.error("domain.overview.cache-write failed:", error);
-      },
+    // waitUntil, not void: workerd cancels unregistered pending I/O once the
+    // response is sent, so a fire-and-forget put never persists the cache.
+    waitUntil(
+      setCached(cacheKey, result, DOMAIN_OVERVIEW_TTL_SECONDS).catch(
+        (error) => {
+          console.error("domain.overview.cache-write failed:", error);
+        },
+      ),
     );
   }
 
@@ -174,10 +179,15 @@ async function getSuggestedKeywords(
     }));
 
   if (keywords.length > 0) {
-    void setCached(cacheKey, keywords, DOMAIN_OVERVIEW_TTL_SECONDS).catch(
-      (error) => {
-        console.error("domain.keyword-suggestions.cache-write failed:", error);
-      },
+    waitUntil(
+      setCached(cacheKey, keywords, DOMAIN_OVERVIEW_TTL_SECONDS).catch(
+        (error) => {
+          console.error(
+            "domain.keyword-suggestions.cache-write failed:",
+            error,
+          );
+        },
+      ),
     );
   }
 

--- a/src/server/features/domain/services/domainKeywordsPage.ts
+++ b/src/server/features/domain/services/domainKeywordsPage.ts
@@ -1,3 +1,4 @@
+import { waitUntil } from "cloudflare:workers";
 import { z } from "zod";
 import type { BillingCustomerContext } from "@/server/billing/subscription";
 import { createDataforseoClient } from "@/server/lib/dataforseo";
@@ -113,10 +114,14 @@ export async function getKeywordsPage(
     fetchedAt: new Date().toISOString(),
   };
 
-  void setCached(cacheKey, result, DOMAIN_KEYWORDS_PAGE_TTL_SECONDS).catch(
-    (error) => {
-      console.error("domain.keywords-page.cache-write failed:", error);
-    },
+  // waitUntil, not void: workerd cancels unregistered pending I/O once the
+  // response is sent, so a fire-and-forget put never persists the cache.
+  waitUntil(
+    setCached(cacheKey, result, DOMAIN_KEYWORDS_PAGE_TTL_SECONDS).catch(
+      (error) => {
+        console.error("domain.keywords-page.cache-write failed:", error);
+      },
+    ),
   );
 
   return result;

--- a/src/server/features/domain/services/domainPagesPage.ts
+++ b/src/server/features/domain/services/domainPagesPage.ts
@@ -1,3 +1,4 @@
+import { waitUntil } from "cloudflare:workers";
 import { z } from "zod";
 import type { BillingCustomerContext } from "@/server/billing/subscription";
 import { createDataforseoClient } from "@/server/lib/dataforseo";
@@ -193,10 +194,14 @@ export async function getPagesPage(
     fetchedAt: new Date().toISOString(),
   };
 
-  void setCached(cacheKey, result, DOMAIN_PAGES_PAGE_TTL_SECONDS).catch(
-    (error) => {
-      console.error("domain.pages-page.cache-write failed:", error);
-    },
+  // waitUntil, not void: workerd cancels unregistered pending I/O once the
+  // response is sent, so a fire-and-forget put never persists the cache.
+  waitUntil(
+    setCached(cacheKey, result, DOMAIN_PAGES_PAGE_TTL_SECONDS).catch(
+      (error) => {
+        console.error("domain.pages-page.cache-write failed:", error);
+      },
+    ),
   );
 
   return result;

--- a/src/server/features/keywords/services/research/serp.ts
+++ b/src/server/features/keywords/services/research/serp.ts
@@ -1,3 +1,4 @@
+import { waitUntil } from "cloudflare:workers";
 import { type SerpLiveItem } from "@/server/lib/dataforseo";
 import { buildCacheKey, getCached, setCached } from "@/server/lib/r2-cache";
 import type { SerpResultItem } from "@/types/keywords";
@@ -91,9 +92,13 @@ async function getSerpLiveAnalysis(
     result.reason = "no_organic_results";
   }
 
-  void setCached(cacheKey, result, SERP_CACHE_TTL_SECONDS).catch((error) => {
-    console.error("keywords.serp.cache-write failed:", error);
-  });
+  // waitUntil, not void: workerd cancels unregistered pending I/O once the
+  // response is sent, so a fire-and-forget put never persists the cache.
+  waitUntil(
+    setCached(cacheKey, result, SERP_CACHE_TTL_SECONDS).catch((error) => {
+      console.error("keywords.serp.cache-write failed:", error);
+    }),
+  );
 
   return result;
 }


### PR DESCRIPTION
## Problem

Five cache-write sites use `void setCached(...)` — a fire-and-forget promise that is never awaited and never registered with `waitUntil`:

- `DomainService.ts` — domain overview (`domain.rankOverview`, ~100–300 credits/call) and keyword suggestions
- `domainKeywordsPage.ts` / `domainPagesPage.ts` — paginated domain keyword/page views
- `keywords/services/research/serp.ts` — SERP research analysis

On Cloudflare Workers, workerd cancels unregistered pending I/O once the response is sent, so the R2 `put` behind these calls is dropped before it lands. The 12-hour caches these services advertise never actually persist — every identical call re-issues the full metered DataForSEO request.

Easy to miss because everything looks fine functionally: results come back, the `.catch` never fires (the promise is cancelled, not rejected), and dev-mode/miniflare often lets the write finish anyway.

## Fix

Register the writes with `waitUntil` from `cloudflare:workers`, matching the pattern already used elsewhere in the codebase (`instrumentation.ts`, `brandLookup.ts`, `promptExplorer.ts`). Response latency is unchanged — the write still happens after the response, it just isn't cancelled anymore.

No behavior change beyond the writes becoming durable. 613 tests green, `tsc` clean.

(Found while auditing our deployment's DataForSEO spend — cache hit-rate for `get_domain_overview` was 0% despite repeated identical calls.)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes R2 cache writes so they persist after the Worker response returns. The main changes are:

- Registers domain overview and keyword suggestion cache writes with `waitUntil`.
- Registers paginated domain keyword and page cache writes with `waitUntil`.
- Registers SERP analysis cache writes with `waitUntil`.
- Keeps existing cache keys, TTLs, DataForSEO calls, and response shaping unchanged.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The change is narrowly scoped to an established `waitUntil(setCached(...).catch(...))` pattern. Cache keys, TTLs, request inputs, response schemas, and data shaping stay unchanged. No correctness or security issues were found in the changed paths.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated that the TypeScript compile for server-cache-waituntil completed cleanly with EXIT\_CODE: 0.
- Verified the Vitest run for server-cache-waituntil passed, with 3 test files and 19 tests.
- Confirmed the static waitUntil cache registration check passed (RESULT: PASS; EXIT\_CODE: 0) for the updated changes.
- Recognized that a verification harness script was generated and used for the static check.

<a href="https://app.greptile.com/trex/runs/14030633/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/server/features/domain/services/DomainService.ts | Replaces fire-and-forget domain overview and keyword suggestion cache writes with `waitUntil` registration. |
| src/server/features/domain/services/domainKeywordsPage.ts | Registers paginated domain keyword cache writes with `waitUntil` while preserving the existing cached/fetch/return flow. |
| src/server/features/domain/services/domainPagesPage.ts | Registers paginated domain page cache writes with `waitUntil` without changing request parameters or response shaping. |
| src/server/features/keywords/services/research/serp.ts | Registers SERP analysis cache writes with `waitUntil` so successful DataForSEO responses can persist after response completion. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Caller
participant Service as Domain/SERP service
participant R2 as R2 cache
participant DFS as DataForSEO
participant Worker as workerd waitUntil

Caller->>Service: request domain/SERP data
Service->>R2: getCached(cacheKey)
alt cache hit
    R2-->>Service: cached result
    Service-->>Caller: return cached result
else cache miss
    Service->>DFS: fetch metered data
    DFS-->>Service: API result
    Service->>Worker: waitUntil(setCached(cacheKey, result, ttl))
    Service-->>Caller: return fresh result
    Worker->>R2: persist cache write after response
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Caller
participant Service as Domain/SERP service
participant R2 as R2 cache
participant DFS as DataForSEO
participant Worker as workerd waitUntil

Caller->>Service: request domain/SERP data
Service->>R2: getCached(cacheKey)
alt cache hit
    R2-->>Service: cached result
    Service-->>Caller: return cached result
else cache miss
    Service->>DFS: fetch metered data
    DFS-->>Service: API result
    Service->>Worker: waitUntil(setCached(cacheKey, result, ttl))
    Service-->>Caller: return fresh result
    Worker->>R2: persist cache write after response
end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: register cache writes with waitUnti..."](https://github.com/every-app/open-seo/commit/6109fce00f5c12ba4a00eef166707087329c6486) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43311678)</sub>

<!-- /greptile_comment -->