### PR TITLE
test(e2e): update landing redirect assertions for dashboard landing page

### DIFF
--- a/e2e/domain-overview-test-utils.ts
+++ b/e2e/domain-overview-test-utils.ts
@@ -181,11 +181,11 @@ export async function openDomainOverview(page: Page, tab: DomainTab) {
     window.sessionStorage.setItem("domain-overview-e2e-cleared", "1");
   });
   await page.goto("/");
-  await page.waitForURL(/\/p\/([^/]+)\/keywords(?:\?.*)?$/, {
+  await page.waitForURL(/\/p\/([^/]+)\/?$/, {
     timeout: 30_000,
   });
 
-  const match = page.url().match(/\/p\/([^/]+)\/keywords/);
+  const match = page.url().match(/\/p\/([^/]+)/);
   if (!match) throw new Error(`Could not read project id from ${page.url()}`);
 
   const params = new URLSearchParams({

--- a/e2e/keyword-research-navigation.spec.ts
+++ b/e2e/keyword-research-navigation.spec.ts
@@ -2,11 +2,11 @@ import { expect, test, type Page } from "@playwright/test";
 
 async function getProjectId(page: Page) {
   await page.goto("/");
-  await page.waitForURL(/\/p\/([^/]+)\/keywords(?:\?.*)?$/, {
+  await page.waitForURL(/\/p\/([^/]+)\/?$/, {
     timeout: 30_000,
   });
 
-  const match = page.url().match(/\/p\/([^/]+)\/keywords/);
+  const match = page.url().match(/\/p\/([^/]+)/);
   if (!match) throw new Error(`Could not read project id from ${page.url()}`);
   return match[1];
 }


### PR DESCRIPTION
The e2e suite has been red since #398 moved the landing redirect from `/p/:id/keywords` to `/p/:id` (the new project dashboard): both suites still wait for a `/p/<id>/keywords` URL after visiting `/`, so every spec times out in `getProjectId` before the actual test starts.

This updates the two wait-for regexes to expect the dashboard landing.

With this, 9 of 11 specs pass. The remaining two domain tab-close specs fail on a separate tab-persistence bug — that's #108; with both, the suite is fully green.
