### PR TITLE
feat(keywords): add search intent filter to Keyword Research

### DIFF
--- a/src/client/features/keywords/components/IntentBadge.tsx
+++ b/src/client/features/keywords/components/IntentBadge.tsx
@@ -18,32 +18,41 @@ const SHORT_LABELS: Record<KeywordIntent, string> = {
   unknown: "?",
 };
 
+/** Full intent labels, shared with the keyword filters so both stay in sync. */
+export const INTENT_LABELS: Record<KeywordIntent, string> = {
+  informational: "Informational",
+  commercial: "Commercial",
+  transactional: "Transactional",
+  navigational: "Navigational",
+  unknown: "Unknown",
+};
+
 const DESCRIPTIONS: Record<
   KeywordIntent,
   { label: string; description: string }
 > = {
   informational: {
-    label: "Informational",
+    label: INTENT_LABELS.informational,
     description:
       "The searcher wants information or answers. Use this for educational content, guides, and comparison-light explainers.",
   },
   commercial: {
-    label: "Commercial",
+    label: INTENT_LABELS.commercial,
     description:
       "The searcher is researching options before a purchase. Treat this as buying intent for comparisons, alternatives, and product-led pages.",
   },
   transactional: {
-    label: "Transactional",
+    label: INTENT_LABELS.transactional,
     description:
       "The searcher is ready to complete an action, often a purchase. Prioritize clear offers, pricing, trials, or conversion paths.",
   },
   navigational: {
-    label: "Navigational",
+    label: INTENT_LABELS.navigational,
     description:
       "The searcher is looking for a specific site, brand, or page. These queries usually reward matching the expected destination.",
   },
   unknown: {
-    label: "Unknown",
+    label: INTENT_LABELS.unknown,
     description:
       "Intent was not available for this keyword, so avoid making content strategy decisions from this badge alone.",
   },

--- a/src/client/features/keywords/hooks/useKeywordFiltering.test.ts
+++ b/src/client/features/keywords/hooks/useKeywordFiltering.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import type { KeywordIntent, KeywordResearchRow } from "@/types/keywords";
+import {
+  EMPTY_FILTERS,
+  parseIntentFilter,
+  toggleIntentFilter,
+  type KeywordFilterValues,
+} from "@/client/features/keywords/keywordResearchTypes";
+import { applyKeywordFiltersAndSort } from "./useKeywordFiltering";
+
+function makeRow(keyword: string, intent: KeywordIntent): KeywordResearchRow {
+  return {
+    keyword,
+    searchVolume: 100,
+    trend: [],
+    keywordDifficulty: 10,
+    cpc: 1,
+    competition: 0.5,
+    intent,
+  };
+}
+
+function filter(
+  rows: KeywordResearchRow[],
+  overrides: Partial<KeywordFilterValues>,
+): KeywordResearchRow[] {
+  return applyKeywordFiltersAndSort({
+    rows,
+    filters: { ...EMPTY_FILTERS, ...overrides },
+    sortField: "keyword",
+    sortDir: "asc",
+  });
+}
+
+const rows: KeywordResearchRow[] = [
+  makeRow("buy running shoes", "transactional"),
+  makeRow("best running shoes", "commercial"),
+  makeRow("how to run", "informational"),
+  makeRow("nike store", "navigational"),
+  makeRow("mystery term", "unknown"),
+];
+
+describe("parseIntentFilter", () => {
+  it("returns an empty list for an empty string", () => {
+    expect(parseIntentFilter("")).toEqual([]);
+  });
+
+  it("parses a comma-separated string in canonical order", () => {
+    expect(parseIntentFilter("transactional,informational")).toEqual([
+      "informational",
+      "transactional",
+    ]);
+  });
+
+  it("drops unknown tokens and de-duplicates", () => {
+    expect(parseIntentFilter("commercial,bogus,commercial")).toEqual([
+      "commercial",
+    ]);
+  });
+});
+
+describe("toggleIntentFilter", () => {
+  it("adds an intent when absent and keeps canonical order", () => {
+    expect(toggleIntentFilter("transactional", "informational")).toBe(
+      "informational,transactional",
+    );
+  });
+
+  it("removes an intent when already present", () => {
+    expect(
+      toggleIntentFilter("informational,transactional", "informational"),
+    ).toBe("transactional");
+  });
+});
+
+describe("applyKeywordFiltersAndSort — intent filtering", () => {
+  it("returns every row when no intent is selected", () => {
+    expect(filter(rows, { intents: "" })).toHaveLength(rows.length);
+  });
+
+  it("keeps only rows matching a single selected intent", () => {
+    const result = filter(rows, { intents: "transactional" });
+    expect(result.map((r) => r.keyword)).toEqual(["buy running shoes"]);
+  });
+
+  it("keeps rows matching any of multiple selected intents", () => {
+    const result = filter(rows, { intents: "transactional,commercial" });
+    expect(result.map((r) => r.keyword).toSorted()).toEqual([
+      "best running shoes",
+      "buy running shoes",
+    ]);
+  });
+
+  it("combines the intent filter with other filters (AND)", () => {
+    // "running" narrows to the two shoe rows; intent narrows to the commercial one.
+    const result = filter(rows, {
+      include: "running",
+      intents: "commercial",
+    });
+    expect(result.map((r) => r.keyword)).toEqual(["best running shoes"]);
+  });
+
+  it("ignores invalid intent tokens (treated as no intent match constraint)", () => {
+    const result = filter(rows, { intents: "bogus" });
+    expect(result).toHaveLength(rows.length);
+  });
+});

--- a/src/client/features/keywords/hooks/useKeywordFiltering.ts
+++ b/src/client/features/keywords/hooks/useKeywordFiltering.ts
@@ -2,10 +2,13 @@ import { useMemo } from "react";
 import { sortBy } from "remeda";
 import { parseTerms } from "@/client/features/keywords/utils";
 import type { KeywordResearchRow } from "@/types/keywords";
-import type { KeywordFilterValues } from "@/client/features/keywords/keywordResearchTypes";
+import {
+  parseIntentFilter,
+  type KeywordFilterValues,
+} from "@/client/features/keywords/keywordResearchTypes";
 import type { SortDir, SortField } from "@/client/features/keywords/components";
 
-function applyKeywordFiltersAndSort(params: {
+export function applyKeywordFiltersAndSort(params: {
   rows: KeywordResearchRow[];
   filters: KeywordFilterValues;
   sortField: SortField;
@@ -13,6 +16,7 @@ function applyKeywordFiltersAndSort(params: {
 }): KeywordResearchRow[] {
   const includeTerms = parseTerms(params.filters.include);
   const excludeTerms = parseTerms(params.filters.exclude);
+  const selectedIntents = parseIntentFilter(params.filters.intents);
 
   const filtered = params.rows.filter((row) => {
     const haystack = row.keyword.toLowerCase();
@@ -23,6 +27,10 @@ function applyKeywordFiltersAndSort(params: {
       return false;
     }
     if (excludeTerms.some((term) => haystack.includes(term))) {
+      return false;
+    }
+
+    if (selectedIntents.length > 0 && !selectedIntents.includes(row.intent)) {
       return false;
     }
 

--- a/src/client/features/keywords/hooks/useLocalKeywordFilters.test.ts
+++ b/src/client/features/keywords/hooks/useLocalKeywordFilters.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { EMPTY_FILTERS } from "@/client/features/keywords/keywordResearchTypes";
+import { filterValuesSchema } from "./useLocalKeywordFilters";
+
+describe("filterValuesSchema — persistence migration", () => {
+  it("defaults intents to '' for blobs persisted before the intent filter existed", () => {
+    // A filter blob saved by an older build has no `intents` key.
+    const legacyBlob = {
+      include: "shoes",
+      exclude: "",
+      minVol: "100",
+      maxVol: "",
+      minCpc: "",
+      maxCpc: "",
+      minKd: "",
+      maxKd: "",
+    };
+
+    const parsed = filterValuesSchema.parse(legacyBlob);
+
+    expect(parsed.intents).toBe("");
+    // The rest of the user's saved filters survive the migration.
+    expect(parsed.include).toBe("shoes");
+    expect(parsed.minVol).toBe("100");
+  });
+
+  it("preserves a stored intents value", () => {
+    const parsed = filterValuesSchema.parse({
+      ...EMPTY_FILTERS,
+      intents: "transactional,commercial",
+    });
+
+    expect(parsed.intents).toBe("transactional,commercial");
+  });
+});

--- a/src/client/features/keywords/hooks/useLocalKeywordFilters.ts
+++ b/src/client/features/keywords/hooks/useLocalKeywordFilters.ts
@@ -8,7 +8,7 @@ import {
 
 const STORAGE_KEY = "keyword-default-filters";
 
-const filterValuesSchema = z.object({
+export const filterValuesSchema = z.object({
   include: z.string(),
   exclude: z.string(),
   minVol: z.string(),
@@ -17,6 +17,9 @@ const filterValuesSchema = z.object({
   maxCpc: z.string(),
   minKd: z.string(),
   maxKd: z.string(),
+  // Defaulted so filter blobs persisted before the intent filter existed still
+  // parse (missing key -> "") instead of discarding the user's saved filters.
+  intents: z.string().default(""),
 });
 
 function loadFiltersFromStorage(): KeywordFilterValues {
@@ -63,6 +66,7 @@ export function useLocalKeywordFilters() {
       "maxCpc",
       "minKd",
       "maxKd",
+      "intents",
     ];
 
     for (const key of keys) {

--- a/src/client/features/keywords/keywordResearchTypes.ts
+++ b/src/client/features/keywords/keywordResearchTypes.ts
@@ -1,3 +1,5 @@
+import type { KeywordIntent } from "@/types/keywords";
+
 export const MAX_KEYWORDS_PER_SUBMIT = 5;
 
 export type ResultLimit = 150 | 300 | 500;
@@ -17,6 +19,14 @@ export type KeywordFilterValues = {
   maxCpc: string;
   minKd: string;
   maxKd: string;
+  /**
+   * Selected search intents, stored as a comma-separated string (e.g.
+   * "transactional,commercial") so it fits the all-strings filter shape used
+   * for form state, persistence, and active-filter counting. Empty = no intent
+   * filter. Use {@link parseIntentFilter} / {@link toggleIntentFilter} to read
+   * and edit it rather than parsing the string ad hoc.
+   */
+  intents: string;
 };
 
 export const EMPTY_FILTERS: KeywordFilterValues = {
@@ -28,4 +38,43 @@ export const EMPTY_FILTERS: KeywordFilterValues = {
   maxCpc: "",
   minKd: "",
   maxKd: "",
+  intents: "",
 };
+
+/** Canonical intent order for stable serialization and UI display. */
+export const KEYWORD_INTENT_ORDER: KeywordIntent[] = [
+  "informational",
+  "commercial",
+  "transactional",
+  "navigational",
+  "unknown",
+];
+
+const KEYWORD_INTENT_SET = new Set<string>(KEYWORD_INTENT_ORDER);
+
+/** Parses the stored intents string into a list of valid, de-duplicated intents. */
+export function parseIntentFilter(value: string): KeywordIntent[] {
+  if (!value) return [];
+  const selected = new Set(
+    value
+      .split(",")
+      .map((part) => part.trim())
+      .filter((part): part is KeywordIntent => KEYWORD_INTENT_SET.has(part)),
+  );
+  // Emit in canonical order so persistence and comparisons are deterministic.
+  return KEYWORD_INTENT_ORDER.filter((intent) => selected.has(intent));
+}
+
+/** Toggles one intent in the stored string, preserving canonical order. */
+export function toggleIntentFilter(
+  value: string,
+  intent: KeywordIntent,
+): string {
+  const selected = new Set(parseIntentFilter(value));
+  if (selected.has(intent)) {
+    selected.delete(intent);
+  } else {
+    selected.add(intent);
+  }
+  return KEYWORD_INTENT_ORDER.filter((item) => selected.has(item)).join(",");
+}

--- a/src/client/features/keywords/page/KeywordResearchDesktopResults.tsx
+++ b/src/client/features/keywords/page/KeywordResearchDesktopResults.tsx
@@ -23,9 +23,10 @@ import {
 import type { KeywordResearchRow } from "@/types/keywords";
 import type { KeywordResearchControllerState } from "./types";
 import {
+  FilterIntentSelect,
   FilterRangeInputs,
   FilterTextInput,
-} from "./keywordResearchDesktopFilters";
+} from "./keywordResearchFilters";
 import { KeywordResearchDesktopTable } from "./KeywordResearchDesktopTable";
 import {
   KeywordResearchPagination,
@@ -330,6 +331,8 @@ function DesktopFilters({ controller }: Props) {
           maxName="maxKd"
         />
       </div>
+
+      <FilterIntentSelect form={filtersForm} />
     </div>
   );
 }

--- a/src/client/features/keywords/page/KeywordResearchDesktopTable.tsx
+++ b/src/client/features/keywords/page/KeywordResearchDesktopTable.tsx
@@ -19,7 +19,7 @@ import {
 import { DifficultyBadge } from "@/client/features/domain/components/DifficultyBadge";
 import { formatNumber } from "@/client/features/keywords/utils";
 import type { KeywordResearchRow } from "@/types/keywords";
-import { EmptyFilterResults } from "./keywordResearchDesktopFilters";
+import { EmptyFilterResults } from "./keywordResearchFilters";
 
 type Props = {
   activeFilterCount: number;

--- a/src/client/features/keywords/page/KeywordResearchMobileResults.tsx
+++ b/src/client/features/keywords/page/KeywordResearchMobileResults.tsx
@@ -15,6 +15,7 @@ import {
 import { exportTableToSheets } from "@/client/lib/exportToSheets";
 import { captureClientEvent } from "@/client/lib/posthog";
 import { SerpAnalysisCard } from "@/client/features/keywords/components";
+import { FilterIntentSelect } from "./keywordResearchFilters";
 import { KeywordResearchDesktopTable } from "./KeywordResearchDesktopTable";
 import {
   KeywordResearchPagination,
@@ -322,6 +323,8 @@ function MobileFilters({ controller }: Props) {
           placeholder="Max difficulty"
         />
       </div>
+
+      <FilterIntentSelect form={filtersForm} />
     </div>
   );
 }

--- a/src/client/features/keywords/page/keywordResearchFilters.tsx
+++ b/src/client/features/keywords/page/keywordResearchFilters.tsx
@@ -1,4 +1,62 @@
+import {
+  KEYWORD_INTENT_ORDER,
+  parseIntentFilter,
+  toggleIntentFilter,
+} from "@/client/features/keywords/keywordResearchTypes";
+import { INTENT_LABELS } from "@/client/features/keywords/components/IntentBadge";
 import type { KeywordResearchControllerState } from "./types";
+
+export function FilterIntentSelect({
+  form,
+}: {
+  form: KeywordResearchControllerState["filtersForm"];
+}) {
+  return (
+    <div
+      role="group"
+      aria-labelledby="keyword-intent-filter-label"
+      className="rounded-lg border border-base-300 bg-base-100 p-2.5 space-y-2"
+    >
+      <p
+        id="keyword-intent-filter-label"
+        className="text-[11px] font-semibold uppercase tracking-wide text-base-content/60"
+      >
+        Intent
+      </p>
+      <form.Field name="intents">
+        {(field) => {
+          const selected = parseIntentFilter(field.state.value);
+          return (
+            <div className="flex flex-wrap gap-1.5">
+              {KEYWORD_INTENT_ORDER.map((intent) => {
+                const isActive = selected.includes(intent);
+                return (
+                  <button
+                    key={intent}
+                    type="button"
+                    aria-pressed={isActive}
+                    className={`btn btn-xs ${
+                      isActive
+                        ? "btn-primary"
+                        : "btn-ghost border border-base-300"
+                    }`}
+                    onClick={() =>
+                      field.handleChange(
+                        toggleIntentFilter(field.state.value, intent),
+                      )
+                    }
+                  >
+                    {INTENT_LABELS[intent]}
+                  </button>
+                );
+              })}
+            </div>
+          );
+        }}
+      </form.Field>
+    </div>
+  );
+}
 
 export function FilterTextInput({
   form,


### PR DESCRIPTION
Closes #67.

## What
Adds a **multi-select intent filter** (Informational, Commercial, Transactional, Navigational, Unknown) to the Keyword Research table, so users can isolate e.g. transactional terms instead of scanning the intent badges by hand.

## Coverage (per the acceptance criteria)
- [x] Filter by one or more intents, including Transactional.
- [x] Intent participates in the active-filter count, persistence, and clear-all.
- [x] Sorting, pagination, save, and export use the filtered row set.
- [x] A clear empty state shows when no rows match (existing `EmptyFilterResults`, shared by both layouts).
- [x] Tests cover single and multiple intent selections.
- [x] Multi-select present on **both** the desktop and mobile layouts. Intent classification and URL params are unchanged.

## Design
- Selected intents are stored as a **comma-separated string** in a new `intents` field on `KeywordFilterValues`. This deliberately fits the existing all-strings filter shape: active-filter counting (`Object.values(...).filter(v => v.trim() !== "")`), the `z.string()` persistence schema, and clear-all all work with no special-casing. Reads/writes go through `parseIntentFilter` / `toggleIntentFilter`, which keep a canonical order and de-duplicate.
- Because sorting, pagination, save, and export already derive from `filteredRows`, they respect the intent filter automatically — no changes needed there.
- The persistence schema defaults `intents` to `""`, so filter blobs saved before this change still load instead of being discarded.

## Tests
- `useKeywordFiltering.test.ts`: single-intent, multiple-intent, intent + other filters (AND), invalid-token handling, and the `parseIntentFilter` / `toggleIntentFilter` helpers.
- `useLocalKeywordFilters.test.ts`: persistence migration (a legacy blob with no `intents` key loads with `intents: ""` and keeps the user's other filters).

`pnpm ci:check` and the full `pnpm test` suite pass.

## Notes
- The intent labels are reused from `IntentBadge` (`INTENT_LABELS`) so the table and the filter stay in sync.
- Renamed `keywordResearchDesktopFilters.tsx` → `keywordResearchFilters.tsx`, since the shared filter components (including the new one) are now imported by the mobile layout too.
- I wasn't able to exercise the live UI end-to-end locally (Keyword Research needs a DataForSEO key), so the verification here is typecheck + unit tests. Happy to tweak the visual details (e.g. matching chip colors to the intent badge palette) if you'd prefer.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a multi-select search intent filter to Keyword Research. The main changes are:

- Shared intent labels between `IntentBadge` and the new filter UI.
- New `intents` filter state with canonical parsing and toggling helpers.
- Intent filtering applied to the existing filtered row set used by sorting, pagination, save, and export.
- Persistence support for the new filter field with migration for older saved filter blobs.
- Desktop and mobile filter UI updates plus unit tests for filtering and persistence.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with low risk.

The changes are focused on client-side filter state and UI, reuse the existing string-based filter model, and include tests for filtering and persistence migration.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the requested verification and completed the contract validation, but local artifact references were not uploaded.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/client/features/keywords/keywordResearchTypes.ts | Adds `intents` to keyword filter state plus canonical parsing and toggling helpers for intent multi-select serialization. |
| src/client/features/keywords/hooks/useKeywordFiltering.ts | Applies parsed intent selections during row filtering before existing numeric filters and sorting. |
| src/client/features/keywords/hooks/useLocalKeywordFilters.ts | Extends persisted filter validation and reset handling to include the new `intents` string field. |
| src/client/features/keywords/page/keywordResearchFilters.tsx | Renames the desktop filter module to shared filters and adds an accessible multi-select intent button group. |
| src/client/features/keywords/page/KeywordResearchDesktopResults.tsx | Imports the shared filter components and adds the intent selector to the desktop filter panel. |
| src/client/features/keywords/page/KeywordResearchMobileResults.tsx | Adds the shared intent selector to the mobile filter panel while retaining filtered export and pagination flows. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User
participant FilterUI as Desktop/Mobile FilterIntentSelect
participant Form as filtersForm.values.intents
participant Parser as parseIntentFilter/toggleIntentFilter
participant Filtering as useKeywordFiltering
participant Results as Table/Pagination/Save/Export

User->>FilterUI: Click intent button
FilterUI->>Parser: toggleIntentFilter(current, intent)
Parser-->>Form: Canonical comma-separated intents
Form->>Filtering: Updated KeywordFilterValues
Filtering->>Parser: parseIntentFilter(intents)
Filtering-->>Results: filteredRows matching selected intents
Results-->>User: Updated rows, counts, pagination, save/export set
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User
participant FilterUI as Desktop/Mobile FilterIntentSelect
participant Form as filtersForm.values.intents
participant Parser as parseIntentFilter/toggleIntentFilter
participant Filtering as useKeywordFiltering
participant Results as Table/Pagination/Save/Export

User->>FilterUI: Click intent button
FilterUI->>Parser: toggleIntentFilter(current, intent)
Parser-->>Form: Canonical comma-separated intents
Form->>Filtering: Updated KeywordFilterValues
Filtering->>Parser: parseIntentFilter(intents)
Filtering-->>Results: filteredRows matching selected intents
Results-->>User: Updated rows, counts, pagination, save/export set
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(keywords): add search intent filter..."](https://github.com/every-app/open-seo/commit/8587baa91d9e9e8083bd3527be3fc0e4edf755f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43311675)</sub>

<!-- /greptile_comment -->