### PR TITLE
Fix SQLite rank-tracking timestamp parsing

### DIFF
--- a/src/client/features/dashboard/cardParts.tsx
+++ b/src/client/features/dashboard/cardParts.tsx
@@ -1,3 +1,5 @@
+import { parseStoredTimestamp } from "@/shared/stored-timestamps";
+
 // Shared building blocks for the dashboard cards. Same visual language as
 // the GSC IntegrationCard (rounded-xl, shadow-sm, header row + divider) so
 // the embedded SearchConsoleConnectionCard doesn't read as a different
@@ -96,16 +98,10 @@ export function newLost(value: number | null): string {
 }
 
 export function formatDay(timestamp: string): string {
-  const ms = Date.parse(
-    // SQLite's current_timestamp default has no timezone marker; treat it as
-    // UTC rather than letting the browser parse it as local time.
-    /^\d{4}-\d{2}-\d{2} /.test(timestamp)
-      ? `${timestamp.replace(" ", "T")}Z`
-      : timestamp,
+  return (
+    parseStoredTimestamp(timestamp)?.toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric",
+    }) ?? timestamp
   );
-  if (Number.isNaN(ms)) return timestamp;
-  return new Date(ms).toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-  });
 }

--- a/src/client/features/rank-tracking/KeywordTrendModal.tsx
+++ b/src/client/features/rank-tracking/KeywordTrendModal.tsx
@@ -9,6 +9,7 @@ import { getRankKeywordHistory } from "@/serverFunctions/rank-tracking";
 import type { RankKeywordHistoryPoint } from "@/serverFunctions/rank-tracking";
 import { LOCATIONS } from "@/client/features/keywords/locations";
 import { formatLocationLabel } from "@/shared/keyword-locations";
