### PR TITLE
docs: add community Railway self-hosting option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,12 @@ OpenSEO exposes an MCP server so AI agents like Claude Code, OpenClaw, and Herme
 
 ## Self-Hosting
 
-OpenSEO supports two self-hosting paths:
+OpenSEO supports these self-hosting paths:
 
 - **Simple: Docker** for personal use on your own machine (recommended for getting started). See [`docs/SELF_HOSTING_DOCKER.md`](./docs/SELF_HOSTING_DOCKER.md).
+- **Railway** for one-click cloud Docker hosting with a persistent volume (community template). See [`docs/SELF_HOSTING_RAILWAY.md`](./docs/SELF_HOSTING_RAILWAY.md).
+
+  [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/openseo)
 - **Advanced: Cloudflare** for internet-facing self-hosting across multiple devices or with your team (works on the free plan). See [`docs/SELF_HOSTING_CLOUDFLARE.md`](./docs/SELF_HOSTING_CLOUDFLARE.md).
 
 Either way, you need a DataForSEO API key to get SEO data. See [`docs/DATAFORSEO_API_KEY.md`](./docs/DATAFORSEO_API_KEY.md).

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ OpenSEO supports these self-hosting paths:
 - **Railway** for one-click cloud Docker hosting with a persistent volume (community template). See [`docs/SELF_HOSTING_RAILWAY.md`](./docs/SELF_HOSTING_RAILWAY.md).
 
   [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/openseo)
+
 - **Advanced: Cloudflare** for internet-facing self-hosting across multiple devices or with your team (works on the free plan). See [`docs/SELF_HOSTING_CLOUDFLARE.md`](./docs/SELF_HOSTING_CLOUDFLARE.md).
 
 Either way, you need a DataForSEO API key to get SEO data. See [`docs/DATAFORSEO_API_KEY.md`](./docs/DATAFORSEO_API_KEY.md).

--- a/docs/SELF_HOSTING_RAILWAY.md
+++ b/docs/SELF_HOSTING_RAILWAY.md
@@ -1,0 +1,35 @@
+# Railway Self-Hosting
+
+Deploy OpenSEO on [Railway](https://railway.com) using the published Docker image (`ghcr.io/every-app/open-seo`) with a persistent volume.
+
+> **Community template:** [railway.com/deploy/openseo](https://railway.com/deploy/openseo) is a community Railway listing (Social Freak Network), not an official every-app product. Review the template overview before deploying.
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/openseo)
+
+## What you get
+
+- Image: `ghcr.io/every-app/open-seo` (semver tags)
+- Volume at `/app/.wrangler` for local D1/KV/R2 state (same path as Docker Compose)
+- No separate Postgres or Redis service
+
+## Requirements
+
+- A DataForSEO API key (see [`DATAFORSEO_API_KEY.md`](./DATAFORSEO_API_KEY.md)) — Base64 of `email:password`
+- Enough RAM for a multi-minute cold start (~4GB+ recommended; the image migrates and builds on start)
+
+## Security
+
+Railway Docker deploys use `AUTH_MODE=local_noauth` (no application login), same as [`SELF_HOSTING_DOCKER.md`](./SELF_HOSTING_DOCKER.md). Anyone who can reach the public URL can use the app as admin. Only expose it on a private network, behind your own auth proxy, or accept that risk for personal use.
+
+## After deploy
+
+1. Set `DATAFORSEO_API_KEY` when prompted (or in service variables).
+2. Confirm the public domain targets Railway’s `PORT` (often `8080`).
+3. Optionally enable **Image Auto Updates** (minor + patch) under service Settings → Source so new OpenSEO releases are pulled automatically.
+4. Prefer release tags over floating `:latest` if you want update-on-release behavior.
+
+## Related
+
+- Local Docker: [`SELF_HOSTING_DOCKER.md`](./SELF_HOSTING_DOCKER.md)
+- Cloudflare: [`SELF_HOSTING_CLOUDFLARE.md`](./SELF_HOSTING_CLOUDFLARE.md)
+- Template: https://railway.com/deploy/openseo


### PR DESCRIPTION
## Summary
- Adds a **Railway** self-hosting path to the README with a Deploy on Railway button pointing at the community template: https://railway.com/deploy/openseo
- Adds `docs/SELF_HOSTING_RAILWAY.md` covering the GHCR image + `/app/.wrangler` volume, DataForSEO key, `local_noauth` security note, and Image Auto Updates
- Clearly labels the template as a **community** listing (not an official every-app product)
- Deploy links use clean URLs with no UTM/tracking parameters

## Context
OpenSEO already ships a Docker self-host path (`ghcr.io/every-app/open-seo`). This template wraps that same image on Railway so people can one-click deploy with persistence. Happy to adjust wording/placement if you'd rather keep Railway out of the main README or link only from Discord.

## Test plan
- [ ] README Self-Hosting section renders the button and links correctly
- [ ] `docs/SELF_HOSTING_RAILWAY.md` links resolve
- [ ] Deploy button opens https://railway.com/deploy/openseo with no query params
