### PR TITLE
fix(sidebar): keep hover and active nav backgrounds visually distinct

### DIFF
--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -40,7 +40,8 @@ const navItemClass = `${navItemBaseClass} transition-colors hover:bg-base-300/30
 const navItemActiveProps = {
   // Keep the active tint on hover so the active item does not fall back to the
   // lighter hover background of navItemClass.
-  className: "bg-base-300/50 hover:bg-base-300/50 font-medium text-base-content",
+  className:
+    "bg-base-300/50 hover:bg-base-300/50 font-medium text-base-content",
 };
 
 function SidebarNavLink({

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -32,10 +32,15 @@ interface SidebarProps {
 const navItemBaseClass =
   "relative flex items-center gap-2.5 rounded-md px-3 py-1.5 text-sm text-base-content/70";
 
-const navItemClass = `${navItemBaseClass} transition-colors hover:bg-base-300/50 hover:text-base-content`;
+// Hover uses a lighter tint than the active background (bg-base-300/50) so a
+// hovered item next to the active one stays visually distinct instead of
+// merging into a single block.
+const navItemClass = `${navItemBaseClass} transition-colors hover:bg-base-300/30 hover:text-base-content`;
 
 const navItemActiveProps = {
-  className: "bg-base-300/50 font-medium text-base-content",
+  // Keep the active tint on hover so the active item does not fall back to the
+  // lighter hover background of navItemClass.
+  className: "bg-base-300/50 hover:bg-base-300/50 font-medium text-base-content",
 };
 
 function SidebarNavLink({


### PR DESCRIPTION
Closes #80

## Problem
Hovering a sidebar item adjacent to the active one made the two backgrounds merge into a single block, because both the active state and the hover state used the same `bg-base-300/50`.

## Fix
- Lighten the hover tint to `bg-base-300/30` so a hovered item stays distinct from the active one.
- Pin the active item's hover background to `bg-base-300/50` so the active item keeps its own tint on hover instead of falling back to the lighter hover shade.

Pure CSS/class change, no behavior change. `pnpm ci:check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes a pure Tailwind class change to fix a sidebar visual issue where hovering a nav item adjacent to the active one caused both backgrounds to appear identical, merging into a single block.

- Lightens the non-active hover tint from `bg-base-300/50` to `bg-base-300/30` so a hovered item stays visually distinct from the active item.
- Adds `hover:bg-base-300/50` to the active item's class set so it retains its own tint on hover rather than inheriting the lighter shade from the base class.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a two-line Tailwind class adjustment with no behavioral, logic, or data changes.

The change touches only two string constants that define Tailwind hover/active classes on sidebar nav items. TanStack Router's Link appends activeProps.className to the base className; since Tailwind JIT encounters hover:bg-base-300/30 (line 38) before hover:bg-base-300/50 (line 43) in source order, the latter is emitted later in the stylesheet and wins via cascade when both are present on an active element — exactly the intended outcome. No logic, data, auth, or backend code is affected.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/client/components/Sidebar.tsx | Two Tailwind class string constants updated: hover tint lightened to bg-base-300/30 for non-active items, and hover:bg-base-300/50 pinned on the active item's activeProps. No logic or behavior change. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Nav item rendered] --> B{Is link active?}
    B -- No --> C[navItemClass applied\nhover: bg-base-300/30]
    B -- Yes --> D[navItemClass + navItemActiveProps applied\nbase: bg-base-300/50\nhover: bg-base-300/50 wins via CSS cascade]
    C --> E[Hovered inactive item\nshows lighter tint /30]
    D --> F[Hovered active item\nretains full tint /50]
    E --> G[Inactive and active items\nremain visually distinct]
    F --> G
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Nav item rendered] --> B{Is link active?}
    B -- No --> C[navItemClass applied\nhover: bg-base-300/30]
    B -- Yes --> D[navItemClass + navItemActiveProps applied\nbase: bg-base-300/50\nhover: bg-base-300/50 wins via CSS cascade]
    C --> E[Hovered inactive item\nshows lighter tint /30]
    D --> F[Hovered active item\nretains full tint /50]
    E --> G[Inactive and active items\nremain visually distinct]
    F --> G
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(sidebar): keep hover and active back..."](https://github.com/every-app/open-seo/commit/59e5806a38e6f378c65dc5e701ad723c376e5509) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43797804)</sub>

<!-- /greptile_comment -->