### PR TITLE
feat(rank-tracking): include rank check date in exports

### DIFF
--- a/src/client/features/rank-tracking/RankTrackingDomainDetail.tsx
+++ b/src/client/features/rank-tracking/RankTrackingDomainDetail.tsx
@@ -270,16 +270,17 @@ export function RankTrackingDomainDetail({
               showDesktop,
               showMobile,
               config.domain,
-              config.locationName,
+              {
+                locationName: config.locationName,
+                lastCheckedAt: run?.lastCheckedAt,
+              },
             )
           }
           onExportToSheets={() =>
-            exportRankTrackingToSheets(
-              filtered,
-              showDesktop,
-              showMobile,
-              config.locationName,
-            )
+            exportRankTrackingToSheets(filtered, showDesktop, showMobile, {
+              locationName: config.locationName,
+              lastCheckedAt: run?.lastCheckedAt,
+            })
           }
           onCopyKeywords={() => {
             void navigator.clipboard.writeText(
@@ -334,6 +335,7 @@ export function RankTrackingDomainDetail({
               locationCode={config.locationCode}
               locationName={config.locationName}
               serpDepth={config.serpDepth}
+              lastCheckedAt={run?.lastCheckedAt}
             />
           )}
         </div>

--- a/src/client/features/rank-tracking/RankTrackingTable.tsx
+++ b/src/client/features/rank-tracking/RankTrackingTable.tsx
@@ -40,6 +40,7 @@ export function RankTrackingTable({
   locationCode,
   locationName,
   serpDepth,
+  lastCheckedAt,
 }: {
   totalCount: number;
   rows: RankTrackingRow[];
@@ -53,6 +54,7 @@ export function RankTrackingTable({
   locationCode: number;
   locationName?: string | null;
   serpDepth: number;
+  lastCheckedAt?: string | null;
 }) {
   const queryClient = useQueryClient();
   const [showConfirm, setShowConfirm] = useState(false);
@@ -100,6 +102,7 @@ export function RankTrackingTable({
       selectedRankRows,
       showDesktop,
       showMobile,
+      { lastCheckedAt },
     );
     void exportTableToSheets({
       headers,
@@ -113,6 +116,7 @@ export function RankTrackingTable({
       selectedRankRows,
       showDesktop,
       showMobile,
+      { lastCheckedAt },
     );
     const csvRows = exportRows.map((row) =>
       row.map((cell, idx) =>

--- a/src/client/features/rank-tracking/RankTrackingTableParts.test.ts
+++ b/src/client/features/rank-tracking/RankTrackingTableParts.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import type { RankTrackingRow } from "@/types/schemas/rank-tracking";
+import {
+  buildRankTrackingExport,
+  formatCheckedAtDate,
+} from "./RankTrackingTableParts";
+
+function makeRow(keyword: string): RankTrackingRow {
+  return {
+    trackingKeywordId: keyword,
+    keyword,
+    searchVolume: 100,
+    keywordDifficulty: 20,
+    cpc: 1.5,
+    desktop: {
+      position: 3,
+      previousPosition: 5,
+      rankingUrl: "/page",
+      serpFeatures: [],
+    },
+    mobile: {
+      position: 4,
+      previousPosition: null,
+      rankingUrl: null,
+      serpFeatures: [],
+    },
+  };
+}
+
+describe("formatCheckedAtDate", () => {
+  it("formats a Postgres ISO timestamp as a machine-sortable YYYY-MM-DD date", () => {
+    expect(formatCheckedAtDate("2026-07-01T12:34:56.000Z")).toBe("2026-07-01");
+  });
+
+  it("keeps the stored UTC date for a zone-less SQLite/D1 timestamp", () => {
+    // "YYYY-MM-DD HH:MM:SS" has no zone; slicing avoids new Date() parsing it
+    // as local time and shifting the calendar day (e.g. exporting 2026-06-30).
+    expect(formatCheckedAtDate("2026-07-01 01:30:00")).toBe("2026-07-01");
+  });
+
+  it("returns an empty string for missing values", () => {
+    expect(formatCheckedAtDate(null)).toBe("");
+    expect(formatCheckedAtDate(undefined)).toBe("");
+    expect(formatCheckedAtDate("")).toBe("");
+  });
+
+  it("returns an empty string for unparseable values instead of 'Invalid Date'", () => {
+    expect(formatCheckedAtDate("not-a-date")).toBe("");
+  });
+});
+
+describe("buildRankTrackingExport — Last checked at column", () => {
+  it("appends a 'Last checked at' header without shifting existing columns", () => {
+    const { headers } = buildRankTrackingExport(
+      [makeRow("alpha")],
+      true,
+      true,
+      { lastCheckedAt: "2026-07-01T00:00:00.000Z" },
+    );
+
+    // Existing columns keep their positions (CPC stays at index 3, which the
+    // CSV cents-formatting relies on).
+    expect(headers[0]).toBe("Keyword");
+    expect(headers[3]).toBe("CPC");
+    // New column is appended last.
+    expect(headers[headers.length - 1]).toBe("Last checked at");
+  });
+
+  it("puts the formatted date in the last cell of every row", () => {
+    const { rows } = buildRankTrackingExport(
+      [makeRow("alpha"), makeRow("beta")],
+      true,
+      true,
+      { lastCheckedAt: "2026-07-01T12:00:00.000Z" },
+    );
+
+    expect(rows).toHaveLength(2);
+    for (const row of rows) {
+      expect(row[row.length - 1]).toBe("2026-07-01");
+    }
+  });
+
+  it("keeps the column present but empty when no run timestamp is available", () => {
+    const { headers, rows } = buildRankTrackingExport(
+      [makeRow("alpha")],
+      true,
+      true,
+    );
+
+    expect(headers[headers.length - 1]).toBe("Last checked at");
+    expect(rows[0][rows[0].length - 1]).toBe("");
+  });
+
+  it("includes the date regardless of which devices are shown", () => {
+    const desktopOnly = buildRankTrackingExport([makeRow("a")], true, false, {
+      lastCheckedAt: "2026-07-01T00:00:00.000Z",
+    });
+    const mobileOnly = buildRankTrackingExport([makeRow("a")], false, true, {
+      lastCheckedAt: "2026-07-01T00:00:00.000Z",
+    });
+
+    expect(desktopOnly.headers[desktopOnly.headers.length - 1]).toBe(
+      "Last checked at",
+    );
+    expect(desktopOnly.rows[0][desktopOnly.rows[0].length - 1]).toBe(
+      "2026-07-01",
+    );
+    expect(mobileOnly.rows[0][mobileOnly.rows[0].length - 1]).toBe(
+      "2026-07-01",
+    );
+  });
+});

--- a/src/client/features/rank-tracking/RankTrackingTableParts.tsx
+++ b/src/client/features/rank-tracking/RankTrackingTableParts.tsx
@@ -170,12 +170,42 @@ export function csvChange(
   return previous - current;
 }
 
+type RankTrackingExportMeta = {
+  locationName?: string | null;
+  lastCheckedAt?: string | null;
+};
+
+/**
+ * Formats a run timestamp as a machine-sortable `YYYY-MM-DD` date for exports.
+ *
+ * Timestamps arrive as UTC in two shapes depending on the DB backend: SQLite/D1
+ * `"YYYY-MM-DD HH:MM:SS"` (no zone) and Postgres ISO `"YYYY-MM-DDTHH:MM:SS.sssZ"`.
+ * Both start with the UTC calendar date, so we slice it straight from the string
+ * and report the stored date as-is. Parsing the zone-less D1 string through
+ * `new Date()` would treat it as LOCAL time, and `toISOString()` could then shift
+ * it a day off (e.g. an early-morning-UTC check exporting as the previous day).
+ *
+ * Returns "" for missing or unparseable values so the column stays present but
+ * empty rather than emitting "Invalid Date".
+ */
+export function formatCheckedAtDate(value: string | null | undefined): string {
+  if (!value) return "";
+  const isoDate = /^(\d{4}-\d{2}-\d{2})/.exec(value);
+  if (isoDate) return isoDate[1];
+  // Fallback for any other parseable shape; guard against "Invalid Date".
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toISOString().slice(0, 10);
+}
+
 export function buildRankTrackingExport(
   sorted: RankTrackingRow[],
   showDesktop: boolean,
   showMobile: boolean,
-  locationName?: string | null,
+  options: RankTrackingExportMeta = {},
 ): { headers: string[]; rows: (string | number)[][] } {
+  const { locationName, lastCheckedAt } = options;
+  const checkedAt = formatCheckedAtDate(lastCheckedAt);
   const headers = [
     "Keyword",
     // Exports lack the table's tooltip, so name the city inline.
@@ -200,6 +230,9 @@ export function buildRankTrackingExport(
           "Mobile SERP Features",
         ]
       : []),
+    // Appended last so existing column indices (e.g. the CPC formatting in
+    // exportRankTrackingCsv keyed on index 3) stay stable.
+    "Last checked at",
   ];
   // Emit empty cells (not "Not ranking" strings) so Sheets infers a numeric
   // column type and the user can sort by position.
@@ -224,6 +257,7 @@ export function buildRankTrackingExport(
           row.mobile.serpFeatures.join(", "),
         ]
       : []),
+    checkedAt,
   ]);
   return { headers, rows };
 }
@@ -232,13 +266,13 @@ export function exportRankTrackingToSheets(
   sorted: RankTrackingRow[],
   showDesktop: boolean,
   showMobile: boolean,
-  locationName?: string | null,
+  meta: RankTrackingExportMeta = {},
 ) {
   const { headers, rows } = buildRankTrackingExport(
     sorted,
     showDesktop,
     showMobile,
-    locationName,
+    meta,
   );
   void exportTableToSheets({ headers, rows, feature: "rank_tracking" });
 }
@@ -248,7 +282,7 @@ export function exportRankTrackingCsv(
   showDesktop: boolean,
   showMobile: boolean,
   domain: string,
-  locationName?: string | null,
+  meta: RankTrackingExportMeta = {},
 ) {
   if (sorted.length === 0) {
     toast.error("No data to export");
@@ -258,7 +292,7 @@ export function exportRankTrackingCsv(
     sorted,
     showDesktop,
     showMobile,
-    locationName,
+    meta,
   );
   // CSV file download keeps cents-formatted CPC for human readability;
   // clipboard/Sheets export uses raw numbers (see buildRankTrackingExport).


### PR DESCRIPTION
Closes #70.

## What
Adds a machine-sortable **`Last checked at`** column to the Rank Tracking exports, so saved CSV/Sheets files record *when* the rankings were checked.

## Coverage (per the acceptance criteria)
- [x] Full-table **and** selected-row **CSV** exports include `Last checked at`.
- [x] **Sheets** exports include the same field and value (both routes go through `buildRankTrackingExport`, so header and value are identical to CSV).
- [x] Format is consistent and sortable in spreadsheets (`YYYY-MM-DD`).
- [x] Existing columns and filtered-row behaviour unchanged — the column is appended **last**, so existing indices (e.g. the CSV cents-formatting keyed on index 3) stay stable.

## Implementation notes
- The date is sliced straight from the stored **UTC** timestamp rather than parsed via `new Date().toISOString()`. This is deliberate: the default D1/SQLite backend stores `current_timestamp` as a zone-less `"YYYY-MM-DD HH:MM:SS"` string, which `new Date()` would interpret as *local* time and could then shift a calendar day for non-UTC users. Slicing yields the correct stored UTC date for both the D1 and Postgres backends, and a deterministic value in a shared export file.
- Note: the export uses the stored **UTC** date, while the on-screen "Last:" label in the detail header uses `toLocaleDateString()` (local). These can differ by a day right around midnight; UTC was chosen for the export because it's deterministic and machine-sortable across users. Happy to align if you'd prefer local.
- Threaded the value through as an options object (`RankTrackingExportMeta`) instead of adding another positional param, to keep the export call sites readable.

## Tests
Added `RankTrackingTableParts.test.ts` covering the header append (without shifting existing columns), the per-row value, the empty-when-no-run case, device-visibility independence, and `formatCheckedAtDate` for Postgres ISO, zone-less SQLite/D1 (regression for the day-shift), and missing/unparseable inputs.

`pnpm ci:check` and the full `pnpm test` suite pass.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds the last rank-check date to rank-tracking exports. The main changes are:

- Appends a `Last checked at` column to CSV and Sheets export data.
- Threads `lastCheckedAt` through full-table and selected-row export paths.
- Formats stored timestamps as sortable `YYYY-MM-DD` values.
- Adds tests for export column placement, empty timestamps, device visibility, and timestamp formats.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The change is narrowly scoped to client-side export metadata and date formatting. Existing export column indices are preserved. Focused tests cover timestamp formats and export shape behavior. No functional or security issues were found in the changed paths.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the requested verification.
- The verification completed, but its local artifact references were not uploaded.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/client/features/rank-tracking/RankTrackingDomainDetail.tsx | Threads the latest run timestamp into full-table CSV/Sheets exports and the table component without changing filtering behavior. |
| src/client/features/rank-tracking/RankTrackingTable.tsx | Adds `lastCheckedAt` to selected-row CSV/Sheets export metadata so bulk exports share the new date column. |
| src/client/features/rank-tracking/RankTrackingTableParts.tsx | Adds export metadata, UTC date formatting, and appends `Last checked at` consistently to rank-tracking export headers and rows. |
| src/client/features/rank-tracking/RankTrackingTableParts.test.ts | Covers the new date formatter and export column placement/value behavior across full and device-specific export shapes. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User
participant Detail as RankTrackingDomainDetail
participant Table as RankTrackingTable
participant Export as buildRankTrackingExport
participant Destination as CSV / Sheets

User->>Detail: Export full filtered table
Detail->>Export: rows, device visibility, locationName, lastCheckedAt
Export-->>Detail: headers + rows with Last checked at
Detail->>Destination: download CSV or send to Sheets

User->>Table: Export selected rows
Table->>Export: selected rows, device visibility, lastCheckedAt
Export-->>Table: headers + rows with Last checked at
Table->>Destination: download CSV or send to Sheets
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User
participant Detail as RankTrackingDomainDetail
participant Table as RankTrackingTable
participant Export as buildRankTrackingExport
participant Destination as CSV / Sheets

User->>Detail: Export full filtered table
Detail->>Export: rows, device visibility, locationName, lastCheckedAt
Export-->>Detail: headers + rows with Last checked at
Detail->>Destination: download CSV or send to Sheets

User->>Table: Export selected rows
Table->>Export: selected rows, device visibility, lastCheckedAt
Export-->>Table: headers + rows with Last checked at
Table->>Destination: download CSV or send to Sheets
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(rank-tracking): include rank check ..."](https://github.com/every-app/open-seo/commit/872c418e2020297d1844adfd6812584152d46bae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43311677)</sub>

<!-- /greptile_comment -->