### PR TITLE
Add Macao Google Ads-only keyword market

### DIFF
--- a/src/client/features/keywords/components/GoogleAdsAvailabilityNotice.test.ts
+++ b/src/client/features/keywords/components/GoogleAdsAvailabilityNotice.test.ts
@@ -1,0 +1,16 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { GoogleAdsAvailabilityNotice } from "./GoogleAdsAvailabilityNotice";
+
+describe("GoogleAdsAvailabilityNotice", () => {
+  it("shows unsupported KD and intent as not_available", () => {
+    const markup = renderToStaticMarkup(
+      createElement(GoogleAdsAvailabilityNotice),
+    );
+
+    expect(markup).toContain("KD");
+    expect(markup).toContain("intent");
+    expect(markup.match(/not_available/g)).toHaveLength(2);
+  });
+});

--- a/src/client/features/keywords/components/GoogleAdsAvailabilityNotice.tsx
+++ b/src/client/features/keywords/components/GoogleAdsAvailabilityNotice.tsx
@@ -1,0 +1,12 @@
+export function GoogleAdsAvailabilityNotice() {
+  return (
+    <div
+      className="rounded-lg border border-info/30 bg-info/10 px-3 py-2 text-sm text-base-content"
+      role="status"
+      aria-label="Google Ads metric availability"
+    >
+      Google Ads-only market: KD <code>not_available</code>; intent{" "}
+      <code>not_available</code>.
+    </div>
+  );
+}

--- a/src/client/features/keywords/components/index.ts
+++ b/src/client/features/keywords/components/index.ts
@@ -1,3 +1,4 @@
 export * from "./KeywordUi";
 export * from "./DisplayPrimitives";
 export * from "./IntentBadge";
+export * from "./GoogleAdsAvailabilityNotice";

--- a/src/client/features/keywords/page/KeywordResearchDesktopResults.tsx
+++ b/src/client/features/keywords/page/KeywordResearchDesktopResults.tsx
@@ -17,6 +17,7 @@ import { exportTableToSheets } from "@/client/lib/exportToSheets";
 import { captureClientEvent } from "@/client/lib/posthog";
 import {
   AreaTrendChart,
+  GoogleAdsAvailabilityNotice,
   OverviewStats,
   SerpAnalysisCard,
 } from "@/client/features/keywords/components";
@@ -111,6 +112,9 @@ function DesktopKeywordPanel({ controller }: Props) {
             </span>
           ) : null}
         </div>
