### PR TITLE
feat(search-performance): add page-path and metric filters to GSC Insights

### DIFF
--- a/src/client/features/search-performance/SearchPerformanceAdvancedFilters.test.ts
+++ b/src/client/features/search-performance/SearchPerformanceAdvancedFilters.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  compileAdvancedSearchPerformanceFilters,
+  getAdvancedSearchPerformanceFilterErrors,
+  validateMetricValue,
+} from "@/client/features/search-performance/SearchPerformanceAdvancedFilters";
+
+describe("validateMetricValue", () => {
+  it("flags non-numeric input", () => {
+    expect(validateMetricValue("abc", "nonNegativeInt")).toBe(
+      "Enter a valid number",
+    );
+  });
+
+  it("flags negative impressions", () => {
+    expect(validateMetricValue("-1", "nonNegativeInt")).toBe(
+      "Must be 0 or greater",
+    );
+  });
+
+  it("flags non-positive position bounds", () => {
+    expect(validateMetricValue("0", "positiveNumber")).toBe(
+      "Must be greater than 0",
+    );
+  });
+});
+
+describe("getAdvancedSearchPerformanceFilterErrors", () => {
+  it("flags min greater than max", () => {
+    expect(
+      getAdvancedSearchPerformanceFilterErrors({
+        pagePath: "",
+        minImpressions: "100",
+        maxImpressions: "10",
+        minClicks: "",
+        maxClicks: "",
+        minPosition: "",
+        maxPosition: "",
+      }),
+    ).toEqual({
+      minImpressions: "Min cannot exceed max",
+      maxImpressions: "Min cannot exceed max",
+    });
+  });
+});
+
+describe("compileAdvancedSearchPerformanceFilters", () => {
+  it("keeps valid path filters when a metric field is invalid", () => {
+    expect(
+      compileAdvancedSearchPerformanceFilters({
+        pagePath: "/blogs/",
+        minImpressions: "abc",
+        maxImpressions: "",
+        minClicks: "",
+        maxClicks: "",
+        minPosition: "",
+        maxPosition: "",
+      }),
+    ).toEqual({ pagePath: "/blogs/" });
+  });
+});

