### PR TITLE
fix(domain): memoize the pages-table data slice to stop an infinite render loop

### DIFF
--- a/e2e/domain-overview-filters.spec.ts
+++ b/e2e/domain-overview-filters.spec.ts
@@ -181,7 +181,7 @@ test.describe("Domain Overview filters", () => {
     );
     await applyFilters(page, "pMinTraffic", "20");
 
-    const domainInput = page.getByPlaceholder("Enter a domain").nth(1);
+    const domainInput = page.getByPlaceholder("Enter a domain").first();
     await domainInput.click();
     await domainInput.press(
       process.platform === "darwin" ? "Meta+A" : "Control+A",

--- a/e2e/domain-overview-test-utils.ts
+++ b/e2e/domain-overview-test-utils.ts
@@ -7,8 +7,11 @@ import {
   type TestInfo,
 } from "@playwright/test";
 
-export const PRIMARY_TEST_DOMAIN = "primary.example";
-export const SECONDARY_TEST_DOMAIN = "secondary.example";
+// Real .com suffix on purpose: form-submit validation (isValidDomainHost via
+// tldts) rejects the reserved .example TLD, and these constants reach the one
+// test that submits through the real form instead of URL navigation.
+export const PRIMARY_TEST_DOMAIN = "primary.example.com";
+export const SECONDARY_TEST_DOMAIN = "secondary.example.com";
 const RESPONSIVE_TIMEOUT_MS = 1_500;
 const INPUT_LATENCY_BUDGET_MS = 8_000;
 

--- a/src/client/features/domain/components/DomainPagesTable.tsx
+++ b/src/client/features/domain/components/DomainPagesTable.tsx
@@ -78,8 +78,12 @@ function DomainPagesTableComponent({
     ],
     [currentSortOrder, domain, onSortClick, sortMode],
   );
+  // Memoized on purpose: a fresh slice every render defeats TanStack Table's
+  // data-keyed memo, so _autoResetPageIndex fires each render and its setState
+  // schedules another one — an unbounded render loop that freezes the tab.
+  const tableData = useMemo(() => rows.slice(0, 100), [rows]);
   const table = useAppTable({
-    data: rows.slice(0, 100),
+    data: tableData,
     columns,
   });
   useDomainRenderDebug("DomainPagesTable", {


### PR DESCRIPTION
## Bug
Clicking **Clear all** on the Domain Overview → Pages tab freezes the browser tab.

`DomainPagesTable` passes a fresh `rows.slice(0, 100)` to the table on every render. TanStack Table keys its core row-model memo on the data reference, so the memo never stabilizes and `_autoResetPageIndex` fires on every render — each firing queues `resetPageIndex()` → setState → render → new slice, unbounded (~7-8k renders/sec until the tab dies). `DomainKeywordsTable` passes `rows` directly and is unaffected.

Repro: open a domain with pages data → Pages tab → apply any page filter → Clear all.

## Fix
Memoize the slice on `rows` (one `useMemo`).

## Also
Two e2e repairs that were masking this (the suite doesn't run in your CI): the domain-submit test targets a second "Enter a domain" input that never existed (`.nth(1)` → `.first()`), and the `.example` fixture domains are rejected by the tldts TLD validation on real form submits (→ `.example.com`, still RFC-2606-safe). With these, `domain-overview-filters.spec.ts` passes 7/7 headless.

Found by wiring this e2e suite into CI on a fork.