### PR TITLE
Document reproducible contributor verification

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -16,4 +16,18 @@ See [LOCAL_DEVELOPMENT.md](./LOCAL_DEVELOPMENT.md) for how to run the app locall
 
 - Keep PRs focused: one feature or fix per PR.
 - For larger features, open an issue first so we can align on the approach before you invest time.
-- Make sure `pnpm ci:check` passes before requesting review.
+- Before requesting review, run the same root checks used by CI:
+
+  ```sh
+  pnpm ci:check
+  pnpm test:ci
+  pnpm vite build
+  ```
+
+- If you changed the website under `web/`, also run:
+
+  ```sh
+  pnpm --dir web install --frozen-lockfile
+  pnpm --dir web run types:check
+  pnpm --dir web run build
+  ```

--- a/docs/LOCAL_DEVELOPMENT.md
+++ b/docs/LOCAL_DEVELOPMENT.md
@@ -3,17 +3,23 @@
 ## Prerequisites
 
 - Node.js 20+
-- [pnpm](https://pnpm.io/)
+- [Corepack](https://nodejs.org/api/corepack.html) (bundled through Node.js 24; install it separately on Node.js 25+)
 - A DataForSEO account/API credentials
 
 ## Local Development Workflow
 
 ```sh
-pnpm install
+# Activates the exact pnpm version declared in package.json.
+corepack enable
+pnpm install --frozen-lockfile
 
 # Run once per fresh local DB
 pnpm run db:migrate:local
 ```
+
+Verify that `pnpm --version` reports the version declared by the
+`packageManager` field in `package.json`. An older global pnpm may reject
+the repository's lockfile as incompatible.
 
 Configure `.env.local`:
 


### PR DESCRIPTION
## What changed

- Documented Corepack setup so contributors use the exact pnpm version declared in `package.json` instead of an incompatible global pnpm.
- Switched the initial install command to `pnpm install --frozen-lockfile`.
- Expanded the pre-review checklist to match the root CI checks: static checks, tests, and production worker build.
- Added the website-specific install, typecheck, and build commands for changes under `web/`.

## Why

The current local-development guide accepts any pnpm version, while the repository pins pnpm 10.30.1. Older global pnpm releases reject the lockfile as incompatible. The contribution guide also asks only for `pnpm ci:check`, while GitHub Actions separately runs tests, the production worker build, and website validation.

This makes the documented contributor path reproduce CI failures before a PR is opened.

## Validation

- `pnpm ci:check`
- Markdown formatting check passed

Corepack is bundled through Node.js 24 and must be installed separately on Node.js 25+, matching the current Node.js documentation.