--- a/src/client/features/search-performance/SearchPerformanceAdvancedFilters.test.ts
+++ b/src/client/features/search-performance/SearchPerformanceAdvancedFilters.test.ts
@@ -30,6 +30,7 @@ describe("getAdvancedSearchPerformanceFilterErrors", () => {
     expect(
       getAdvancedSearchPerformanceFilterErrors({
         pagePath: "",
+        excludePagePath: "",
         minImpressions: "100",
         maxImpressions: "10",
         minClicks: "",
@@ -49,6 +50,7 @@ describe("compileAdvancedSearchPerformanceFilters", () => {
     expect(
       compileAdvancedSearchPerformanceFilters({
         pagePath: "/blogs/",
+        excludePagePath: "/tag/",
         minImpressions: "abc",
         maxImpressions: "",
         minClicks: "",
@@ -56,6 +58,6 @@ describe("compileAdvancedSearchPerformanceFilters", () => {
         minPosition: "",
         maxPosition: "",
       }),
-    ).toEqual({ pagePath: "/blogs/" });
+    ).toEqual({ pagePath: "/blogs/", excludePagePath: "/tag/" });
   });
 });

--- a/src/client/features/search-performance/SearchPerformanceAdvancedFilters.tsx
+++ b/src/client/features/search-performance/SearchPerformanceAdvancedFilters.tsx
@@ -6,6 +6,7 @@ import {
 
 export type SearchPerformanceAdvancedFilterValues = {
   pagePath: string;
+  excludePagePath: string;
   minImpressions: string;
   maxImpressions: string;
   minClicks: string;
@@ -17,6 +18,7 @@ export type SearchPerformanceAdvancedFilterValues = {
 export const EMPTY_SEARCH_PERFORMANCE_ADVANCED_FILTERS: SearchPerformanceAdvancedFilterValues =
   {
     pagePath: "",
+    excludePagePath: "",
     minImpressions: "",
     maxImpressions: "",
     minClicks: "",
@@ -127,9 +129,11 @@ export function compileAdvancedSearchPerformanceFilters(
 ): SearchPerformanceMetricFilters {
   const errors = getAdvancedSearchPerformanceFilterErrors(values);
   const pagePath = values.pagePath.trim();
+  const excludePagePath = values.excludePagePath.trim();
   const result: SearchPerformanceMetricFilters = {};
 
   if (pagePath) result.pagePath = pagePath;
+  if (excludePagePath) result.excludePagePath = excludePagePath;
 
   if (!errors.minImpressions && !errors.maxImpressions) {
     const minImpressions = parseOptionalNonNegativeInt(values.minImpressions);
@@ -228,17 +232,20 @@ function MetricRangeField({
 export function SearchPerformanceAdvancedFilters({
   values,
   onChange,
+  onApply,
   onClear,
   activeFilterCount,
 }: {
   values: SearchPerformanceAdvancedFilterValues;
   onChange: (values: SearchPerformanceAdvancedFilterValues) => void;
+  onApply: () => void;
   onClear: () => void;
   activeFilterCount: number;
 }) {
   const errors = getAdvancedSearchPerformanceFilterErrors(values);
   const compiledFilters = compileAdvancedSearchPerformanceFilters(values);
   const metricFiltersActive = hasActiveMetricFilters(compiledFilters);
+  const canApply = Object.keys(errors).length === 0;
 
   const update = <K extends keyof SearchPerformanceAdvancedFilterValues>(
     key: K,
@@ -248,78 +255,110 @@ export function SearchPerformanceAdvancedFilters({
   };
 
   return (
-    <div className="space-y-3 rounded-lg border border-base-300 bg-base-200/40 p-3">
-      <div className="flex flex-wrap items-center justify-between gap-2">
+    <details className="rounded-lg border border-base-300 bg-base-200/40">
+      <summary className="flex cursor-pointer list-none flex-wrap items-center justify-between gap-2 p-3 [&::-webkit-details-marker]:hidden">
         <div className="text-sm font-medium">Path and metric filters</div>
-        <div className="flex items-center gap-2">
-          {activeFilterCount > 0 ? (
-            <span className="badge badge-sm badge-primary">
-              {activeFilterCount} active
+        {activeFilterCount > 0 ? (
+          <span className="badge badge-sm badge-primary">
+            {activeFilterCount} active
+          </span>
+        ) : null}
+      </summary>
+      <div className="space-y-3 border-t border-base-300 p-3">
+        <div className="grid gap-3 sm:grid-cols-2">
+          <label className="flex min-w-0 flex-col gap-1">
+            <span className="text-xs font-medium text-base-content/60">
+              Page path contains
             </span>
-          ) : null}
-          <button
-            type="button"
-            className="btn btn-ghost btn-xs"
-            onClick={onClear}
-            disabled={
-              activeFilterCount === 0 &&
-              !hasAdvancedSearchPerformanceFilterErrors(values)
-            }
-          >
-            Clear
-          </button>
+            <input
+              type="text"
+              className="input input-bordered input-sm w-full"
+              placeholder="/blogs/ or /blogs/*"
+              value={values.pagePath}
+              onChange={(event) => update("pagePath", event.target.value)}
+              aria-label="Page path contains"
+            />
+          </label>
+          <label className="flex min-w-0 flex-col gap-1">
+            <span className="text-xs font-medium text-base-content/60">
+              Page path excludes
+            </span>
+            <input
+              type="text"
+              className="input input-bordered input-sm w-full"
+              placeholder="/tag/ or /author/"
+              value={values.excludePagePath}
+              onChange={(event) =>
+                update("excludePagePath", event.target.value)
+              }
+              aria-label="Page path excludes"
+            />
+          </label>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          <MetricRangeField
+            label="Impressions"
+            minValue={values.minImpressions}
+            maxValue={values.maxImpressions}
+            minError={errors.minImpressions}
+            maxError={errors.maxImpressions}
+            onMinChange={(value) => update("minImpressions", value)}
+            onMaxChange={(value) => update("maxImpressions", value)}
+          />
+          <MetricRangeField
+            label="Clicks"
+            minValue={values.minClicks}
+            maxValue={values.maxClicks}
+            minError={errors.minClicks}
+            maxError={errors.maxClicks}
+            onMinChange={(value) => update("minClicks", value)}
+            onMaxChange={(value) => update("maxClicks", value)}
+          />
+          <MetricRangeField
+            label="Avg position"
+            minValue={values.minPosition}
+            maxValue={values.maxPosition}
+            minError={errors.minPosition}
+            maxError={errors.maxPosition}
+            onMinChange={(value) => update("minPosition", value)}
+            onMaxChange={(value) => update("maxPosition", value)}
+            inputMode="decimal"
+          />
+        </div>
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          {metricFiltersActive ? (
+            <p className="text-xs text-base-content/60">
+              Tables and exports consider up to{" "}
+              {SEARCH_PERFORMANCE_METRIC_FILTER_ROW_LIMIT.toLocaleString()} rows
+              when metric ranges are set.
+            </p>
+          ) : (
+            <span />
+          )}
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              className="btn btn-ghost btn-sm"
+              onClick={onClear}
+              disabled={
+                activeFilterCount === 0 &&
+                Object.keys(compiledFilters).length === 0 &&
+                !hasAdvancedSearchPerformanceFilterErrors(values)
+              }
+            >
+              Clear
+            </button>
+            <button
+              type="button"
+              className="btn btn-primary btn-sm"
+              onClick={onApply}
+              disabled={!canApply}
+            >
+              Apply filters
+            </button>
+          </div>
         </div>
       </div>
-      <label className="flex min-w-0 flex-col gap-1">
-        <span className="text-xs font-medium text-base-content/60">
-          Page path prefix
-        </span>
-        <input
-          type="text"
-          className="input input-bordered input-sm w-full max-w-md"
-          placeholder="/blogs/ or /blogs/*"
-          value={values.pagePath}
-          onChange={(event) => update("pagePath", event.target.value)}
-          aria-label="Page path prefix"
-        />
-      </label>
-      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-        <MetricRangeField
-          label="Impressions"
-          minValue={values.minImpressions}
-          maxValue={values.maxImpressions}
-          minError={errors.minImpressions}
-          maxError={errors.maxImpressions}
-          onMinChange={(value) => update("minImpressions", value)}
-          onMaxChange={(value) => update("maxImpressions", value)}
-        />
-        <MetricRangeField
-          label="Clicks"
-          minValue={values.minClicks}
-          maxValue={values.maxClicks}
-          minError={errors.minClicks}
-          maxError={errors.maxClicks}
-          onMinChange={(value) => update("minClicks", value)}
-          onMaxChange={(value) => update("maxClicks", value)}
-        />
-        <MetricRangeField
-          label="Avg position"
-          minValue={values.minPosition}
-          maxValue={values.maxPosition}
-          minError={errors.minPosition}
-          maxError={errors.maxPosition}
-          onMinChange={(value) => update("minPosition", value)}
-          onMaxChange={(value) => update("maxPosition", value)}
-          inputMode="decimal"
-        />
-      </div>
-      {metricFiltersActive ? (
-        <p className="text-xs text-base-content/60">
-          Tables and exports consider up to{" "}
-          {SEARCH_PERFORMANCE_METRIC_FILTER_ROW_LIMIT.toLocaleString()} rows
-          when metric ranges are set.
-        </p>
-      ) : null}
-    </div>
+    </details>
   );
 }

--- a/src/client/features/search-performance/SearchPerformanceAdvancedFilters.tsx
+++ b/src/client/features/search-performance/SearchPerformanceAdvancedFilters.tsx
@@ -1,0 +1,325 @@
+import {
+  hasActiveMetricFilters,
+  SEARCH_PERFORMANCE_METRIC_FILTER_ROW_LIMIT,
+  type SearchPerformanceMetricFilters,
+} from "@/types/schemas/search-performance";
+
+export type SearchPerformanceAdvancedFilterValues = {
+  pagePath: string;
+  minImpressions: string;
+  maxImpressions: string;
+  minClicks: string;
+  maxClicks: string;
+  minPosition: string;
+  maxPosition: string;
+};
+
+export const EMPTY_SEARCH_PERFORMANCE_ADVANCED_FILTERS: SearchPerformanceAdvancedFilterValues =
+  {
+    pagePath: "",
+    minImpressions: "",
+    maxImpressions: "",
+    minClicks: "",
+    maxClicks: "",
+    minPosition: "",
+    maxPosition: "",
+  };
+
+type MetricParseMode = "nonNegativeInt" | "positiveNumber";
+
+function parseOptionalNonNegativeInt(value: string): number | undefined {
+  if (!value.trim()) return undefined;
+  if (validateMetricValue(value, "nonNegativeInt")) return undefined;
+  return Math.trunc(Number(value));
+}
+
+function parseOptionalPositiveNumber(value: string): number | undefined {
+  if (!value.trim()) return undefined;
+  if (validateMetricValue(value, "positiveNumber")) return undefined;
+  return Number(value);
+}
+
+export function validateMetricValue(
+  value: string,
+  mode: MetricParseMode,
+): string | undefined {
+  if (!value.trim()) return undefined;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return "Enter a valid number";
+  if (mode === "nonNegativeInt" && parsed < 0) {
+    return "Must be 0 or greater";
+  }
+  if (mode === "positiveNumber" && parsed <= 0) {
+    return "Must be greater than 0";
+  }
+  return undefined;
+}
+
+function validateMetricRange(
+  minValue: string,
+  maxValue: string,
+  mode: MetricParseMode,
+): { min?: string; max?: string } {
+  const minError = validateMetricValue(minValue, mode);
+  const maxError = validateMetricValue(maxValue, mode);
+  if (minError || maxError) {
+    return {
+      ...(minError ? { min: minError } : {}),
+      ...(maxError ? { max: maxError } : {}),
+    };
+  }
+  if (!minValue.trim() || !maxValue.trim()) return {};
+
+  const min =
+    mode === "nonNegativeInt" ? Math.trunc(Number(minValue)) : Number(minValue);
+  const max =
+    mode === "nonNegativeInt" ? Math.trunc(Number(maxValue)) : Number(maxValue);
+  if (min > max) {
+    return { min: "Min cannot exceed max", max: "Min cannot exceed max" };
+  }
+  return {};
+}
+
+export function getAdvancedSearchPerformanceFilterErrors(
+  values: SearchPerformanceAdvancedFilterValues,
+): Partial<Record<keyof SearchPerformanceAdvancedFilterValues, string>> {
+  const errors: Partial<
+    Record<keyof SearchPerformanceAdvancedFilterValues, string>
+  > = {};
+
+  const impressions = validateMetricRange(
+    values.minImpressions,
+    values.maxImpressions,
+    "nonNegativeInt",
+  );
+  if (impressions.min) errors.minImpressions = impressions.min;
+  if (impressions.max) errors.maxImpressions = impressions.max;
+
+  const clicks = validateMetricRange(
+    values.minClicks,
+    values.maxClicks,
+    "nonNegativeInt",
+  );
+  if (clicks.min) errors.minClicks = clicks.min;
+  if (clicks.max) errors.maxClicks = clicks.max;
+
+  const position = validateMetricRange(
+    values.minPosition,
+    values.maxPosition,
+    "positiveNumber",
+  );
+  if (position.min) errors.minPosition = position.min;
+  if (position.max) errors.maxPosition = position.max;
+
+  return errors;
+}
+
+function hasAdvancedSearchPerformanceFilterErrors(
+  values: SearchPerformanceAdvancedFilterValues,
+): boolean {
+  return (
+    Object.keys(getAdvancedSearchPerformanceFilterErrors(values)).length > 0
+  );
+}
+
+export function compileAdvancedSearchPerformanceFilters(
+  values: SearchPerformanceAdvancedFilterValues,
+): SearchPerformanceMetricFilters {
+  const errors = getAdvancedSearchPerformanceFilterErrors(values);
+  const pagePath = values.pagePath.trim();
+  const result: SearchPerformanceMetricFilters = {};
+
+  if (pagePath) result.pagePath = pagePath;
+
+  if (!errors.minImpressions && !errors.maxImpressions) {
+    const minImpressions = parseOptionalNonNegativeInt(values.minImpressions);
+    const maxImpressions = parseOptionalNonNegativeInt(values.maxImpressions);
+    if (minImpressions !== undefined) result.minImpressions = minImpressions;
+    if (maxImpressions !== undefined) result.maxImpressions = maxImpressions;
+  }
+
+  if (!errors.minClicks && !errors.maxClicks) {
+    const minClicks = parseOptionalNonNegativeInt(values.minClicks);
+    const maxClicks = parseOptionalNonNegativeInt(values.maxClicks);
+    if (minClicks !== undefined) result.minClicks = minClicks;
+    if (maxClicks !== undefined) result.maxClicks = maxClicks;
+  }
+
+  if (!errors.minPosition && !errors.maxPosition) {
+    const minPosition = parseOptionalPositiveNumber(values.minPosition);
+    const maxPosition = parseOptionalPositiveNumber(values.maxPosition);
+    if (minPosition !== undefined) result.minPosition = minPosition;
+    if (maxPosition !== undefined) result.maxPosition = maxPosition;
+  }
+
+  return result;
+}
+
+export function countActiveAdvancedSearchPerformanceFilters(
+  values: SearchPerformanceAdvancedFilterValues,
+): number {
+  return Object.keys(compileAdvancedSearchPerformanceFilters(values)).length;
+}
+
+type MetricRangeFieldProps = {
+  label: string;
+  minValue: string;
+  maxValue: string;
+  minError?: string;
+  maxError?: string;
+  onMinChange: (value: string) => void;
+  onMaxChange: (value: string) => void;
+  minPlaceholder?: string;
+  maxPlaceholder?: string;
+  inputMode?: "numeric" | "decimal";
+};
+
+function MetricRangeField({
+  label,
+  minValue,
+  maxValue,
+  minError,
+  maxError,
+  onMinChange,
+  onMaxChange,
+  minPlaceholder = "Min",
+  maxPlaceholder = "Max",
+  inputMode = "numeric",
+}: MetricRangeFieldProps) {
+  return (
+    <div className="flex min-w-0 flex-col gap-1">
+      <span className="text-xs font-medium text-base-content/60">{label}</span>
+      <div className="flex gap-1">
+        <label className="flex min-w-0 flex-1 flex-col gap-1">
+          <input
+            type="text"
+            inputMode={inputMode}
+            className={`input input-bordered input-sm w-full min-w-0 ${minError ? "input-error" : ""}`}
+            placeholder={minPlaceholder}
+            value={minValue}
+            onChange={(event) => onMinChange(event.target.value)}
+            aria-label={`${label} minimum`}
+            aria-invalid={minError ? true : undefined}
+          />
+          {minError ? (
+            <span className="text-xs text-error">{minError}</span>
+          ) : null}
+        </label>
+        <label className="flex min-w-0 flex-1 flex-col gap-1">
+          <input
+            type="text"
+            inputMode={inputMode}
+            className={`input input-bordered input-sm w-full min-w-0 ${maxError ? "input-error" : ""}`}
+            placeholder={maxPlaceholder}
+            value={maxValue}
+            onChange={(event) => onMaxChange(event.target.value)}
+            aria-label={`${label} maximum`}
+            aria-invalid={maxError ? true : undefined}
+          />
+          {maxError ? (
+            <span className="text-xs text-error">{maxError}</span>
+          ) : null}
+        </label>
+      </div>
+    </div>
+  );
+}
+
+export function SearchPerformanceAdvancedFilters({
+  values,
+  onChange,
+  onClear,
+  activeFilterCount,
+}: {
+  values: SearchPerformanceAdvancedFilterValues;
+  onChange: (values: SearchPerformanceAdvancedFilterValues) => void;
+  onClear: () => void;
+  activeFilterCount: number;
+}) {
+  const errors = getAdvancedSearchPerformanceFilterErrors(values);
+  const compiledFilters = compileAdvancedSearchPerformanceFilters(values);
+  const metricFiltersActive = hasActiveMetricFilters(compiledFilters);
+
+  const update = <K extends keyof SearchPerformanceAdvancedFilterValues>(
+    key: K,
+    value: SearchPerformanceAdvancedFilterValues[K],
+  ) => {
+    onChange({ ...values, [key]: value });
+  };
+
+  return (
+    <div className="space-y-3 rounded-lg border border-base-300 bg-base-200/40 p-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="text-sm font-medium">Path and metric filters</div>
+        <div className="flex items-center gap-2">
+          {activeFilterCount > 0 ? (
+            <span className="badge badge-sm badge-primary">
+              {activeFilterCount} active
+            </span>
+          ) : null}
+          <button
+            type="button"
+            className="btn btn-ghost btn-xs"
+            onClick={onClear}
+            disabled={
+              activeFilterCount === 0 &&
+              !hasAdvancedSearchPerformanceFilterErrors(values)
+            }
+          >
+            Clear
+          </button>
+        </div>
+      </div>
+      <label className="flex min-w-0 flex-col gap-1">
+        <span className="text-xs font-medium text-base-content/60">
+          Page path prefix
+        </span>
+        <input
+          type="text"
+          className="input input-bordered input-sm w-full max-w-md"
+          placeholder="/blogs/ or /blogs/*"
+          value={values.pagePath}
+          onChange={(event) => update("pagePath", event.target.value)}
+          aria-label="Page path prefix"
+        />
+      </label>
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        <MetricRangeField
+          label="Impressions"
+          minValue={values.minImpressions}
+          maxValue={values.maxImpressions}
+          minError={errors.minImpressions}
+          maxError={errors.maxImpressions}
+          onMinChange={(value) => update("minImpressions", value)}
+          onMaxChange={(value) => update("maxImpressions", value)}
+        />
+        <MetricRangeField
+          label="Clicks"
+          minValue={values.minClicks}
+          maxValue={values.maxClicks}
+          minError={errors.minClicks}
+          maxError={errors.maxClicks}
+          onMinChange={(value) => update("minClicks", value)}
+          onMaxChange={(value) => update("maxClicks", value)}
+        />
+        <MetricRangeField
+          label="Avg position"
+          minValue={values.minPosition}
+          maxValue={values.maxPosition}
+          minError={errors.minPosition}
+          maxError={errors.maxPosition}
+          onMinChange={(value) => update("minPosition", value)}
+          onMaxChange={(value) => update("maxPosition", value)}
+          inputMode="decimal"
+        />
+      </div>
+      {metricFiltersActive ? (
+        <p className="text-xs text-base-content/60">
+          Tables and exports consider up to{" "}
+          {SEARCH_PERFORMANCE_METRIC_FILTER_ROW_LIMIT.toLocaleString()} rows
+          when metric ranges are set.
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/client/features/search-performance/SearchPerformancePage.tsx
+++ b/src/client/features/search-performance/SearchPerformancePage.tsx
@@ -150,8 +150,9 @@ export function SearchPerformancePage({ projectId }: { projectId: string }) {
     useState<SearchPerformanceAdvancedFilterValues>(
       EMPTY_SEARCH_PERFORMANCE_ADVANCED_FILTERS,
     );
-  const activeAdvancedFilterCount =
-    countActiveAdvancedSearchPerformanceFilters(appliedAdvancedFilters);
+  const activeAdvancedFilterCount = countActiveAdvancedSearchPerformanceFilters(
+    appliedAdvancedFilters,
+  );
 
   // Any change to the query set (tab, filters, page size) restarts at page 1.
   useEffect(() => {
@@ -164,20 +165,10 @@ export function SearchPerformancePage({ projectId }: { projectId: string }) {
     country,
     appliedAdvancedFilters,
   );
-  const compiledAdvancedFilters = compileAdvancedSearchPerformanceFilters(
-    appliedAdvancedFilters,
-  );
   const metricFiltersActive = hasActiveMetricFilters(filterInput);
 
   const reportQuery = useQuery({
-    queryKey: [
-      "searchPerformance",
-      projectId,
-      range,
-      device,
-      country,
-      compiledAdvancedFilters,
-    ],
+    queryKey: ["searchPerformance", projectId, filterInput],
     queryFn: () =>
       getSearchPerformanceReport({ data: { projectId, ...filterInput } }),
     placeholderData: keepPreviousData,
@@ -354,9 +345,7 @@ export function SearchPerformancePage({ projectId }: { projectId: string }) {
                 <SearchPerformanceAdvancedFilters
                   values={advancedFilterDraft}
                   onChange={setAdvancedFilterDraft}
-                  onApply={() =>
-                    setAppliedAdvancedFilters(advancedFilterDraft)
-                  }
+                  onApply={() => setAppliedAdvancedFilters(advancedFilterDraft)}
                   onClear={() => {
                     setAdvancedFilterDraft(
                       EMPTY_SEARCH_PERFORMANCE_ADVANCED_FILTERS,

--- a/src/client/features/search-performance/SearchPerformancePage.tsx
+++ b/src/client/features/search-performance/SearchPerformancePage.tsx
@@ -13,6 +13,13 @@ import { TablePagination } from "@/client/components/table/TablePagination";
 import { SearchConsoleConnectionCard } from "@/client/features/gsc/SearchConsoleConnectionCard";
 import { SearchPerformanceLoadingState } from "@/client/features/search-performance/SearchPerformanceLoadingState";
 import {
+  compileAdvancedSearchPerformanceFilters,
+  countActiveAdvancedSearchPerformanceFilters,
+  EMPTY_SEARCH_PERFORMANCE_ADVANCED_FILTERS,
+  SearchPerformanceAdvancedFilters,
+  type SearchPerformanceAdvancedFilterValues,
+} from "@/client/features/search-performance/SearchPerformanceAdvancedFilters";
+import {
   DimensionTable,
   exportDimensionRows,
   exportStriking,
@@ -30,11 +37,14 @@ import {
 } from "@/serverFunctions/searchPerformance";
 import {
   GSC_DEVICES,
+  hasActiveMetricFilters,
   SEARCH_PERFORMANCE_DEFAULT_PAGE_SIZE,
+  SEARCH_PERFORMANCE_METRIC_FILTER_ROW_LIMIT,
   SEARCH_PERFORMANCE_PAGE_SIZES,
   SEARCH_PERFORMANCE_RANGES,
   type SearchPerformanceDateRange,
   type SearchPerformanceDevice,
+  type SearchPerformanceMetricFilters,
   type SearchPerformanceTableDimension,
 } from "@/types/schemas/search-performance";
 
@@ -77,18 +87,20 @@ type FilterInput = {
   dateRange: SearchPerformanceDateRange;
   device?: SearchPerformanceDevice;
   country?: string;
-};
+} & SearchPerformanceMetricFilters;
 
 // The server filter payload: drop device/country when set to the "ALL" sentinel.
 function buildFilterInput(
   range: SearchPerformanceDateRange,
   device: SearchPerformanceDevice | typeof ALL,
   country: string,
+  advanced: SearchPerformanceAdvancedFilterValues,
 ): FilterInput {
   return {
     dateRange: range,
     ...(device === ALL ? {} : { device }),
     ...(country === ALL ? {} : { country }),
+    ...compileAdvancedSearchPerformanceFilters(advanced),
   };
 }
 
@@ -130,16 +142,30 @@ export function SearchPerformancePage({ projectId }: { projectId: string }) {
   const [pageSize, setPageSize] = useState<number>(
     SEARCH_PERFORMANCE_DEFAULT_PAGE_SIZE,
   );
+  const [advancedFilters, setAdvancedFilters] =
+    useState<SearchPerformanceAdvancedFilterValues>(
+      EMPTY_SEARCH_PERFORMANCE_ADVANCED_FILTERS,
+    );
+  const activeAdvancedFilterCount =
+    countActiveAdvancedSearchPerformanceFilters(advancedFilters);
 
   // Any change to the query set (tab, filters, page size) restarts at page 1.
   useEffect(() => {
     setPage(1);
-  }, [tab, range, device, country, pageSize]);
+  }, [tab, range, device, country, pageSize, advancedFilters]);
 
-  const filterInput = buildFilterInput(range, device, country);
+  const filterInput = buildFilterInput(range, device, country, advancedFilters);
+  const metricFiltersActive = hasActiveMetricFilters(filterInput);
 
   const reportQuery = useQuery({
-    queryKey: ["searchPerformance", projectId, range, device, country],
+    queryKey: [
+      "searchPerformance",
+      projectId,
+      range,
+      device,
+      country,
+      advancedFilters,
+    ],
     queryFn: () =>
       getSearchPerformanceReport({ data: { projectId, ...filterInput } }),
     placeholderData: keepPreviousData,
@@ -167,10 +193,18 @@ export function SearchPerformancePage({ projectId }: { projectId: string }) {
         "query",
         1,
         SEARCH_PERFORMANCE_DEFAULT_PAGE_SIZE,
-        buildFilterInput(range, device, country),
+        buildFilterInput(range, device, country, advancedFilters),
       ),
     );
-  }, [report?.connected, projectId, range, device, country, queryClient]);
+  }, [
+    report?.connected,
+    projectId,
+    range,
+    device,
+    country,
+    advancedFilters,
+    queryClient,
+  ]);
 
   const handleExport = async (target: ExportTarget) => {
     if (!report?.connected) return;
@@ -226,6 +260,14 @@ export function SearchPerformancePage({ projectId }: { projectId: string }) {
         ) : (
           <>
             <TotalsCards report={report} />
+            <SearchPerformanceAdvancedFilters
+              values={advancedFilters}
+              onChange={setAdvancedFilters}
+              onClear={() =>
+                setAdvancedFilters(EMPTY_SEARCH_PERFORMANCE_ADVANCED_FILTERS)
+              }
+              activeFilterCount={activeAdvancedFilterCount}
+            />
             <div className="overflow-hidden rounded-xl border border-base-300 bg-base-100">
               <div className="flex flex-col gap-3 border-b border-base-300 px-4 py-3 lg:flex-row lg:items-center lg:justify-between">
                 <div role="tablist" className="tabs tabs-border w-fit">
@@ -314,10 +356,16 @@ export function SearchPerformancePage({ projectId }: { projectId: string }) {
               </div>
 
               {tab === "striking" ? (
-                <StrikingDistanceTable
-                  projectId={projectId}
-                  rows={report.strikingDistance}
-                />
+                report.strikingDistance.length === 0 ? (
+                  <p className="p-4 text-sm text-base-content/60">
+                    No rows match these filters.
+                  </p>
+                ) : (
+                  <StrikingDistanceTable
+                    projectId={projectId}
+                    rows={report.strikingDistance}
+                  />
+                )
               ) : tableQuery.isPending ? (
                 <div className="flex items-center gap-2 p-8 text-sm text-base-content/60">
                   <Loader2 className="size-4 animate-spin" /> Loading…
@@ -333,10 +381,16 @@ export function SearchPerformancePage({ projectId }: { projectId: string }) {
               ) : (
                 <>
                   <div className="p-4">
-                    <DimensionTable
-                      rows={tableRows}
-                      keyLabel={tab === "queries" ? "Query" : "Page"}
-                    />
+                    {tableRows.length === 0 ? (
+                      <p className="text-sm text-base-content/60">
+                        No rows match these filters.
+                      </p>
+                    ) : (
+                      <DimensionTable
+                        rows={tableRows}
+                        keyLabel={tab === "queries" ? "Query" : "Page"}
+                      />
+                    )}
                   </div>
                   <TablePagination
                     page={page}
@@ -348,6 +402,13 @@ export function SearchPerformancePage({ projectId }: { projectId: string }) {
                     onPageChange={setPage}
                     onPageSizeChange={setPageSize}
                   />
+                  {metricFiltersActive ? (
+                    <p className="border-t border-base-300 px-4 py-2 text-xs text-base-content/60">
+                      Pagination and export use up to{" "}
+                      {SEARCH_PERFORMANCE_METRIC_FILTER_ROW_LIMIT.toLocaleString()}{" "}
+                      matching rows when metric ranges are set.
+                    </p>
+                  ) : null}
                 </>
               )}
             </div>

--- a/src/client/features/search-performance/SearchPerformancePage.tsx
+++ b/src/client/features/search-performance/SearchPerformancePage.tsx
@@ -155,6 +155,8 @@ export function SearchPerformancePage({ projectId }: { projectId: string }) {
   }, [tab, range, device, country, pageSize, advancedFilters]);
 
   const filterInput = buildFilterInput(range, device, country, advancedFilters);
+  const compiledAdvancedFilters =
+    compileAdvancedSearchPerformanceFilters(advancedFilters);
   const metricFiltersActive = hasActiveMetricFilters(filterInput);
 
   const reportQuery = useQuery({
@@ -164,7 +166,7 @@ export function SearchPerformancePage({ projectId }: { projectId: string }) {
       range,
       device,
       country,
-      advancedFilters,
+      compiledAdvancedFilters,
     ],
     queryFn: () =>
       getSearchPerformanceReport({ data: { projectId, ...filterInput } }),
@@ -193,18 +195,10 @@ export function SearchPerformancePage({ projectId }: { projectId: string }) {
         "query",
         1,
         SEARCH_PERFORMANCE_DEFAULT_PAGE_SIZE,
-        buildFilterInput(range, device, country, advancedFilters),
+        filterInput,
       ),
     );
-  }, [
-    report?.connected,
-    projectId,
-    range,
-    device,
-    country,
-    advancedFilters,
-    queryClient,
-  ]);
+  }, [report?.connected, projectId, filterInput, queryClient]);
 
   const handleExport = async (target: ExportTarget) => {
     if (!report?.connected) return;

--- a/src/client/features/search-performance/SearchPerformancePage.tsx
+++ b/src/client/features/search-performance/SearchPerformancePage.tsx
@@ -142,21 +142,31 @@ export function SearchPerformancePage({ projectId }: { projectId: string }) {
   const [pageSize, setPageSize] = useState<number>(
     SEARCH_PERFORMANCE_DEFAULT_PAGE_SIZE,
   );
-  const [advancedFilters, setAdvancedFilters] =
+  const [advancedFilterDraft, setAdvancedFilterDraft] =
+    useState<SearchPerformanceAdvancedFilterValues>(
+      EMPTY_SEARCH_PERFORMANCE_ADVANCED_FILTERS,
+    );
+  const [appliedAdvancedFilters, setAppliedAdvancedFilters] =
     useState<SearchPerformanceAdvancedFilterValues>(
       EMPTY_SEARCH_PERFORMANCE_ADVANCED_FILTERS,
     );
   const activeAdvancedFilterCount =
-    countActiveAdvancedSearchPerformanceFilters(advancedFilters);
+    countActiveAdvancedSearchPerformanceFilters(appliedAdvancedFilters);
 
   // Any change to the query set (tab, filters, page size) restarts at page 1.
   useEffect(() => {
     setPage(1);
-  }, [tab, range, device, country, pageSize, advancedFilters]);
+  }, [tab, range, device, country, pageSize, appliedAdvancedFilters]);
 
-  const filterInput = buildFilterInput(range, device, country, advancedFilters);
-  const compiledAdvancedFilters =
-    compileAdvancedSearchPerformanceFilters(advancedFilters);
+  const filterInput = buildFilterInput(
+    range,
+    device,
+    country,
+    appliedAdvancedFilters,
+  );
+  const compiledAdvancedFilters = compileAdvancedSearchPerformanceFilters(
+    appliedAdvancedFilters,
+  );
   const metricFiltersActive = hasActiveMetricFilters(filterInput);
 
   const reportQuery = useQuery({
@@ -254,14 +264,6 @@ export function SearchPerformancePage({ projectId }: { projectId: string }) {
         ) : (
           <>
             <TotalsCards report={report} />
-            <SearchPerformanceAdvancedFilters
-              values={advancedFilters}
-              onChange={setAdvancedFilters}
-              onClear={() =>
-                setAdvancedFilters(EMPTY_SEARCH_PERFORMANCE_ADVANCED_FILTERS)
-              }
-              activeFilterCount={activeAdvancedFilterCount}
-            />
             <div className="overflow-hidden rounded-xl border border-base-300 bg-base-100">
               <div className="flex flex-col gap-3 border-b border-base-300 px-4 py-3 lg:flex-row lg:items-center lg:justify-between">
                 <div role="tablist" className="tabs tabs-border w-fit">
@@ -347,6 +349,24 @@ export function SearchPerformancePage({ projectId }: { projectId: string }) {
                     ]}
                   />
                 </div>
+              </div>
+              <div className="border-b border-base-300 px-4 py-3">
+                <SearchPerformanceAdvancedFilters
+                  values={advancedFilterDraft}
+                  onChange={setAdvancedFilterDraft}
+                  onApply={() =>
+                    setAppliedAdvancedFilters(advancedFilterDraft)
+                  }
+                  onClear={() => {
+                    setAdvancedFilterDraft(
+                      EMPTY_SEARCH_PERFORMANCE_ADVANCED_FILTERS,
+                    );
+                    setAppliedAdvancedFilters(
+                      EMPTY_SEARCH_PERFORMANCE_ADVANCED_FILTERS,
+                    );
+                  }}
+                  activeFilterCount={activeAdvancedFilterCount}
+                />
               </div>
 
               {tab === "striking" ? (

--- a/src/client/features/search-performance/SearchPerformanceParts.tsx
+++ b/src/client/features/search-performance/SearchPerformanceParts.tsx
@@ -158,31 +158,39 @@ export function TotalsCards({ report }: { report: Report }) {
   const { totals, prevTotals, range } = report;
   const deltaTitle = `vs ${range.prevStartDate} to ${range.prevEndDate}`;
   return (
-    <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
-      <TotalCard
-        label="Clicks"
-        value={formatCount(totals.clicks)}
-        delta={percentDelta(totals.clicks, prevTotals.clicks)}
-        deltaTitle={deltaTitle}
-      />
-      <TotalCard
-        label="Impressions"
-        value={formatCount(totals.impressions)}
-        delta={percentDelta(totals.impressions, prevTotals.impressions)}
-        deltaTitle={deltaTitle}
-      />
-      <TotalCard
-        label="CTR"
-        value={formatCtr(totals.ctr)}
-        delta={percentDelta(totals.ctr, prevTotals.ctr)}
-        deltaTitle={deltaTitle}
-      />
-      <TotalCard
-        label="Avg position"
-        value={formatPosition(totals.position)}
-        delta={positionDelta(totals.position, prevTotals.position)}
-        deltaTitle={deltaTitle}
-      />
+    <div className="space-y-2">
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+        <TotalCard
+          label="Clicks"
+          value={formatCount(totals.clicks)}
+          delta={percentDelta(totals.clicks, prevTotals.clicks)}
+          deltaTitle={deltaTitle}
+        />
+        <TotalCard
+          label="Impressions"
+          value={formatCount(totals.impressions)}
+          delta={percentDelta(totals.impressions, prevTotals.impressions)}
+          deltaTitle={deltaTitle}
+        />
+        <TotalCard
+          label="CTR"
+          value={formatCtr(totals.ctr)}
+          delta={percentDelta(totals.ctr, prevTotals.ctr)}
+          deltaTitle={deltaTitle}
+        />
+        <TotalCard
+          label="Avg position"
+          value={formatPosition(totals.position)}
+          delta={positionDelta(totals.position, prevTotals.position)}
+          deltaTitle={deltaTitle}
+        />
+      </div>
+      {report.metricFiltersActive ? (
+        <p className="text-xs text-base-content/60">
+          Totals reflect date, device, country, and page-path filters. Metric
+          ranges apply to tables and exports only.
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/src/server/features/gsc/searchPerformanceFilters.test.ts
+++ b/src/server/features/gsc/searchPerformanceFilters.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import {
+  filterDimensionRowsByMetrics,
+  filterStrikingDistanceByMetrics,
+  matchesMetricFilters,
+  normalizePagePathFilter,
+  paginateRows,
+  toPagePathGscFilter,
+} from "@/server/features/gsc/searchPerformanceFilters";
+
+describe("normalizePagePathFilter", () => {
+  it("strips a trailing wildcard", () => {
+    expect(normalizePagePathFilter("/blogs/*")).toBe("/blogs/");
+  });
+
+  it("keeps full URL fragments", () => {
+    expect(normalizePagePathFilter("https://example.com/tools")).toBe(
+      "https://example.com/tools",
+    );
+  });
+
+  it("returns undefined for blank input", () => {
+    expect(normalizePagePathFilter("  ")).toBeUndefined();
+  });
+});
+
+describe("toPagePathGscFilter", () => {
+  it("maps to a GSC page contains filter", () => {
+    expect(toPagePathGscFilter("/blogs/*")).toEqual({
+      dimension: "page",
+      operator: "contains",
+      expression: "/blogs/",
+    });
+  });
+});
+
+describe("matchesMetricFilters", () => {
+  const row = { clicks: 10, impressions: 100, position: 8 };
+
+  it("excludes rows below the impressions minimum", () => {
+    expect(matchesMetricFilters(row, { minImpressions: 101 })).toBe(false);
+  });
+
+  it("includes rows within position bounds", () => {
+    expect(matchesMetricFilters(row, { minPosition: 4, maxPosition: 10 })).toBe(
+      true,
+    );
+  });
+
+  it("passes all rows when no bounds are set", () => {
+    expect(matchesMetricFilters(row, {})).toBe(true);
+  });
+});
+
+describe("filterDimensionRowsByMetrics", () => {
+  it("filters dimension rows before pagination", () => {
+    const rows = [
+      {
+        key: "a",
+        clicks: 1,
+        impressions: 50,
+        ctr: 0.02,
+        position: 5,
+      },
+      {
+        key: "b",
+        clicks: 2,
+        impressions: 200,
+        ctr: 0.01,
+        position: 6,
+      },
+    ];
+
+    expect(
+      filterDimensionRowsByMetrics(rows, { minImpressions: 100 }).map(
+        (row) => row.key,
+      ),
+    ).toEqual(["b"]);
+  });
+});
+
+describe("paginateRows", () => {
+  it("slices filtered rows before returning a page", () => {
+    const rows = Array.from({ length: 30 }, (_, index) => index + 1);
+    const page1 = paginateRows(rows, 1, 25);
+    expect(page1.rows).toHaveLength(25);
+    expect(page1.hasNextPage).toBe(true);
+
+    const page2 = paginateRows(rows, 2, 25);
+    expect(page2.rows).toEqual([26, 27, 28, 29, 30]);
+    expect(page2.hasNextPage).toBe(false);
+  });
+});
+
+describe("filterStrikingDistanceByMetrics", () => {
+  it("filters striking-distance rows by metrics", () => {
+    const rows = [
+      {
+        query: "kw",
+        page: "https://x.com/a",
+        clicks: 1,
+        impressions: 20,
+        position: 12,
+      },
+    ];
+
+    expect(
+      filterStrikingDistanceByMetrics(rows, { minImpressions: 100 }),
+    ).toEqual([]);
+  });
+});

--- a/src/server/features/gsc/searchPerformanceFilters.ts
+++ b/src/server/features/gsc/searchPerformanceFilters.ts
@@ -1,0 +1,96 @@
+import type { GscPerformanceFilter } from "@/server/features/gsc/searchAnalytics";
+import type { SearchPerformanceMetricFilters } from "@/types/schemas/search-performance";
+
+type MetricFilterableRow = {
+  clicks: number;
+  impressions: number;
+  position: number;
+};
+
+type SearchPerformanceDimensionRow = MetricFilterableRow & {
+  key: string;
+  ctr: number;
+};
+
+type StrikingDistanceFilterableRow = MetricFilterableRow & {
+  query: string;
+  page: string;
+};
+
+/** Strip trailing wildcard and whitespace from a user-entered path prefix. */
+export function normalizePagePathFilter(
+  input: string | undefined,
+): string | undefined {
+  if (!input?.trim()) return undefined;
+  let normalized = input.trim();
+  if (normalized.endsWith("*")) {
+    normalized = normalized.slice(0, -1).trimEnd();
+  }
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+export function toPagePathGscFilter(pagePath: string): GscPerformanceFilter {
+  const expression = normalizePagePathFilter(pagePath);
+  if (!expression) {
+    throw new Error("Page path filter requires a non-empty expression");
+  }
+  return { dimension: "page", operator: "contains", expression };
+}
+
+export function matchesMetricFilters(
+  row: MetricFilterableRow,
+  filters: SearchPerformanceMetricFilters,
+): boolean {
+  if (
+    filters.minImpressions !== undefined &&
+    row.impressions < filters.minImpressions
+  ) {
+    return false;
+  }
+  if (
+    filters.maxImpressions !== undefined &&
+    row.impressions > filters.maxImpressions
+  ) {
+    return false;
+  }
+  if (filters.minClicks !== undefined && row.clicks < filters.minClicks) {
+    return false;
+  }
+  if (filters.maxClicks !== undefined && row.clicks > filters.maxClicks) {
+    return false;
+  }
+  if (filters.minPosition !== undefined && row.position < filters.minPosition) {
+    return false;
+  }
+  if (filters.maxPosition !== undefined && row.position > filters.maxPosition) {
+    return false;
+  }
+  return true;
+}
+
+export function filterDimensionRowsByMetrics(
+  rows: SearchPerformanceDimensionRow[],
+  filters: SearchPerformanceMetricFilters,
+): SearchPerformanceDimensionRow[] {
+  return rows.filter((row) => matchesMetricFilters(row, filters));
+}
+
+export function filterStrikingDistanceByMetrics(
+  rows: StrikingDistanceFilterableRow[],
+  filters: SearchPerformanceMetricFilters,
+): StrikingDistanceFilterableRow[] {
+  return rows.filter((row) => matchesMetricFilters(row, filters));
+}
+
+export function paginateRows<T>(
+  rows: T[],
+  page: number,
+  pageSize: number,
+): { rows: T[]; hasNextPage: boolean } {
+  const offset = (page - 1) * pageSize;
+  const pageRows = rows.slice(offset, offset + pageSize);
+  return {
+    rows: pageRows,
+    hasNextPage: offset + pageSize < rows.length,
+  };
+}

--- a/src/serverFunctions/searchPerformance.ts
+++ b/src/serverFunctions/searchPerformance.ts
@@ -14,11 +14,23 @@ import {
   sumSearchTotals,
   toDimensionRows,
 } from "@/server/features/gsc/searchPerformanceReport";
+import {
+  filterDimensionRowsByMetrics,
+  filterStrikingDistanceByMetrics,
+  normalizePagePathFilter,
+  paginateRows,
+  toPagePathGscFilter,
+} from "@/server/features/gsc/searchPerformanceFilters";
 import { requireProjectContext } from "@/serverFunctions/middleware";
 import {
+  hasActiveMetricFilters,
   searchPerformanceInputSchema,
   searchPerformanceTableExportInputSchema,
   searchPerformanceTableInputSchema,
+  SEARCH_PERFORMANCE_METRIC_FILTER_ROW_LIMIT,
+  type SearchPerformanceDateRange,
+  type SearchPerformanceMetricFilters,
+  type SearchPerformanceTableDimension,
 } from "@/types/schemas/search-performance";
 
 // query x page fan-out needs more rows to find the 5..20 band.
@@ -28,25 +40,57 @@ const DAILY_ROW_LIMIT = 200;
 const COUNTRY_ROW_LIMIT = 25;
 // Export pulls the whole dimension in one shot, capped at GSC's per-call max
 // (GSC_MAX_ROW_LIMIT). Large stores get everything up to this ceiling.
-const EXPORT_ROW_LIMIT = 1000;
+const EXPORT_ROW_LIMIT = SEARCH_PERFORMANCE_METRIC_FILTER_ROW_LIMIT;
 
 /** Build GSC filter groups shared by every call. Device applies everywhere;
  *  country applies everywhere except the country breakdown itself (so the
- *  dropdown keeps every option visible while one country is selected). */
-function buildGscFilters(data: { device?: string; country?: string }): {
+ *  dropdown keeps every option visible while one country is selected).
+ *  Page path applies as a `page` contains filter when set. */
+function buildGscFilters(data: {
+  device?: string;
+  country?: string;
+  pagePath?: string;
+}): {
   deviceFilters: GscPerformanceFilter[];
   filters: GscPerformanceFilter[];
 } {
   const deviceFilters: GscPerformanceFilter[] = data.device
     ? [{ dimension: "device", operator: "equals", expression: data.device }]
     : [];
+  const pagePath = normalizePagePathFilter(data.pagePath);
+  const pageFilters: GscPerformanceFilter[] = pagePath
+    ? [toPagePathGscFilter(pagePath)]
+    : [];
   const filters: GscPerformanceFilter[] = data.country
     ? [
         ...deviceFilters,
+        ...pageFilters,
         { dimension: "country", operator: "equals", expression: data.country },
       ]
-    : deviceFilters;
+    : [...deviceFilters, ...pageFilters];
   return { deviceFilters, filters };
+}
+
+async function fetchFilteredDimensionRows(
+  data: SearchPerformanceMetricFilters & {
+    dateRange: SearchPerformanceDateRange;
+    dimension: SearchPerformanceTableDimension;
+  },
+  contextProjectId: string,
+) {
+  const { startDate, endDate } = resolveDateRange({
+    dateRange: data.dateRange,
+  });
+  const { filters } = buildGscFilters(data);
+  const result = await GscService.getPerformance({
+    projectId: contextProjectId,
+    startDate,
+    endDate,
+    dimensions: [data.dimension],
+    filters,
+    rowLimit: EXPORT_ROW_LIMIT,
+  });
+  return filterDimensionRowsByMetrics(toDimensionRows(result.rows), data);
 }
 
 /** Not connected, or a dead/denied grant (token failure or 401/403): the page
@@ -72,6 +116,7 @@ export const getSearchPerformanceReport = createServerFn({ method: "POST" })
     const prev = previousPeriod(startDate, endDate);
     const projectId = context.projectId;
     const { deviceFilters, filters } = buildGscFilters(data);
+    const metricFiltersActive = hasActiveMetricFilters(data);
 
     try {
       const [current, previous, queryPages, countries] = await Promise.all([
@@ -111,6 +156,7 @@ export const getSearchPerformanceReport = createServerFn({ method: "POST" })
 
       return {
         connected: true as const,
+        metricFiltersActive,
         range: {
           startDate,
           endDate,
@@ -119,7 +165,10 @@ export const getSearchPerformanceReport = createServerFn({ method: "POST" })
         },
         totals: sumSearchTotals(current.rows),
         prevTotals: sumSearchTotals(previous.rows),
-        strikingDistance: buildStrikingDistanceRows(queryPages.rows),
+        strikingDistance: filterStrikingDistanceByMetrics(
+          buildStrikingDistanceRows(queryPages.rows),
+          data,
+        ),
         countries: toDimensionRows(countries.rows),
       };
     } catch (error) {
@@ -143,9 +192,31 @@ export const getSearchPerformanceTable = createServerFn({ method: "POST" })
       dateRange: data.dateRange,
     });
     const { filters } = buildGscFilters(data);
-    const offset = (data.page - 1) * data.pageSize;
 
     try {
+      if (hasActiveMetricFilters(data)) {
+        const filteredRows = await fetchFilteredDimensionRows(
+          data,
+          context.projectId,
+        );
+        const { rows, hasNextPage } = paginateRows(
+          filteredRows,
+          data.page,
+          data.pageSize,
+        );
+
+        return {
+          connected: true as const,
+          dimension: data.dimension,
+          page: data.page,
+          pageSize: data.pageSize,
+          hasNextPage,
+          rows,
+        };
+      }
+
+      const offset = (data.page - 1) * data.pageSize;
+
       const result = await GscService.getPerformance({
         projectId: context.projectId,
         startDate,
@@ -185,22 +256,13 @@ export const exportSearchPerformanceTable = createServerFn({ method: "POST" })
   .middleware(requireProjectContext)
   .validator(searchPerformanceTableExportInputSchema)
   .handler(async ({ data, context }) => {
-    const { startDate, endDate } = resolveDateRange({
-      dateRange: data.dateRange,
-    });
-    const { filters } = buildGscFilters(data);
-
-    const result = await GscService.getPerformance({
-      projectId: context.projectId,
-      startDate,
-      endDate,
-      dimensions: [data.dimension],
-      filters,
-      rowLimit: EXPORT_ROW_LIMIT,
-    });
+    const filteredRows = await fetchFilteredDimensionRows(
+      data,
+      context.projectId,
+    );
 
     return {
       dimension: data.dimension,
-      rows: toDimensionRows(result.rows),
+      rows: filteredRows,
     };
   });

--- a/src/serverFunctions/searchPerformance.ts
+++ b/src/serverFunctions/searchPerformance.ts
@@ -63,7 +63,12 @@ function buildGscFilters(data: {
   const pageFilters: GscPerformanceFilter[] = [
     ...(pagePath ? [toPagePathGscFilter(pagePath)] : []),
     ...(excludePagePath
-      ? [{ ...toPagePathGscFilter(excludePagePath), operator: "notContains" }]
+      ? [
+          {
+            ...toPagePathGscFilter(excludePagePath),
+            operator: "notContains" as const,
+          },
+        ]
       : []),
   ];
   const filters: GscPerformanceFilter[] = data.country

--- a/src/serverFunctions/searchPerformance.ts
+++ b/src/serverFunctions/searchPerformance.ts
@@ -50,6 +50,7 @@ function buildGscFilters(data: {
   device?: string;
   country?: string;
   pagePath?: string;
+  excludePagePath?: string;
 }): {
   deviceFilters: GscPerformanceFilter[];
   filters: GscPerformanceFilter[];
@@ -58,9 +59,13 @@ function buildGscFilters(data: {
     ? [{ dimension: "device", operator: "equals", expression: data.device }]
     : [];
   const pagePath = normalizePagePathFilter(data.pagePath);
-  const pageFilters: GscPerformanceFilter[] = pagePath
-    ? [toPagePathGscFilter(pagePath)]
-    : [];
+  const excludePagePath = normalizePagePathFilter(data.excludePagePath);
+  const pageFilters: GscPerformanceFilter[] = [
+    ...(pagePath ? [toPagePathGscFilter(pagePath)] : []),
+    ...(excludePagePath
+      ? [{ ...toPagePathGscFilter(excludePagePath), operator: "notContains" }]
+      : []),
+  ];
   const filters: GscPerformanceFilter[] = data.country
     ? [
         ...deviceFilters,
@@ -75,7 +80,6 @@ async function fetchFilteredDimensionRows(
   data: SearchPerformanceMetricFilters & {
     dateRange: SearchPerformanceDateRange;
     dimension: SearchPerformanceTableDimension;
-    // These preserve the report-level GSC scope for table and export fetches.
     device?: string;
     country?: string;
   },

--- a/src/serverFunctions/searchPerformance.ts
+++ b/src/serverFunctions/searchPerformance.ts
@@ -75,6 +75,8 @@ async function fetchFilteredDimensionRows(
   data: SearchPerformanceMetricFilters & {
     dateRange: SearchPerformanceDateRange;
     dimension: SearchPerformanceTableDimension;
+    device?: string;
+    country?: string;
   },
   contextProjectId: string,
 ) {

--- a/src/serverFunctions/searchPerformance.ts
+++ b/src/serverFunctions/searchPerformance.ts
@@ -75,6 +75,7 @@ async function fetchFilteredDimensionRows(
   data: SearchPerformanceMetricFilters & {
     dateRange: SearchPerformanceDateRange;
     dimension: SearchPerformanceTableDimension;
+    // These preserve the report-level GSC scope for table and export fetches.
     device?: string;
     country?: string;
   },

--- a/src/types/schemas/search-performance.test.ts
+++ b/src/types/schemas/search-performance.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  hasActiveMetricFilters,
+  searchPerformanceInputSchema,
+  searchPerformanceTableInputSchema,
+} from "@/types/schemas/search-performance";
+
+describe("searchPerformanceInputSchema", () => {
+  it("accepts page path and partial metric ranges", () => {
+    const parsed = searchPerformanceInputSchema.parse({
+      projectId: "p1",
+      pagePath: "/blogs/*",
+      minImpressions: 10,
+      maxPosition: 20,
+    });
+
+    expect(parsed.pagePath).toBe("/blogs/*");
+    expect(parsed.minImpressions).toBe(10);
+    expect(parsed.maxPosition).toBe(20);
+  });
+
+  it("treats blank page path as unset", () => {
+    const parsed = searchPerformanceInputSchema.parse({
+      projectId: "p1",
+      pagePath: "   ",
+    });
+
+    expect(parsed.pagePath).toBeUndefined();
+  });
+
+  it("rejects impressions min greater than max", () => {
+    expect(() =>
+      searchPerformanceInputSchema.parse({
+        projectId: "p1",
+        minImpressions: 100,
+        maxImpressions: 10,
+      }),
+    ).toThrow(/Impressions minimum cannot exceed maximum/);
+  });
+
+  it("rejects negative clicks", () => {
+    expect(() =>
+      searchPerformanceInputSchema.parse({
+        projectId: "p1",
+        minClicks: -1,
+      }),
+    ).toThrow();
+  });
+});
+
+describe("searchPerformanceTableInputSchema", () => {
+  it("accepts metric filters with pagination", () => {
+    const parsed = searchPerformanceTableInputSchema.parse({
+      projectId: "p1",
+      dimension: "page",
+      page: 2,
+      pageSize: 50,
+      minClicks: 5,
+    });
+
+    expect(parsed.page).toBe(2);
+    expect(parsed.minClicks).toBe(5);
+  });
+});
+
+describe("hasActiveMetricFilters", () => {
+  it("returns false when no metric bounds are set", () => {
+    expect(hasActiveMetricFilters({})).toBe(false);
+  });
+
+  it("returns true when any metric bound is set", () => {
+    expect(hasActiveMetricFilters({ maxPosition: 10 })).toBe(true);
+  });
+});

--- a/src/types/schemas/search-performance.test.ts
+++ b/src/types/schemas/search-performance.test.ts
@@ -10,11 +10,13 @@ describe("searchPerformanceInputSchema", () => {
     const parsed = searchPerformanceInputSchema.parse({
       projectId: "p1",
       pagePath: "/blogs/*",
+      excludePagePath: "/tag/",
       minImpressions: 10,
       maxPosition: 20,
     });
 
     expect(parsed.pagePath).toBe("/blogs/*");
+    expect(parsed.excludePagePath).toBe("/tag/");
     expect(parsed.minImpressions).toBe(10);
     expect(parsed.maxPosition).toBe(20);
   });

--- a/src/types/schemas/search-performance.ts
+++ b/src/types/schemas/search-performance.ts
@@ -79,15 +79,13 @@ const searchPerformanceFilterShape = {
   ...searchPerformanceMetricFilterShape,
 };
 
-export type SearchPerformanceMetricFilters = {
-  pagePath?: string;
-  minImpressions?: number;
-  maxImpressions?: number;
-  minClicks?: number;
-  maxClicks?: number;
-  minPosition?: number;
-  maxPosition?: number;
-};
+const searchPerformanceMetricFilterSchema = z.object(
+  searchPerformanceMetricFilterShape,
+);
+
+export type SearchPerformanceMetricFilters = z.infer<
+  typeof searchPerformanceMetricFilterSchema
+>;
 
 export function hasActiveMetricFilters(
   filters: SearchPerformanceMetricFilters,

--- a/src/types/schemas/search-performance.ts
+++ b/src/types/schemas/search-performance.ts
@@ -58,6 +58,7 @@ const optionalPagePath = z
 // and the paginated table calls always accept the exact same filter surface.
 const searchPerformanceMetricFilterShape = {
   pagePath: optionalPagePath,
+  excludePagePath: optionalPagePath,
   minImpressions: optionalNonNegativeInt,
   maxImpressions: optionalNonNegativeInt,
   minClicks: optionalNonNegativeInt,

--- a/src/types/schemas/search-performance.ts
+++ b/src/types/schemas/search-performance.ts
@@ -16,8 +16,56 @@ export type SearchPerformanceDateRange =
   (typeof SEARCH_PERFORMANCE_RANGES)[number];
 export type SearchPerformanceDevice = (typeof GSC_DEVICES)[number];
 
+const optionalNonNegativeInt = z.number().int().nonnegative().optional();
+const optionalPositiveNumber = z.number().positive().optional();
+
+function refineMetricRanges(
+  data: {
+    minImpressions?: number;
+    maxImpressions?: number;
+    minClicks?: number;
+    maxClicks?: number;
+    minPosition?: number;
+    maxPosition?: number;
+  },
+  ctx: z.RefinementCtx,
+) {
+  const pairs: [keyof typeof data, keyof typeof data, string][] = [
+    ["minImpressions", "maxImpressions", "Impressions"],
+    ["minClicks", "maxClicks", "Clicks"],
+    ["minPosition", "maxPosition", "Position"],
+  ];
+  for (const [minKey, maxKey, label] of pairs) {
+    const min = data[minKey];
+    const max = data[maxKey];
+    if (min !== undefined && max !== undefined && min > max) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `${label} minimum cannot exceed maximum`,
+        path: [minKey],
+      });
+    }
+  }
+}
+
+const optionalPagePath = z
+  .string()
+  .transform((value) => value.trim())
+  .transform((value) => (value.length > 0 ? value : undefined))
+  .optional();
+
 // Shared report/table filters. Spread into each request schema so the overview
 // and the paginated table calls always accept the exact same filter surface.
+const searchPerformanceMetricFilterShape = {
+  pagePath: optionalPagePath,
+  minImpressions: optionalNonNegativeInt,
+  maxImpressions: optionalNonNegativeInt,
+  minClicks: optionalNonNegativeInt,
+  maxClicks: optionalNonNegativeInt,
+  minPosition: optionalPositiveNumber,
+  maxPosition: optionalPositiveNumber,
+};
+
 const searchPerformanceFilterShape = {
   projectId: z.string().min(1),
   dateRange: z.enum(SEARCH_PERFORMANCE_RANGES).default("last_28_days"),
@@ -28,11 +76,35 @@ const searchPerformanceFilterShape = {
     .length(3)
     .transform((value) => value.toLowerCase())
     .optional(),
+  ...searchPerformanceMetricFilterShape,
 };
 
-export const searchPerformanceInputSchema = z.object(
-  searchPerformanceFilterShape,
-);
+export type SearchPerformanceMetricFilters = {
+  pagePath?: string;
+  minImpressions?: number;
+  maxImpressions?: number;
+  minClicks?: number;
+  maxClicks?: number;
+  minPosition?: number;
+  maxPosition?: number;
+};
+
+export function hasActiveMetricFilters(
+  filters: SearchPerformanceMetricFilters,
+): boolean {
+  return (
+    filters.minImpressions !== undefined ||
+    filters.maxImpressions !== undefined ||
+    filters.minClicks !== undefined ||
+    filters.maxClicks !== undefined ||
+    filters.minPosition !== undefined ||
+    filters.maxPosition !== undefined
+  );
+}
+
+export const searchPerformanceInputSchema = z
+  .object(searchPerformanceFilterShape)
+  .superRefine(refineMetricRanges);
 
 /** The dimensions that get their own paginated table (query + page). Striking
  *  distance is computed from the overview call and never paginates. */
@@ -42,22 +114,28 @@ export type SearchPerformanceTableDimension =
 
 export const SEARCH_PERFORMANCE_PAGE_SIZES = [25, 50, 100] as const;
 export const SEARCH_PERFORMANCE_DEFAULT_PAGE_SIZE = 25;
+/** Max GSC rows fetched before in-app metric filtering and pagination. */
+export const SEARCH_PERFORMANCE_METRIC_FILTER_ROW_LIMIT = 1000;
 
-export const searchPerformanceTableInputSchema = z.object({
-  ...searchPerformanceFilterShape,
-  dimension: z.enum(SEARCH_PERFORMANCE_TABLE_DIMENSIONS),
-  page: z.number().int().positive().default(1),
-  pageSize: z
-    .number()
-    .int()
-    .refine((value) =>
-      (SEARCH_PERFORMANCE_PAGE_SIZES as readonly number[]).includes(value),
-    )
-    .default(SEARCH_PERFORMANCE_DEFAULT_PAGE_SIZE),
-});
+export const searchPerformanceTableInputSchema = z
+  .object({
+    ...searchPerformanceFilterShape,
+    dimension: z.enum(SEARCH_PERFORMANCE_TABLE_DIMENSIONS),
+    page: z.number().int().positive().default(1),
+    pageSize: z
+      .number()
+      .int()
+      .refine((value) =>
+        (SEARCH_PERFORMANCE_PAGE_SIZES as readonly number[]).includes(value),
+      )
+      .default(SEARCH_PERFORMANCE_DEFAULT_PAGE_SIZE),
+  })
+  .superRefine(refineMetricRanges);
 
 /** Export pulls the full dataset (capped) rather than a single page. */
-export const searchPerformanceTableExportInputSchema = z.object({
-  ...searchPerformanceFilterShape,
-  dimension: z.enum(SEARCH_PERFORMANCE_TABLE_DIMENSIONS),
-});
+export const searchPerformanceTableExportInputSchema = z
+  .object({
+    ...searchPerformanceFilterShape,
+    dimension: z.enum(SEARCH_PERFORMANCE_TABLE_DIMENSIONS),
+  })
+  .superRefine(refineMetricRanges);


### PR DESCRIPTION
## Summary

GSC Insights (Search Performance) now supports path-prefix filtering and min/max ranges for impressions, clicks, and average position. Users can isolate sections like `/blogs/*` and focus on rows above meaningful thresholds without scanning the full table manually.

Path filters are pushed to GSC as `page` contains filters. Metric ranges are applied server-side after fetch and before pagination/export, so table pages, exports, and striking-distance rows share the same effective filter set. Overview totals honor path/device/country filters; when metric ranges are active, the UI explains that totals exclude those bounds and notes the 1,000-row cap for filtered tables/exports.

## Validation

- `pnpm run ci:check` — pass (prettier, knip, tsc, oxlint)
- `pnpm run test:ci` — 632 tests pass

Manual QA with a connected GSC property is recommended for filter UX and export parity.

## Test plan

- [ ] Set page path `/blogs/` or `/blogs/*` and confirm queries/pages/striking distance narrow to matching URLs
- [ ] Set min impressions/clicks/position and confirm table, pagination, and CSV/Sheets export match
- [ ] Enter invalid metric values and confirm inline errors; valid path filter still applies
- [ ] With metric filters active, confirm overview disclaimer and 1,000-row cap note appear
- [ ] Clear filters resets table and striking distance

Fixes every-app/open-seo#68


<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds page-path prefix filtering and min/max metric ranges (impressions, clicks, average position) to the GSC Search Performance feature. Path filters are pushed to GSC as `page contains` filters; metric filters are applied server-side after a capped 1,000-row fetch, with consistent behavior across the overview, paginated table, and CSV/Sheets export.

- **New `searchPerformanceFilters.ts` module** extracts pure filter/pagination helpers (`normalizePagePathFilter`, `matchesMetricFilters`, `paginateRows`, etc.) with good unit-test coverage.
- **`getSearchPerformanceTable` gains a metric-filter branch** that fetches up to 1,000 rows from GSC, filters in-app, then paginates; without metric filters the original GSC-side `startRow` pagination is preserved.
- **`fetchFilteredDimensionRows`** is a shared helper used by both the table and export paths, but its parameter type omits `device` and `country` even though `buildGscFilters` reads them from the object at runtime — making the device/country filtering implicit and unenforceable by TypeScript.
</details>


<details><summary><h3>Confidence Score: 3/5</h3></summary>

The filtering logic is well-tested in isolation, but the shared `fetchFilteredDimensionRows` helper has a type contract that doesn't capture all of its dependencies, which could silently break device/country filtering if the function is reused or refactored.

The core concern is `fetchFilteredDimensionRows`: it passes its `data` argument to `buildGscFilters`, which reads `device` and `country` from the object at runtime, but those fields are absent from the function's declared parameter type. This works today because both callers pass the full validated request, but TypeScript cannot enforce that invariant. A future caller passing only metric-filter fields would silently produce unscoped GSC queries. The query-key issue (raw form strings instead of compiled filters) is a secondary concern that can cause unnecessary cache churn when users type numeric values.

src/serverFunctions/searchPerformance.ts — the `fetchFilteredDimensionRows` signature and its implicit dependency on runtime properties not reflected in its type.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/serverFunctions/searchPerformance.ts | Adds metric-filter branch to `getSearchPerformanceTable` and refactors export to use `fetchFilteredDimensionRows`; the helper's type signature omits `device`/`country` even though `buildGscFilters` reads them at runtime, creating a hidden contract. |
| src/types/schemas/search-performance.ts | Adds Zod metric-filter fields, `refineMetricRanges` cross-field validation, and `hasActiveMetricFilters`; `SearchPerformanceMetricFilters` is a manually-maintained parallel type instead of being derived via `z.infer`. |
| src/client/features/search-performance/SearchPerformancePage.tsx | Wires advanced filter state into queries, prefetch, and export; query key uses raw form string state rather than the compiled canonical filter object, risking unnecessary cache misses. |
| src/server/features/gsc/searchPerformanceFilters.ts | New module with well-tested, pure filter/pagination helpers: `normalizePagePathFilter`, `toPagePathGscFilter`, `matchesMetricFilters`, `filterDimensionRowsByMetrics`, `filterStrikingDistanceByMetrics`, and `paginateRows`. |
| src/client/features/search-performance/SearchPerformanceAdvancedFilters.tsx | New UI component with client-side validation, metric range fields, and filter compilation; logic is flat, well-tested, and mixes no server concerns. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as SearchPerformancePage
    participant SF as searchPerformance (serverFn)
    participant Filters as searchPerformanceFilters
    participant GSC as GscService

    UI->>SF: "getSearchPerformanceReport({ pagePath, device, country, ... })"
    SF->>SF: buildGscFilters(data) → deviceFilters + filters (incl. pagePath)
    SF->>GSC: getPerformance(filters) × 3 (current, previous, queryPages)
    GSC-->>SF: raw rows
    SF->>Filters: filterStrikingDistanceByMetrics(rows, metricFilters)
    SF-->>UI: "{ totals, strikingDistance, metricFiltersActive }"

    UI->>SF: "getSearchPerformanceTable({ page, pageSize, metric filters... })"
    alt hasActiveMetricFilters
        SF->>Filters: fetchFilteredDimensionRows(data, projectId)
        Filters->>GSC: "getPerformance(filters, rowLimit=1000)"
        GSC-->>Filters: up to 1000 rows
        Filters->>Filters: filterDimensionRowsByMetrics(rows, metricFilters)
        Filters->>Filters: paginateRows(filtered, page, pageSize)
        Filters-->>SF: "{ rows, hasNextPage }"
    else no metric filters
        SF->>GSC: "getPerformance(filters, startRow=offset, rowLimit=pageSize+1)"
        GSC-->>SF: page rows
    end
    SF-->>UI: "{ rows, hasNextPage }"

    UI->>SF: "exportSearchPerformanceTable({ dimension, filters... })"
    SF->>Filters: fetchFilteredDimensionRows(data, projectId)
    Filters->>GSC: "getPerformance(filters, rowLimit=1000)"
    GSC-->>Filters: rows
    Filters->>Filters: filterDimensionRowsByMetrics
    SF-->>UI: "{ dimension, rows }"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as SearchPerformancePage
    participant SF as searchPerformance (serverFn)
    participant Filters as searchPerformanceFilters
    participant GSC as GscService

    UI->>SF: "getSearchPerformanceReport({ pagePath, device, country, ... })"
    SF->>SF: buildGscFilters(data) → deviceFilters + filters (incl. pagePath)
    SF->>GSC: getPerformance(filters) × 3 (current, previous, queryPages)
    GSC-->>SF: raw rows
    SF->>Filters: filterStrikingDistanceByMetrics(rows, metricFilters)
    SF-->>UI: "{ totals, strikingDistance, metricFiltersActive }"

    UI->>SF: "getSearchPerformanceTable({ page, pageSize, metric filters... })"
    alt hasActiveMetricFilters
        SF->>Filters: fetchFilteredDimensionRows(data, projectId)
        Filters->>GSC: "getPerformance(filters, rowLimit=1000)"
        GSC-->>Filters: up to 1000 rows
        Filters->>Filters: filterDimensionRowsByMetrics(rows, metricFilters)
        Filters->>Filters: paginateRows(filtered, page, pageSize)
        Filters-->>SF: "{ rows, hasNextPage }"
    else no metric filters
        SF->>GSC: "getPerformance(filters, startRow=offset, rowLimit=pageSize+1)"
        GSC-->>SF: page rows
    end
    SF-->>UI: "{ rows, hasNextPage }"

    UI->>SF: "exportSearchPerformanceTable({ dimension, filters... })"
    SF->>Filters: fetchFilteredDimensionRows(data, projectId)
    Filters->>GSC: "getPerformance(filters, rowLimit=1000)"
    GSC-->>Filters: rows
    Filters->>Filters: filterDimensionRowsByMetrics
    SF-->>UI: "{ dimension, rows }"
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/client/features/search-performance/SearchPerformancePage.tsx`, line 476-485 ([link](https://github.com/every-app/open-seo/blob/03207c5db862dc9bffc02058da24f1a41dd1c294/src/client/features/search-performance/SearchPerformancePage.tsx#L476-L485)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Query key uses raw form strings instead of compiled canonical filters**

   `advancedFilters` in the query key holds raw string values (e.g. `"100"`, `"100.0"`, `"abc"`). Two form states that compile to identical `SearchPerformanceMetricFilters` — such as `"10"` vs `"10.0"`, or a partially invalid form that compiles the same as an empty one — produce different cache entries and trigger separate network calls. Using `compileAdvancedSearchPerformanceFilters(advancedFilters)` as the key value gives TanStack Query a stable semantic identity that matches what the server actually receives.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/client/features/search-performance/SearchPerformancePage.tsx
   Line: 476-485

   Comment:
   **Query key uses raw form strings instead of compiled canonical filters**

   `advancedFilters` in the query key holds raw string values (e.g. `"100"`, `"100.0"`, `"abc"`). Two form states that compile to identical `SearchPerformanceMetricFilters` — such as `"10"` vs `"10.0"`, or a partially invalid form that compiles the same as an empty one — produce different cache entries and trigger separate network calls. Using `compileAdvancedSearchPerformanceFilters(advancedFilters)` as the key value gives TanStack Query a stable semantic identity that matches what the server actually receives.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fclient%2Ffeatures%2Fsearch-performance%2FSearchPerformancePage.tsx%0ALine%3A%20476-485%0A%0AComment%3A%0A**Query%20key%20uses%20raw%20form%20strings%20instead%20of%20compiled%20canonical%20filters**%0A%0A%60advancedFilters%60%20in%20the%20query%20key%20holds%20raw%20string%20values%20%28e.g.%20%60%22100%22%60%2C%20%60%22100.0%22%60%2C%20%60%22abc%22%60%29.%20Two%20form%20states%20that%20compile%20to%20identical%20%60SearchPerformanceMetricFilters%60%20%E2%80%94%20such%20as%20%60%2210%22%60%20vs%20%60%2210.0%22%60%2C%20or%20a%20partially%20invalid%20form%20that%20compiles%20the%20same%20as%20an%20empty%20one%20%E2%80%94%20produce%20different%20cache%20entries%20and%20trigger%20separate%20network%20calls.%20Using%20%60compileAdvancedSearchPerformanceFilters%28advancedFilters%29%60%20as%20the%20key%20value%20gives%20TanStack%20Query%20a%20stable%20semantic%20identity%20that%20matches%20what%20the%20server%20actually%20receives.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=every-app%2Fopen-seo&pr=83&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22every-app%2Fopen-seo%22%20on%20the%20existing%20branch%20%22feat%2Fgsc-insights-path-metric-filters%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fgsc-insights-path-metric-filters%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fclient%2Ffeatures%2Fsearch-performance%2FSearchPerformancePage.tsx%0ALine%3A%20476-485%0A%0AComment%3A%0A**Query%20key%20uses%20raw%20form%20strings%20instead%20of%20compiled%20canonical%20filters**%0A%0A%60advancedFilters%60%20in%20the%20query%20key%20holds%20raw%20string%20values%20%28e.g.%20%60%22100%22%60%2C%20%60%22100.0%22%60%2C%20%60%22abc%22%60%29.%20Two%20form%20states%20that%20compile%20to%20identical%20%60SearchPerformanceMetricFilters%60%20%E2%80%94%20such%20as%20%60%2210%22%60%20vs%20%60%2210.0%22%60%2C%20or%20a%20partially%20invalid%20form%20that%20compiles%20the%20same%20as%20an%20empty%20one%20%E2%80%94%20produce%20different%20cache%20entries%20and%20trigger%20separate%20network%20calls.%20Using%20%60compileAdvancedSearchPerformanceFilters%28advancedFilters%29%60%20as%20the%20key%20value%20gives%20TanStack%20Query%20a%20stable%20semantic%20identity%20that%20matches%20what%20the%20server%20actually%20receives.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=every-app%2Fopen-seo&pr=83&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fclient%2Ffeatures%2Fsearch-performance%2FSearchPerformancePage.tsx%0ALine%3A%20476-485%0A%0AComment%3A%0A**Query%20key%20uses%20raw%20form%20strings%20instead%20of%20compiled%20canonical%20filters**%0A%0A%60advancedFilters%60%20in%20the%20query%20key%20holds%20raw%20string%20values%20%28e.g.%20%60%22100%22%60%2C%20%60%22100.0%22%60%2C%20%60%22abc%22%60%29.%20Two%20form%20states%20that%20compile%20to%20identical%20%60SearchPerformanceMetricFilters%60%20%E2%80%94%20such%20as%20%60%2210%22%60%20vs%20%60%2210.0%22%60%2C%20or%20a%20partially%20invalid%20form%20that%20compiles%20the%20same%20as%20an%20empty%20one%20%E2%80%94%20produce%20different%20cache%20entries%20and%20trigger%20separate%20network%20calls.%20Using%20%60compileAdvancedSearchPerformanceFilters%28advancedFilters%29%60%20as%20the%20key%20value%20gives%20TanStack%20Query%20a%20stable%20semantic%20identity%20that%20matches%20what%20the%20server%20actually%20receives.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=83&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asrc%2FserverFunctions%2FsearchPerformance.ts%3A74-94%0A**%60device%60%20and%20%60country%60%20silently%20dropped%20when%20type%20is%20narrowed**%0A%0A%60fetchFilteredDimensionRows%60%20types%20%60data%60%20as%20%60SearchPerformanceMetricFilters%20%26%20%7B%20dateRange%2C%20dimension%20%7D%60%2C%20which%20has%20no%20%60device%60%20or%20%60country%60.%20Inside%2C%20%60buildGscFilters%28data%29%60%20is%20called%20%E2%80%94%20it%20accepts%20those%20fields%20as%20optional%2C%20so%20TypeScript%20doesn't%20complain.%20Today%20it%20works%20because%20both%20callers%20pass%20the%20full%20validated%20request%20object%2C%20so%20the%20runtime%20value%20carries%20%60device%60%20and%20%60country%60%20even%20though%20the%20TypeScript%20type%20doesn't%20declare%20them.%20If%20the%20function%20is%20ever%20called%20with%20a%20genuinely%20narrower%20object%20%28or%20if%20%60buildGscFilters%60%20is%20updated%20to%20check%20for%20the%20field's%20presence%29%2C%20those%20filters%20silently%20won't%20apply%20and%20the%20GSC%20query%20will%20return%20unfiltered%20data.%20The%20type%20should%20declare%20%60device%3F%3A%20string%3B%20country%3F%3A%20string%3B%60%20so%20the%20contract%20is%20explicit.%0A%0A%23%23%23%20Issue%202%20of%203%0Asrc%2Ftypes%2Fschemas%2Fsearch-performance.ts%3A82-90%0A**Manual%20type%20duplicates%20the%20Zod%20shape**%0A%0A%60SearchPerformanceMetricFilters%60%20is%20a%20hand-written%20parallel%20of%20%60searchPerformanceMetricFilterShape%60.%20The%20project%20rule%20is%20to%20derive%20TypeScript%20types%20from%20Zod%20schemas%20with%20%60z.infer%60%20rather%20than%20maintaining%20a%20second%20definition.%20The%20shape%20can%20be%20wrapped%20in%20a%20temporary%20%60z.object%60%20for%20inference%3A%20%60type%20SearchPerformanceMetricFilters%20%3D%20z.infer%3CReturnType%3Ctypeof%20z.object%3Ctypeof%20searchPerformanceMetricFilterShape%3E%3E%3E%60.%20If%20the%20schema's%20transform%20logic%20or%20optional%20fields%20change%20later%2C%20the%20manual%20type%20will%20silently%20drift.%0A-%20Remember%20that%20these%20are%20external%20...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3Dinstruction-0%29%29%0A%0A%23%23%23%20Issue%203%20of%203%0Asrc%2Fclient%2Ffeatures%2Fsearch-performance%2FSearchPerformancePage.tsx%3A476-485%0A**Query%20key%20uses%20raw%20form%20strings%20instead%20of%20compiled%20canonical%20filters**%0A%0A%60advancedFilters%60%20in%20the%20query%20key%20holds%20raw%20string%20values%20%28e.g.%20%60%22100%22%60%2C%20%60%22100.0%22%60%2C%20%60%22abc%22%60%29.%20Two%20form%20states%20that%20compile%20to%20identical%20%60SearchPerformanceMetricFilters%60%20%E2%80%94%20such%20as%20%60%2210%22%60%20vs%20%60%2210.0%22%60%2C%20or%20a%20partially%20invalid%20form%20that%20compiles%20the%20same%20as%20an%20empty%20one%20%E2%80%94%20produce%20different%20cache%20entries%20and%20trigger%20separate%20network%20calls.%20Using%20%60compileAdvancedSearchPerformanceFilters%28advancedFilters%29%60%20as%20the%20key%20value%20gives%20TanStack%20Query%20a%20stable%20semantic%20identity%20that%20matches%20what%20the%20server%20actually%20receives.%0A%0A&repo=every-app%2Fopen-seo&pr=83&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22every-app%2Fopen-seo%22%20on%20the%20existing%20branch%20%22feat%2Fgsc-insights-path-metric-filters%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fgsc-insights-path-metric-filters%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asrc%2FserverFunctions%2FsearchPerformance.ts%3A74-94%0A**%60device%60%20and%20%60country%60%20silently%20dropped%20when%20type%20is%20narrowed**%0A%0A%60fetchFilteredDimensionRows%60%20types%20%60data%60%20as%20%60SearchPerformanceMetricFilters%20%26%20%7B%20dateRange%2C%20dimension%20%7D%60%2C%20which%20has%20no%20%60device%60%20or%20%60country%60.%20Inside%2C%20%60buildGscFilters%28data%29%60%20is%20called%20%E2%80%94%20it%20accepts%20those%20fields%20as%20optional%2C%20so%20TypeScript%20doesn't%20complain.%20Today%20it%20works%20because%20both%20callers%20pass%20the%20full%20validated%20request%20object%2C%20so%20the%20runtime%20value%20carries%20%60device%60%20and%20%60country%60%20even%20though%20the%20TypeScript%20type%20doesn't%20declare%20them.%20If%20the%20function%20is%20ever%20called%20with%20a%20genuinely%20narrower%20object%20%28or%20if%20%60buildGscFilters%60%20is%20updated%20to%20check%20for%20the%20field's%20presence%29%2C%20those%20filters%20silently%20won't%20apply%20and%20the%20GSC%20query%20will%20return%20unfiltered%20data.%20The%20type%20should%20declare%20%60device%3F%3A%20string%3B%20country%3F%3A%20string%3B%60%20so%20the%20contract%20is%20explicit.%0A%0A%23%23%23%20Issue%202%20of%203%0Asrc%2Ftypes%2Fschemas%2Fsearch-performance.ts%3A82-90%0A**Manual%20type%20duplicates%20the%20Zod%20shape**%0A%0A%60SearchPerformanceMetricFilters%60%20is%20a%20hand-written%20parallel%20of%20%60searchPerformanceMetricFilterShape%60.%20The%20project%20rule%20is%20to%20derive%20TypeScript%20types%20from%20Zod%20schemas%20with%20%60z.infer%60%20rather%20than%20maintaining%20a%20second%20definition.%20The%20shape%20can%20be%20wrapped%20in%20a%20temporary%20%60z.object%60%20for%20inference%3A%20%60type%20SearchPerformanceMetricFilters%20%3D%20z.infer%3CReturnType%3Ctypeof%20z.object%3Ctypeof%20searchPerformanceMetricFilterShape%3E%3E%3E%60.%20If%20the%20schema's%20transform%20logic%20or%20optional%20fields%20change%20later%2C%20the%20manual%20type%20will%20silently%20drift.%0A-%20Remember%20that%20these%20are%20external%20...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3Dinstruction-0%29%29%0A%0A%23%23%23%20Issue%203%20of%203%0Asrc%2Fclient%2Ffeatures%2Fsearch-performance%2FSearchPerformancePage.tsx%3A476-485%0A**Query%20key%20uses%20raw%20form%20strings%20instead%20of%20compiled%20canonical%20filters**%0A%0A%60advancedFilters%60%20in%20the%20query%20key%20holds%20raw%20string%20values%20%28e.g.%20%60%22100%22%60%2C%20%60%22100.0%22%60%2C%20%60%22abc%22%60%29.%20Two%20form%20states%20that%20compile%20to%20identical%20%60SearchPerformanceMetricFilters%60%20%E2%80%94%20such%20as%20%60%2210%22%60%20vs%20%60%2210.0%22%60%2C%20or%20a%20partially%20invalid%20form%20that%20compiles%20the%20same%20as%20an%20empty%20one%20%E2%80%94%20produce%20different%20cache%20entries%20and%20trigger%20separate%20network%20calls.%20Using%20%60compileAdvancedSearchPerformanceFilters%28advancedFilters%29%60%20as%20the%20key%20value%20gives%20TanStack%20Query%20a%20stable%20semantic%20identity%20that%20matches%20what%20the%20server%20actually%20receives.%0A%0A&repo=every-app%2Fopen-seo&pr=83&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asrc%2FserverFunctions%2FsearchPerformance.ts%3A74-94%0A**%60device%60%20and%20%60country%60%20silently%20dropped%20when%20type%20is%20narrowed**%0A%0A%60fetchFilteredDimensionRows%60%20types%20%60data%60%20as%20%60SearchPerformanceMetricFilters%20%26%20%7B%20dateRange%2C%20dimension%20%7D%60%2C%20which%20has%20no%20%60device%60%20or%20%60country%60.%20Inside%2C%20%60buildGscFilters%28data%29%60%20is%20called%20%E2%80%94%20it%20accepts%20those%20fields%20as%20optional%2C%20so%20TypeScript%20doesn't%20complain.%20Today%20it%20works%20because%20both%20callers%20pass%20the%20full%20validated%20request%20object%2C%20so%20the%20runtime%20value%20carries%20%60device%60%20and%20%60country%60%20even%20though%20the%20TypeScript%20type%20doesn't%20declare%20them.%20If%20the%20function%20is%20ever%20called%20with%20a%20genuinely%20narrower%20object%20%28or%20if%20%60buildGscFilters%60%20is%20updated%20to%20check%20for%20the%20field's%20presence%29%2C%20those%20filters%20silently%20won't%20apply%20and%20the%20GSC%20query%20will%20return%20unfiltered%20data.%20The%20type%20should%20declare%20%60device%3F%3A%20string%3B%20country%3F%3A%20string%3B%60%20so%20the%20contract%20is%20explicit.%0A%0A%23%23%23%20Issue%202%20of%203%0Asrc%2Ftypes%2Fschemas%2Fsearch-performance.ts%3A82-90%0A**Manual%20type%20duplicates%20the%20Zod%20shape**%0A%0A%60SearchPerformanceMetricFilters%60%20is%20a%20hand-written%20parallel%20of%20%60searchPerformanceMetricFilterShape%60.%20The%20project%20rule%20is%20to%20derive%20TypeScript%20types%20from%20Zod%20schemas%20with%20%60z.infer%60%20rather%20than%20maintaining%20a%20second%20definition.%20The%20shape%20can%20be%20wrapped%20in%20a%20temporary%20%60z.object%60%20for%20inference%3A%20%60type%20SearchPerformanceMetricFilters%20%3D%20z.infer%3CReturnType%3Ctypeof%20z.object%3Ctypeof%20searchPerformanceMetricFilterShape%3E%3E%3E%60.%20If%20the%20schema's%20transform%20logic%20or%20optional%20fields%20change%20later%2C%20the%20manual%20type%20will%20silently%20drift.%0A-%20Remember%20that%20these%20are%20external%20...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3Dinstruction-0%29%29%0A%0A%23%23%23%20Issue%203%20of%203%0Asrc%2Fclient%2Ffeatures%2Fsearch-performance%2FSearchPerformancePage.tsx%3A476-485%0A**Query%20key%20uses%20raw%20form%20strings%20instead%20of%20compiled%20canonical%20filters**%0A%0A%60advancedFilters%60%20in%20the%20query%20key%20holds%20raw%20string%20values%20%28e.g.%20%60%22100%22%60%2C%20%60%22100.0%22%60%2C%20%60%22abc%22%60%29.%20Two%20form%20states%20that%20compile%20to%20identical%20%60SearchPerformanceMetricFilters%60%20%E2%80%94%20such%20as%20%60%2210%22%60%20vs%20%60%2210.0%22%60%2C%20or%20a%20partially%20invalid%20form%20that%20compiles%20the%20same%20as%20an%20empty%20one%20%E2%80%94%20produce%20different%20cache%20entries%20and%20trigger%20separate%20network%20calls.%20Using%20%60compileAdvancedSearchPerformanceFilters%28advancedFilters%29%60%20as%20the%20key%20value%20gives%20TanStack%20Query%20a%20stable%20semantic%20identity%20that%20matches%20what%20the%20server%20actually%20receives.%0A%0A&pr=83&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/serverFunctions/searchPerformance.ts:74-94
**`device` and `country` silently dropped when type is narrowed**

`fetchFilteredDimensionRows` types `data` as `SearchPerformanceMetricFilters & { dateRange, dimension }`, which has no `device` or `country`. Inside, `buildGscFilters(data)` is called — it accepts those fields as optional, so TypeScript doesn't complain. Today it works because both callers pass the full validated request object, so the runtime value carries `device` and `country` even though the TypeScript type doesn't declare them. If the function is ever called with a genuinely narrower object (or if `buildGscFilters` is updated to check for the field's presence), those filters silently won't apply and the GSC query will return unfiltered data. The type should declare `device?: string; country?: string;` so the contract is explicit.

### Issue 2 of 3
src/types/schemas/search-performance.ts:82-90
**Manual type duplicates the Zod shape**

`SearchPerformanceMetricFilters` is a hand-written parallel of `searchPerformanceMetricFilterShape`. The project rule is to derive TypeScript types from Zod schemas with `z.infer` rather than maintaining a second definition. The shape can be wrapped in a temporary `z.object` for inference: `type SearchPerformanceMetricFilters = z.infer<ReturnType<typeof z.object<typeof searchPerformanceMetricFilterShape>>>`. If the schema's transform logic or optional fields change later, the manual type will silently drift.
- Remember that these are external ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

### Issue 3 of 3
src/client/features/search-performance/SearchPerformancePage.tsx:476-485
**Query key uses raw form strings instead of compiled canonical filters**

`advancedFilters` in the query key holds raw string values (e.g. `"100"`, `"100.0"`, `"abc"`). Two form states that compile to identical `SearchPerformanceMetricFilters` — such as `"10"` vs `"10.0"`, or a partially invalid form that compiles the same as an empty one — produce different cache entries and trigger separate network calls. Using `compileAdvancedSearchPerformanceFilters(advancedFilters)` as the key value gives TanStack Query a stable semantic identity that matches what the server actually receives.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(search-performance): add page-path ..."](https://github.com/every-app/open-seo/commit/03207c5db862dc9bffc02058da24f1a41dd1c294) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43770084)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->