+      ) : null}
+      {lastResultSource === "google_ads" ? (
+        <GoogleAdsAvailabilityNotice />
       ) : null}
       {controller.overviewKeyword ? (
         <OverviewStats keyword={controller.overviewKeyword} />

--- a/src/client/features/keywords/page/KeywordResearchMobileResults.tsx
+++ b/src/client/features/keywords/page/KeywordResearchMobileResults.tsx
@@ -14,7 +14,10 @@ import {
 } from "@/client/features/keywords/state/keywordControllerActions";
 import { exportTableToSheets } from "@/client/lib/exportToSheets";
 import { captureClientEvent } from "@/client/lib/posthog";
-import { SerpAnalysisCard } from "@/client/features/keywords/components";
+import {
+  GoogleAdsAvailabilityNotice,
+  SerpAnalysisCard,
+} from "@/client/features/keywords/components";
 import { FilterIntentSelect } from "./keywordResearchFilters";
 import { KeywordResearchDesktopTable } from "./KeywordResearchDesktopTable";
 import {
@@ -136,6 +139,11 @@ function MobileKeywordResults({ controller }: Props) {
           No exact match for{" "}
           <span className="font-medium">"{controller.searchedKeyword}"</span>.
           Showing closest related keywords.
+        </div>
+      ) : null}
+      {controller.lastResultSource === "google_ads" ? (
+        <div className="mx-4 mt-2">
+          <GoogleAdsAvailabilityNotice />
         </div>
       ) : null}
 

--- a/src/server/mcp/tools/dataforseo-research-tools.google-ads.test.ts
+++ b/src/server/mcp/tools/dataforseo-research-tools.google-ads.test.ts
@@ -117,11 +117,19 @@ describe("get_keyword_metrics for Google-Ads-only locations", () => {
       keyword: "hotel reykjavik",
       search_volume: 1300,
       keyword_difficulty: null,
+      keyword_difficulty_status: "not_available",
       main_intent: null,
+      main_intent_status: "not_available",
       cpc: 2.54,
       competition: 0.42,
       competition_level: "HIGH",
     });
+    expect(
+      result.content
+        .filter((item) => item.type === "text")
+        .map((item) => item.text)
+        .join("\n"),
+    ).toContain("not_available");
   });
 
   it("passes the clickstream opt-in to Labs and prefers refined volumes", async () => {

--- a/src/server/mcp/tools/dataforseo-research-tools.ts
+++ b/src/server/mcp/tools/dataforseo-research-tools.ts
@@ -460,7 +460,11 @@ function toMcpKeywordMetricRow(row: KeywordMetricRow) {
     keyword: row.keyword,
     search_volume: row.searchVolume,
     keyword_difficulty: row.keywordDifficulty,
+    keyword_difficulty_status:
+      row.keywordDifficulty == null ? "not_available" : "available",
     main_intent: row.intent,
+    main_intent_status:
+      row.intent == null || row.intent === "" ? "not_available" : "available",
     cpc: row.cpc,
     competition: row.competition,
     competition_level: row.competitionLevel,
@@ -581,10 +585,19 @@ const SERP_COMPETITOR_COLUMNS: McpTableColumn<unknown>[] = [
 const KEYWORD_METRIC_COLUMNS: McpTableColumn<unknown>[] = [
   { header: "keyword", value: (row) => readPath(row, "keyword") },
   { header: "volume", value: (row) => readPath(row, "search_volume") },
-  { header: "KD", value: (row) => readPath(row, "keyword_difficulty") },
+  {
+    header: "KD",
+    value: (row) =>
+      readPath(row, "keyword_difficulty") ??
+      readPath(row, "keyword_difficulty_status"),
+  },
   { header: "CPC", value: (row) => readPath(row, "cpc") },
   { header: "competition", value: (row) => readPath(row, "competition") },
-  { header: "intent", value: (row) => readPath(row, "main_intent") },
+  {
+    header: "intent",
+    value: (row) =>
+      readPath(row, "main_intent") ?? readPath(row, "main_intent_status"),
+  },
 ];
 
 export const getRankedKeywordsTool = {
@@ -868,7 +881,7 @@ export const getKeywordMetricsTool = {
         : row,
     );
 
-    const header = `Fetched metrics for ${rows.length} keywords. Columns: volume = monthly searches, KD = keyword difficulty (0-100), CPC in USD, competition = paid competition (0-1); "—" = unavailable.`;
+    const header = `Fetched metrics for ${rows.length} keywords. Columns: volume = monthly searches, KD = keyword difficulty (0-100), CPC in USD, competition = paid competition (0-1); not_available = unsupported by this provider.`;
     return mcpResponse({
       text:
         rows.length === 0

--- a/src/shared/keyword-locations.test.ts
+++ b/src/shared/keyword-locations.test.ts
@@ -17,6 +17,10 @@ describe("keyword locations", () => {
   it("routes Labs-supported countries to labs", () => {
     expect(getKeywordDataProvider(2840)).toBe("labs"); // US
     expect(getKeywordDataProvider(2826)).toBe("labs"); // UK
+    expect(getKeywordDataProvider(2344)).toBe("labs"); // Hong Kong
+    expect(isSupportedLocationCode(2344)).toBe(true);
+    expect(isLabsLocationCode(2344)).toBe(true);
+    expect(getLanguageCode(2344)).toBe("zh-TW");
   });
 
   it("routes Google-Ads-only countries to google_ads", () => {
@@ -24,6 +28,10 @@ describe("keyword locations", () => {
     expect(isSupportedLocationCode(2352)).toBe(true);
     expect(isLabsLocationCode(2352)).toBe(false);
     expect(getLanguageCode(2352)).toBe("is");
+    expect(getKeywordDataProvider(2446)).toBe("google_ads"); // Macao
+    expect(isSupportedLocationCode(2446)).toBe(true);
+    expect(isLabsLocationCode(2446)).toBe(false);
+    expect(getLanguageCode(2446)).toBe("zh-TW");
   });
 
   it("falls back to labs for unknown codes (Labs rejects them upstream)", () => {
@@ -72,6 +80,8 @@ describe("getIsoCountryCode", () => {
   it("lowercases the shortLabel for standard countries", () => {
     expect(getIsoCountryCode(2840)).toBe("us");
     expect(getIsoCountryCode(2036)).toBe("au");
+    expect(getIsoCountryCode(2344)).toBe("hk");
+    expect(getIsoCountryCode(2446)).toBe("mo");
   });
 
   it("maps the UK display label to its ISO code gb", () => {

--- a/src/shared/keyword-locations.ts
+++ b/src/shared/keyword-locations.ts
@@ -295,6 +295,13 @@ export const LOCATION_OPTIONS: readonly LocationOption[] = [
     googleAdsOnly: true,
   },
   {
+    code: 2446,
+    label: "Macao",
+    shortLabel: "MO",
+    languageCode: "zh-TW",
+    googleAdsOnly: true,
+  },
+  {
     code: 2450,
     label: "Madagascar",
     shortLabel: "MG",


### PR DESCRIPTION
Closes #90.\n\nThis adds Macao location 2446 with zh-TW routing through Google Ads keyword endpoints. Labs-derived KD and intent remain unavailable for Macao and are represented as not_available instead of numeric zero. Hong Kong keeps its existing Labs routing.\n\nThe UI now shows a focused availability notice on desktop and mobile results, and the MCP normalization exposes capability metadata consistently.\n\nValidation:\n- 23 focused Vitest tests passed\n- TypeScript typecheck passed\n- type-aware oxlint passed with 0 warnings/errors\n- Prettier check passed\n\nThe patch is intentionally limited to location routing, unsupported-metric semantics, UI notice, and regression coverage.