### PR TITLE
Fix overlapping hover and active backgrounds in sidebar items

### DIFF
--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -32,7 +32,7 @@ interface SidebarProps {
 const navItemBaseClass =
   "relative flex items-center gap-2.5 rounded-md px-3 py-1.5 text-sm text-base-content/70";
 
-const navItemClass = `${navItemBaseClass} transition-colors hover:bg-base-300/50 hover:text-base-content`;
+const navItemClass = `${navItemBaseClass} transition-colors hover:bg-base-300/50 hover:text-base-content my-0.5`;
 
 const navItemActiveProps = {
   className: "bg-base-300/50 font-medium text-base-content",


### PR DESCRIPTION
### **Summary**

This PR fixes a visual issue in the sidebar where the hover background of a menu item visually overlaps with the adjacent active item.

### **Changes**

- Improved separation between active and hovered sidebar items.
- Updated the sidebar styles to keep hover and active states visually distinct.

Closes #80

### **Testing**

- Verified hover behavior on items adjacent to the active item.
- Confirmed the active state remains unchanged.
- Checked the sidebar across different pages.

<img width="287" height="908" alt="Screenshot 2026-07-11 212740" src="https://github.com/user-attachments/assets/0039d77e-0759-4b31-b783-72f06e049edd" />

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a single Tailwind utility class (`my-0.5`) to the sidebar nav item class string to introduce a 2px vertical gap between items, preventing the hover background of one item from visually touching the active background of an adjacent item.

- The one-character change targets `navItemClass`, which is used by both `SidebarNavLink` and the account menu button in `SidebarFooter`, so all sidebar items gain consistent spacing.
- The active-item left-bar indicator (`absolute left-0 top-1 bottom-1`) is positioned relative to the element's own box and is unaffected by the outer margin.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

A minimal, targeted one-class addition with no logic or data changes — safe to merge.

The only change is appending `my-0.5` to a Tailwind class string. It correctly applies to both nav links and the account button (which reuses `navItemClass`), and does not affect the absolute-positioned active indicator. No backend, auth, billing, or query logic is touched.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/client/components/Sidebar.tsx | Adds `my-0.5` Tailwind margin to `navItemClass` so adjacent sidebar items have a 2px gap that prevents hover and active backgrounds from visually blending together. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Sidebar renders nav groups] --> B[SidebarNavLink per item]
    B --> C{Is item active?}
    C -- Yes --> D["Apply navItemClass + navItemActiveProps\n(bg-base-300/50, font-medium)"]
    C -- No --> E["Apply navItemClass only\n(hover:bg-base-300/50)"]
    D --> F["Render left accent bar\n(absolute, top-1 bottom-1)"]
    E --> G["No accent bar"]
    F --> H["my-0.5 gap separates items\nso hover bg doesn't touch active bg"]
    G --> H
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Sidebar renders nav groups] --> B[SidebarNavLink per item]
    B --> C{Is item active?}
    C -- Yes --> D["Apply navItemClass + navItemActiveProps\n(bg-base-300/50, font-medium)"]
    C -- No --> E["Apply navItemClass only\n(hover:bg-base-300/50)"]
    D --> F["Render left accent bar\n(absolute, top-1 bottom-1)"]
    E --> G["No accent bar"]
    F --> H["my-0.5 gap separates items\nso hover bg doesn't touch active bg"]
    G --> H
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: fix sidebar hover-active overlap bu..."](https://github.com/every-app/open-seo/commit/d285bab4eb0d67202a998df9cfaacfb560bc61d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43526323)</sub>

<!-- /greptile_comment -->