+import { parseStoredTimestamp } from "@/shared/stored-timestamps";
 import { csvChange, DeviceRankCell } from "./RankTrackingTableParts";
 import {
   RankTrendChart,
@@ -104,7 +105,8 @@ export function KeywordTrendModal({
     const keys = new Set<string>();
     for (const p of points) {
       if (p.position === null) {
-        keys.add(`${new Date(p.checkedAt).getTime()}:${p.device}`);
+        const checkedAt = parseStoredTimestamp(p.checkedAt);
+        if (checkedAt) keys.add(`${checkedAt.getTime()}:${p.device}`);
       }
     }
     return keys;
@@ -114,7 +116,7 @@ export function KeywordTrendModal({
 
   const exportRows = () =>
     historyRows.map((r) => [
-      new Date(r.checkedAt).toISOString(),
+      parseStoredTimestamp(r.checkedAt)?.toISOString() ?? r.checkedAt,
       DEVICE_STYLE[r.device].label,
       r.position ?? "",
       csvChange(r.position, r.previousPosition),
@@ -216,7 +218,9 @@ export function KeywordTrendModal({
                   return (
                     <tr key={`${r.device}-${r.checkedAt}-${idx}`}>
                       <td className="whitespace-nowrap text-xs">
-                        {new Date(r.checkedAt).toLocaleDateString()}
+                        {parseStoredTimestamp(
+                          r.checkedAt,
+                        )?.toLocaleDateString() ?? r.checkedAt}
                       </td>
                       {devices.length > 1 && (
                         <td className="text-xs">
@@ -358,7 +362,8 @@ function buildChartData(
 ): ChartRow[] {
   const byTime = new Map<number, ChartRow>();
   for (const p of points) {
-    const ts = new Date(p.checkedAt).getTime();
+    const ts = parseStoredTimestamp(p.checkedAt)?.getTime();
+    if (ts === undefined) continue;
     const row = byTime.get(ts) ?? { checkedAt: ts };
     row[p.device] = p.position === null ? serpDepth : p.position;
     byTime.set(ts, row);

--- a/src/client/features/rank-tracking/RankTrackingDetailHeader.tsx
+++ b/src/client/features/rank-tracking/RankTrackingDetailHeader.tsx
@@ -3,6 +3,7 @@ import { SegmentedToggle } from "@/client/components/SegmentedToggle";
 import { LOCATIONS } from "@/client/features/keywords/locations";
 import { devicesLabel, scheduleLabel } from "@/shared/rank-tracking";
 import { formatLocationLabel } from "@/shared/keyword-locations";
+import { parseStoredTimestamp } from "@/shared/stored-timestamps";
 import type {
   ComparePeriod,
   RankTrackingConfig,
@@ -54,7 +55,9 @@ export function RankTrackingDetailHeader({
           {run && (
             <>
               {" "}
-              &middot; Last: {new Date(run.lastCheckedAt).toLocaleDateString()}
+              &middot; Last:{" "}
+              {parseStoredTimestamp(run.lastCheckedAt)?.toLocaleDateString() ??
+                run.lastCheckedAt}
             </>
           )}
           {costEstimate && costEstimate.keywordCount > 0 && (

--- a/src/client/features/rank-tracking/RankTrackingDomainList.tsx
+++ b/src/client/features/rank-tracking/RankTrackingDomainList.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/serverFunctions/rank-tracking";
 import { devicesLabel, scheduleLabel } from "@/shared/rank-tracking";
 import { formatLocationLabel } from "@/shared/keyword-locations";
+import { parseStoredTimestamp } from "@/shared/stored-timestamps";
 import { Modal } from "@/client/components/Modal";
 import {
   applyDomainListFilters,
@@ -215,7 +216,9 @@ function DomainRow({
             <>
               {" "}
               &middot; Last:{" "}
-              {new Date(summary.lastRunCompletedAt).toLocaleDateString()}
+              {parseStoredTimestamp(
+                summary.lastRunCompletedAt,
+              )?.toLocaleDateString() ?? summary.lastRunCompletedAt}
             </>
           )}
         </p>

--- a/src/client/features/rank-tracking/RankTrackingHistoryMatrix.tsx
+++ b/src/client/features/rank-tracking/RankTrackingHistoryMatrix.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { Loader2 } from "lucide-react";
 import type { RankPositionMatrixCell } from "@/serverFunctions/rank-tracking";
+import { parseStoredTimestamp } from "@/shared/stored-timestamps";
 
 /**
  * "By date" view: keyword rows × recent check columns, each cell the position
@@ -138,8 +139,10 @@ function buildMatrix(cells: RankPositionMatrixCell[]): {
 }
 
 function formatDate(value: string): string {
-  return new Date(value).toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-  });
+  return (
+    parseStoredTimestamp(value)?.toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+    }) ?? value
+  );
 }

--- a/src/client/features/rank-tracking/RankTrackingOverview.tsx
+++ b/src/client/features/rank-tracking/RankTrackingOverview.tsx
@@ -11,6 +11,7 @@ import {
 } from "recharts";
 import type { TooltipContentProps } from "recharts";
 import { getRankConfigTrend } from "@/serverFunctions/rank-tracking";
+import { parseStoredTimestamp } from "@/shared/stored-timestamps";
 import {
   formatDateTick,
   TrendRangeToggle,
@@ -51,13 +52,20 @@ export function RankTrackingOverview({
 
   const chartData = useMemo(
     () =>
-      (trend ?? []).map((p) => ({
-        checkedAt: new Date(p.checkedAt).getTime(),
-        top3: p.top3,
-        top4to10: p.top4to10,
-        top11to20: p.top11to20,
-        notRanking: p.notRanking,
-      })),
+      (trend ?? []).flatMap((p) => {
+        const checkedAt = parseStoredTimestamp(p.checkedAt)?.getTime();
+        return checkedAt === undefined
+          ? []
+          : [
+              {
+                checkedAt,
+                top3: p.top3,
+                top4to10: p.top4to10,
+                top11to20: p.top11to20,
+                notRanking: p.notRanking,
+              },
+            ];
+      }),
     [trend],
   );
 

--- a/src/shared/stored-timestamps.test.ts
+++ b/src/shared/stored-timestamps.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { parseStoredTimestamp } from "./stored-timestamps";
+
+describe("parseStoredTimestamp", () => {
+  it("treats SQLite current_timestamp values as UTC", () => {
+    expect(parseStoredTimestamp("2026-07-20 00:30:00")?.toISOString()).toBe(
+      "2026-07-20T00:30:00.000Z",
+    );
+  });
+
+  it("preserves ISO timestamps from Postgres", () => {
+    expect(
+      parseStoredTimestamp("2026-07-20T00:30:00.789Z")?.toISOString(),
+    ).toBe("2026-07-20T00:30:00.789Z");
+  });
+
+  it("returns null for invalid timestamps", () => {
+    expect(parseStoredTimestamp("not-a-timestamp")).toBeNull();
+  });
+});

--- a/src/shared/stored-timestamps.ts
+++ b/src/shared/stored-timestamps.ts
@@ -1,0 +1,10 @@
+const SQLITE_UTC_TIMESTAMP = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(?:\.\d+)?$/;
+
+/** Parse timestamp text stored by either the SQLite or Postgres backend. */
+export function parseStoredTimestamp(value: string): Date | null {
+  const normalized = SQLITE_UTC_TIMESTAMP.test(value)
+    ? `${value.replace(" ", "T")}Z`
+    : value;
+  const timestamp = Date.parse(normalized);
+  return Number.isNaN(timestamp) ? null : new Date(timestamp);
+}


### PR DESCRIPTION
Closes #94.

## What changed

- Added a shared timestamp parser for text stored by either backend.
- Treats SQLite `current_timestamp` values (`YYYY-MM-DD HH:mm:ss`) as UTC instead of browser-local time.
- Preserves Postgres ISO timestamps unchanged.
- Updated rank-tracking charts, history tables, exports, domain summaries, and detail headers to use the shared parser.
- Invalid timestamp text now degrades safely instead of throwing during render or export.
- Reused the parser in the dashboard's existing SQLite timestamp normalization to keep the invariant in one place.

## Why

SQLite stores UTC timestamps without a timezone marker. Passing those strings directly to `new Date(...)` makes browsers interpret them as local time. For example, in `Europe/Lisbon`, stored UTC `2026-07-20 00:30:00` becomes `2026-07-19T23:30:00.000Z`, shifting chart points and date labels to the previous day.

Postgres stores ISO UTC strings, so the parser normalizes both backends to the same instant without changing storage or scheduling formats.

## Validation

- `pnpm ci:check`
- `pnpm test:ci` — 87 files, 706 tests passed
- `pnpm vite build` — production client and worker build passed
- Focused tests cover SQLite UTC, Postgres ISO, and invalid timestamp inputs
