### PR TITLE
fix(search-tabs): select the right-hand neighbor when closing the active tab

### DIFF
--- a/e2e/keyword-research-navigation.spec.ts
+++ b/e2e/keyword-research-navigation.spec.ts
@@ -115,6 +115,10 @@ test.describe("Keyword Research navigation", () => {
     await expect(
       page.locator(`[data-search-tab-id="${closedTabId}"]`),
     ).toHaveCount(0);
-    await expect(page.getByRole("tab")).toHaveCount(2);
+    // Count only search tabs: the app shell has grown other tablists
+    // (Browse/Chat), so a bare role=tab count would include them.
+    await expect(
+      page.getByRole("tablist", { name: "Search tabs" }).getByRole("tab"),
+    ).toHaveCount(2);
   });
 });

--- a/src/client/features/search-tabs/SearchTabStrip.tsx
+++ b/src/client/features/search-tabs/SearchTabStrip.tsx
@@ -9,6 +9,7 @@ import {
   buildKeywordResearchRequest,
   keywordResearchQueryFn,
 } from "@/client/features/keywords/hooks/useKeywordResearchData";
+import { getLanguageCode } from "@/client/features/keywords/locations";
 import { getBacklinksOverview } from "@/serverFunctions/backlinks";
 import { getDomainOverview } from "@/serverFunctions/domain";
 export type { SearchTab } from "./types";
@@ -43,6 +44,7 @@ export function SearchTabStrip({
     <div className="rounded-xl border border-base-300 bg-base-100 p-1">
       <div
         role="tablist"
+        aria-label="Search tabs"
         className="flex min-w-0 items-stretch gap-1 overflow-x-auto"
       >
         {tabs.map((tab) => {
@@ -186,6 +188,7 @@ function getSearchTabQueryConfig(
   if (tab.input.type === "domain") {
     const input = tab.input;
     const trimmedDomain = input.domain.trim();
+    const languageCode = getLanguageCode(input.locationCode);
 
     return {
       queryKey: [
@@ -194,6 +197,7 @@ function getSearchTabQueryConfig(
         trimmedDomain,
         input.subdomains,
         input.locationCode,
+        languageCode,
       ],
       queryFn: () =>
         getDomainOverview({
@@ -202,6 +206,7 @@ function getSearchTabQueryConfig(
             domain: trimmedDomain,
             includeSubdomains: input.subdomains,
             locationCode: input.locationCode,
+            languageCode,
           },
         }),
       staleTime: 5 * 60_000,

--- a/src/client/features/search-tabs/SearchTabStrip.tsx
+++ b/src/client/features/search-tabs/SearchTabStrip.tsx
@@ -9,7 +9,6 @@ import {
   buildKeywordResearchRequest,
   keywordResearchQueryFn,
 } from "@/client/features/keywords/hooks/useKeywordResearchData";
-import { getLanguageCode } from "@/client/features/keywords/locations";
 import { getBacklinksOverview } from "@/serverFunctions/backlinks";
 import { getDomainOverview } from "@/serverFunctions/domain";
 export type { SearchTab } from "./types";
@@ -188,7 +187,6 @@ function getSearchTabQueryConfig(
   if (tab.input.type === "domain") {
     const input = tab.input;
     const trimmedDomain = input.domain.trim();
-    const languageCode = getLanguageCode(input.locationCode);
 
     return {
       queryKey: [
@@ -197,7 +195,6 @@ function getSearchTabQueryConfig(
         trimmedDomain,
         input.subdomains,
         input.locationCode,
-        languageCode,
       ],
       queryFn: () =>
         getDomainOverview({
@@ -206,7 +203,6 @@ function getSearchTabQueryConfig(
             domain: trimmedDomain,
             includeSubdomains: input.subdomains,
             locationCode: input.locationCode,
-            languageCode,
           },
         }),
       staleTime: 5 * 60_000,

--- a/src/client/features/search-tabs/useSearchTabs.ts
+++ b/src/client/features/search-tabs/useSearchTabs.ts
@@ -255,7 +255,11 @@ export function useSearchTabs(key: string) {
         let activeTabId = current.activeTabId;
         if (current.activeTabId === tabId) {
           closedActive = true;
-          const neighbor = tabs[index - 1] ?? tabs[index] ?? null;
+          // Post-removal array: tabs[index] is the tab that slid into the
+          // closed tab's slot (its right-hand neighbor). Select it first —
+          // browser-tab convention and the documented e2e contract — and fall
+          // back to the left neighbor only when the last tab was closed.
+          const neighbor = tabs[index] ?? tabs[index - 1] ?? null;
           activeTabId = neighbor?.id ?? null;
           nextActiveTab = neighbor;
         }


### PR DESCRIPTION
## Bug
Closing the active search tab selects the tab to the LEFT; browser-tab convention — and this repo's own e2e contract (`keyword-research-navigation.spec.ts`: *"closing the active middle keyword tab removes it and selects the next tab"*) — expect the RIGHT-hand neighbor.

In `closeTab`, the array is post-removal, so `tabs[index]` is the right-hand tab that slid into the closed slot — but the code prefers `tabs[index - 1]`. The suite wasn't running anywhere, so the inversion shipped unnoticed.

## Fix
`tabs[index] ?? tabs[index - 1]` — right-hand neighbor first, left as fallback when the last tab is closed.

## Also
- `aria-label="Search tabs"` on the strip's tablist (the app shell has other tablists; this distinguishes them for assistive tech).
- The spec's final tab-count assertion is scoped to that tablist so unrelated app-shell tabs can't inflate the count. Spec passes 3/3 headless with the fix.

Found by wiring this e2e suite into CI on a fork.