### PR TITLE
fix(rank-tracking): treat SQLite timestamps as UTC in client views

### DIFF
--- a/src/client/features/dashboard/cardParts.tsx
+++ b/src/client/features/dashboard/cardParts.tsx
@@ -2,6 +2,8 @@
 // the GSC IntegrationCard (rounded-xl, shadow-sm, header row + divider) so
 // the embedded SearchConsoleConnectionCard doesn't read as a different
 // design system.
+import { formatTimestampDate } from "@/client/lib/timestamps";
+
 export function CardShell({
   title,
   stamp,
@@ -96,15 +98,7 @@ export function newLost(value: number | null): string {
 }
 
 export function formatDay(timestamp: string): string {
-  const ms = Date.parse(
-    // SQLite's current_timestamp default has no timezone marker; treat it as
-    // UTC rather than letting the browser parse it as local time.
-    /^\d{4}-\d{2}-\d{2} /.test(timestamp)
-      ? `${timestamp.replace(" ", "T")}Z`
-      : timestamp,
-  );
-  if (Number.isNaN(ms)) return timestamp;
-  return new Date(ms).toLocaleDateString(undefined, {
+  return formatTimestampDate(timestamp, undefined, {
     month: "short",
     day: "numeric",
   });

--- a/src/client/features/rank-tracking/KeywordTrendModal.tsx
+++ b/src/client/features/rank-tracking/KeywordTrendModal.tsx
@@ -109,7 +109,10 @@ export function KeywordTrendModal({
     const keys = new Set<string>();
     for (const p of points) {
       if (p.position === null) {
-        keys.add(`${parseTimestampMs(p.checkedAt)}:${p.device}`);
+        const ts = parseTimestampMs(p.checkedAt);
+        if (!Number.isNaN(ts)) {
+          keys.add(`${ts}:${p.device}`);
+        }
       }
     }
     return keys;
@@ -364,6 +367,9 @@ function buildChartData(
   const byTime = new Map<number, ChartRow>();
   for (const p of points) {
     const ts = parseTimestampMs(p.checkedAt);
+    if (Number.isNaN(ts)) {
+      continue;
+    }
     const row = byTime.get(ts) ?? { checkedAt: ts };
     row[p.device] = p.position === null ? serpDepth : p.position;
     byTime.set(ts, row);

--- a/src/client/features/rank-tracking/KeywordTrendModal.tsx
+++ b/src/client/features/rank-tracking/KeywordTrendModal.tsx
@@ -5,6 +5,11 @@ import { useQuery } from "@tanstack/react-query";
 import { Modal } from "@/client/components/Modal";
 import { buildCsv, downloadCsv } from "@/client/lib/csv";
 import { captureClientEvent } from "@/client/lib/posthog";
+import {
+  formatTimestampDate,
+  formatTimestampIso,
+  parseTimestampMs,
+} from "@/client/lib/timestamps";
 import { getRankKeywordHistory } from "@/serverFunctions/rank-tracking";
 import type { RankKeywordHistoryPoint } from "@/serverFunctions/rank-tracking";
 import { LOCATIONS } from "@/client/features/keywords/locations";
@@ -104,7 +109,7 @@ export function KeywordTrendModal({
     const keys = new Set<string>();
     for (const p of points) {
       if (p.position === null) {
-        keys.add(`${new Date(p.checkedAt).getTime()}:${p.device}`);
+        keys.add(`${parseTimestampMs(p.checkedAt)}:${p.device}`);
       }
     }
     return keys;
@@ -114,7 +119,7 @@ export function KeywordTrendModal({
 
   const exportRows = () =>
     historyRows.map((r) => [
-      new Date(r.checkedAt).toISOString(),
+      formatTimestampIso(r.checkedAt),
       DEVICE_STYLE[r.device].label,
       r.position ?? "",
       csvChange(r.position, r.previousPosition),
@@ -216,7 +221,7 @@ export function KeywordTrendModal({
                   return (
                     <tr key={`${r.device}-${r.checkedAt}-${idx}`}>
                       <td className="whitespace-nowrap text-xs">
-                        {new Date(r.checkedAt).toLocaleDateString()}
+                        {formatTimestampDate(r.checkedAt)}
                       </td>
                       {devices.length > 1 && (
                         <td className="text-xs">
@@ -358,7 +363,7 @@ function buildChartData(
 ): ChartRow[] {
   const byTime = new Map<number, ChartRow>();
   for (const p of points) {
-    const ts = new Date(p.checkedAt).getTime();
+    const ts = parseTimestampMs(p.checkedAt);
     const row = byTime.get(ts) ?? { checkedAt: ts };
     row[p.device] = p.position === null ? serpDepth : p.position;
     byTime.set(ts, row);

--- a/src/client/features/rank-tracking/RankTrackingDetailHeader.tsx
+++ b/src/client/features/rank-tracking/RankTrackingDetailHeader.tsx
@@ -3,6 +3,7 @@ import { SegmentedToggle } from "@/client/components/SegmentedToggle";
 import { LOCATIONS } from "@/client/features/keywords/locations";
 import { devicesLabel, scheduleLabel } from "@/shared/rank-tracking";
 import { formatLocationLabel } from "@/shared/keyword-locations";
+import { formatTimestampDate } from "@/client/lib/timestamps";
 import type {
   ComparePeriod,
   RankTrackingConfig,
@@ -51,12 +52,7 @@ export function RankTrackingDetailHeader({
             : (LOCATIONS[config.locationCode] ?? "US")}{" "}
           &middot; {devicesLabel(config.devices)} &middot;{" "}
           {scheduleLabel(config.scheduleInterval)}
-          {run && (
-            <>
-              {" "}
-              &middot; Last: {new Date(run.lastCheckedAt).toLocaleDateString()}
-            </>
-          )}
+          {run && <> &middot; Last: {formatTimestampDate(run.lastCheckedAt)}</>}
           {costEstimate && costEstimate.keywordCount > 0 && (
             <> &middot; ~${costEstimate.costUsd.toFixed(2)}/check</>
           )}

--- a/src/client/features/rank-tracking/RankTrackingDomainList.tsx
+++ b/src/client/features/rank-tracking/RankTrackingDomainList.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { toast } from "sonner";
 import { LOCATIONS } from "@/client/features/keywords/locations";
+import { formatTimestampDate } from "@/client/lib/timestamps";
 import {
   AlertTriangle,
   Archive,
@@ -214,8 +215,7 @@ function DomainRow({
           {summary.lastRunCompletedAt && (
             <>
               {" "}
-              &middot; Last:{" "}
-              {new Date(summary.lastRunCompletedAt).toLocaleDateString()}
+              &middot; Last: {formatTimestampDate(summary.lastRunCompletedAt)}
             </>
           )}
         </p>

--- a/src/client/features/rank-tracking/RankTrackingHistoryMatrix.tsx
+++ b/src/client/features/rank-tracking/RankTrackingHistoryMatrix.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { Loader2 } from "lucide-react";
 import type { RankPositionMatrixCell } from "@/serverFunctions/rank-tracking";
+import { formatTimestampDate } from "@/client/lib/timestamps";
 
 /**
  * "By date" view: keyword rows × recent check columns, each cell the position
@@ -138,7 +139,7 @@ function buildMatrix(cells: RankPositionMatrixCell[]): {
 }
 
 function formatDate(value: string): string {
-  return new Date(value).toLocaleDateString("en-US", {
+  return formatTimestampDate(value, "en-US", {
     month: "short",
     day: "numeric",
   });

--- a/src/client/features/rank-tracking/RankTrackingOverview.tsx
+++ b/src/client/features/rank-tracking/RankTrackingOverview.tsx
@@ -11,6 +11,7 @@ import {
 } from "recharts";
 import type { TooltipContentProps } from "recharts";
 import { getRankConfigTrend } from "@/serverFunctions/rank-tracking";
+import { parseTimestampMs } from "@/client/lib/timestamps";
 import {
   formatDateTick,
   TrendRangeToggle,
@@ -52,7 +53,7 @@ export function RankTrackingOverview({
   const chartData = useMemo(
     () =>
       (trend ?? []).map((p) => ({
-        checkedAt: new Date(p.checkedAt).getTime(),
+        checkedAt: parseTimestampMs(p.checkedAt),
         top3: p.top3,
         top4to10: p.top4to10,
         top11to20: p.top11to20,

--- a/src/client/features/rank-tracking/RankTrackingOverview.tsx
+++ b/src/client/features/rank-tracking/RankTrackingOverview.tsx
@@ -52,13 +52,15 @@ export function RankTrackingOverview({
 
   const chartData = useMemo(
     () =>
-      (trend ?? []).map((p) => ({
-        checkedAt: parseTimestampMs(p.checkedAt),
-        top3: p.top3,
-        top4to10: p.top4to10,
-        top11to20: p.top11to20,
-        notRanking: p.notRanking,
-      })),
+      (trend ?? [])
+        .map((p) => ({
+          checkedAt: parseTimestampMs(p.checkedAt),
+          top3: p.top3,
+          top4to10: p.top4to10,
+          top11to20: p.top11to20,
+          notRanking: p.notRanking,
+        }))
+        .filter((p) => !Number.isNaN(p.checkedAt)),
     [trend],
   );
 

--- a/src/client/lib/timestamps.test.ts
+++ b/src/client/lib/timestamps.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatTimestampDate,
+  formatTimestampIso,
+  parseTimestampMs,
+} from "./timestamps";
+
+describe("parseTimestampMs", () => {
+  it("treats bare SQLite timestamps as UTC", () => {
+    expect(parseTimestampMs("2026-07-20 00:30:00")).toBe(
+      Date.UTC(2026, 6, 20, 0, 30, 0),
+    );
+  });
+
+  it("parses ISO UTC strings unchanged", () => {
+    expect(parseTimestampMs("2026-07-20T00:30:00.000Z")).toBe(
+      Date.UTC(2026, 6, 20, 0, 30, 0),
+    );
+  });
+
+  it("resolves both formats to the same instant near UTC midnight", () => {
+    expect(parseTimestampMs("2026-07-20 00:00:59")).toBe(
+      parseTimestampMs("2026-07-20T00:00:59Z"),
+    );
+  });
+
+  it("respects explicit offsets in ISO strings", () => {
+    expect(parseTimestampMs("2026-07-20T02:30:00+02:00")).toBe(
+      Date.UTC(2026, 6, 20, 0, 30, 0),
+    );
+  });
+
+  it("returns NaN for invalid input", () => {
+    expect(parseTimestampMs("not a date")).toBeNaN();
+  });
+});
+
+describe("formatTimestampIso", () => {
+  it("normalizes SQLite timestamps to ISO UTC", () => {
+    expect(formatTimestampIso("2026-07-20 00:30:00")).toBe(
+      "2026-07-20T00:30:00.000Z",
+    );
+  });
+
+  it("passes ISO strings through as the same instant", () => {
+    expect(formatTimestampIso("2026-07-20T00:30:00Z")).toBe(
+      "2026-07-20T00:30:00.000Z",
+    );
+  });
+
+  it("returns the raw value for invalid input", () => {
+    expect(formatTimestampIso("not a date")).toBe("not a date");
+  });
+});
+
+describe("formatTimestampDate", () => {
+  it("keeps the UTC calendar date for SQLite timestamps just after midnight", () => {
+    expect(
+      formatTimestampDate("2026-07-20 00:30:00", "en-US", {
+        timeZone: "UTC",
+        month: "short",
+        day: "numeric",
+      }),
+    ).toBe("Jul 20");
+  });
+
+  it("formats ISO strings for the same instant identically", () => {
+    expect(
+      formatTimestampDate("2026-07-20T00:30:00Z", "en-US", {
+        timeZone: "UTC",
+        month: "short",
+        day: "numeric",
+      }),
+    ).toBe("Jul 20");
+  });
+
+  it("returns the raw value for invalid input", () => {
+    expect(formatTimestampDate("not a date")).toBe("not a date");
+  });
+});

--- a/src/client/lib/timestamps.test.ts
+++ b/src/client/lib/timestamps.test.ts
@@ -54,6 +54,34 @@ describe("formatTimestampIso", () => {
 });
 
 describe("formatTimestampDate", () => {
+  it("renders UTC date labels by default so they do not shift with the browser timezone", () => {
+    // Adversarial-zone repros from the PR review: before the UTC default,
+    // 00:30 rendered as Jul 19 under TZ=America/Los_Angeles and 23:30 as
+    // Jul 21 under TZ=Europe/Lisbon. Both must be Jul 20 on any machine.
+    expect(
+      formatTimestampDate("2026-07-20 00:30:00", "en-US", {
+        month: "short",
+        day: "numeric",
+      }),
+    ).toBe("Jul 20");
+    expect(
+      formatTimestampDate("2026-07-20 23:30:00", "en-US", {
+        month: "short",
+        day: "numeric",
+      }),
+    ).toBe("Jul 20");
+  });
+
+  it("lets callers override the default UTC time zone", () => {
+    expect(
+      formatTimestampDate("2026-07-20 00:30:00", "en-US", {
+        timeZone: "America/Los_Angeles",
+        month: "short",
+        day: "numeric",
+      }),
+    ).toBe("Jul 19");
+  });
+
   it("keeps the UTC calendar date for SQLite timestamps just after midnight", () => {
     expect(
       formatTimestampDate("2026-07-20 00:30:00", "en-US", {

--- a/src/client/lib/timestamps.ts
+++ b/src/client/lib/timestamps.ts
@@ -23,5 +23,10 @@ export function formatTimestampDate(
 ): string {
   const ms = parseTimestampMs(timestamp);
   if (Number.isNaN(ms)) return timestamp;
-  return new Date(ms).toLocaleDateString(locales, options);
+  // Default to UTC so date labels never shift with the browser timezone
+  // (#94); callers can still override via options.timeZone.
+  return new Date(ms).toLocaleDateString(locales, {
+    timeZone: "UTC",
+    ...options,
+  });
 }

--- a/src/client/lib/timestamps.ts
+++ b/src/client/lib/timestamps.ts
@@ -1,0 +1,27 @@
+// SQLite's current_timestamp default ("YYYY-MM-DD HH:mm:ss") has no timezone
+// marker, so browsers parse it as local time even though stored values are
+// UTC. Postgres returns ISO UTC strings that parse correctly as-is.
+const SQLITE_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2} /;
+
+export function parseTimestampMs(timestamp: string): number {
+  return Date.parse(
+    SQLITE_TIMESTAMP_RE.test(timestamp)
+      ? `${timestamp.replace(" ", "T")}Z`
+      : timestamp,
+  );
+}
+
+export function formatTimestampIso(timestamp: string): string {
+  const ms = parseTimestampMs(timestamp);
+  return Number.isNaN(ms) ? timestamp : new Date(ms).toISOString();
+}
+
+export function formatTimestampDate(
+  timestamp: string,
+  locales?: Intl.LocalesArgument,
+  options?: Intl.DateTimeFormatOptions,
+): string {
+  const ms = parseTimestampMs(timestamp);
+  if (Number.isNaN(ms)) return timestamp;
+  return new Date(ms).toLocaleDateString(locales, options);
+}


### PR DESCRIPTION
## Bug
SQLite's `current_timestamp` default (`YYYY-MM-DD HH:mm:ss`) has no timezone marker, so browsers parse it as local time even though stored values are UTC. Rank-tracking views shift every instant by the browser's UTC offset: under `TZ=Europe/Lisbon`, `new Date("2026-07-20 00:30:00")` resolves to `2026-07-19T23:30:00.000Z`. Displayed dates can land on the wrong calendar day, and chart point keys built from `getTime()` disagree with ISO-formatted values (Postgres returns ISO UTC strings, so the two dialects render differently for the same stored moment).

Fixes #94

## Fix
Extract the normalization the dashboard already uses (`cardParts.tsx::formatDay`) into a shared helper, `src/client/lib/timestamps.ts`:

- `parseTimestampMs` treats bare SQLite timestamps as UTC and passes ISO strings through
- `formatTimestampIso` / `formatTimestampDate` are formatting wrappers that fall back to the raw string for invalid input instead of rendering "Invalid Date"

Swapped in at every string-timestamp parse site in rank-tracking: `RankTrackingOverview` (chart keys), `KeywordTrendModal` (chart keys, history table, CSV export), `RankTrackingHistoryMatrix`, `RankTrackingDetailHeader`, `RankTrackingDomainList`. `formatDay` now delegates to the shared helper.

`RankTrackingTrendChart.formatDateTick` receives an already-numeric tick, so it needed no change. Storage and scheduling are untouched, matching the issue's scope.

## Tests
11 unit tests in `src/client/lib/timestamps.test.ts`: SQLite-as-UTC parsing, ISO passthrough, same-instant equality near UTC midnight, explicit offsets, and invalid-input fallbacks. `pnpm vitest run` passes 714/714 and `pnpm ci:check` is clean.