### PR TITLE
feat(mcp): add create_project tool

### DIFF
--- a/src/server/mcp/server.ts
+++ b/src/server/mcp/server.ts
@@ -6,6 +6,7 @@ import { getDomainKeywordSuggestionsTool } from "@/server/mcp/tools/get-domain-k
 import { getDomainOverviewTool } from "@/server/mcp/tools/get-domain-overview";
 import { getRankTrackerTool } from "@/server/mcp/tools/get-rank-tracker";
 import { getSerpResultsTool } from "@/server/mcp/tools/get-serp-results";
+import { createProjectTool } from "@/server/mcp/tools/create-project";
 import { listProjectsTool } from "@/server/mcp/tools/list-projects";
 import { listSavedKeywordsTool } from "@/server/mcp/tools/list-saved-keywords";
 import {
@@ -52,6 +53,15 @@ export function registerOpenSeoMcpTools(server: McpServer) {
       listProjectsTool.name,
       listProjectsTool.config.outputSchema,
       listProjectsTool.handler,
+    ),
+  );
+  server.registerTool(
+    createProjectTool.name,
+    createProjectTool.config,
+    instrumentMcpToolHandler(
+      createProjectTool.name,
+      createProjectTool.config.outputSchema,
+      createProjectTool.handler,
     ),
   );
   server.registerTool(

--- a/src/server/mcp/tools/create-project.test.ts
+++ b/src/server/mcp/tools/create-project.test.ts
@@ -1,0 +1,112 @@
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import type { ToolExtra } from "@/server/mcp/context";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MCP_AUTH_CONTEXT_PROP } from "@/server/mcp/context";
+
+const mocks = vi.hoisted(() => ({
+  createProject: vi.fn(),
+}));
+
+vi.mock("@/server/features/projects/services/ProjectService", () => ({
+  ProjectService: {
+    createProject: mocks.createProject,
+  },
+}));
+
+const authContext = {
+  userId: "user_123",
+  userEmail: "alice@example.com",
+  organizationId: "org_123",
+  clientId: "client_123",
+  scopes: ["mcp"],
+  audience: "https://open-seo.test/mcp",
+  subject: "user_123",
+  baseUrl: "https://open-seo.test",
+};
+
+const toolExtra: ToolExtra = {
+  signal: new AbortController().signal,
+  requestId: 1,
+  sendNotification: vi.fn(),
+  sendRequest: vi.fn(),
+  authInfo: {
+    token: "token",
+    clientId: "client_123",
+    scopes: ["mcp"],
+    resource: new URL("https://open-seo.test/mcp"),
+    extra: { [MCP_AUTH_CONTEXT_PROP]: authContext },
+  } satisfies AuthInfo,
+};
+
+describe("create_project MCP tool", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.createProject.mockReset();
+  });
+
+  it("creates a project scoped to the caller's organization and returns it", async () => {
+    mocks.createProject.mockResolvedValue({
+      id: "project_new",
+      name: "Acme",
+      domain: "acme.com",
+      locationCode: 2840,
+      languageCode: "en",
+    });
+    const { createProjectTool } = await import("./create-project");
+
+    const result = await createProjectTool.handler(
+      { name: "Acme", domain: "acme.com", locationCode: 2840 },
+      toolExtra,
+    );
+
+    // The schema does not derive languageCode; the service resolves it from
+    // the locationCode, so the tool forwards exactly what was validated.
+    expect(mocks.createProject).toHaveBeenCalledWith("org_123", {
+      name: "Acme",
+      domain: "acme.com",
+      locationCode: 2840,
+    });
+    expect(result.structuredContent?.project).toMatchObject({
+      id: "project_new",
+      name: "Acme",
+      domain: "acme.com",
+      locationCode: 2840,
+      languageCode: "en",
+      url: "https://open-seo.test/p/project_new",
+    });
+    const first = result.content?.[0];
+    expect(first?.type).toBe("text");
+    if (first?.type === "text") {
+      expect(first.text).toContain("project_new");
+    }
+  });
+
+  it("creates a minimal project with only a name (org default market)", async () => {
+    mocks.createProject.mockResolvedValue({
+      id: "project_min",
+      name: "Just a name",
+      domain: null,
+      locationCode: 2840,
+      languageCode: "en",
+    });
+    const { createProjectTool } = await import("./create-project");
+
+    await createProjectTool.handler({ name: "Just a name" }, toolExtra);
+
+    expect(mocks.createProject).toHaveBeenCalledWith("org_123", {
+      name: "Just a name",
+    });
+  });
+
+  it("rejects a languageCode without a locationCode (market pair rule)", async () => {
+    const { createProjectTool } = await import("./create-project");
+
+    await expect(
+      createProjectTool.handler(
+        { name: "Bad market", languageCode: "en" },
+        toolExtra,
+      ),
+    ).rejects.toThrow();
+    expect(mocks.createProject).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/mcp/tools/create-project.ts
+++ b/src/server/mcp/tools/create-project.ts
@@ -1,0 +1,98 @@
+import { ProjectService } from "@/server/features/projects/services/ProjectService";
+import { mcpResponse } from "@/server/mcp/formatters";
+import {
+  requireMcpToolAuthContext,
+  type ToolExtra,
+} from "@/server/mcp/context";
+import { optionalMetaOutputSchema } from "@/server/mcp/output-schemas";
+import { buildDashboardUrl } from "@/server/mcp/urls";
+import { languageCodeSchema, locationCodeSchema } from "@/server/mcp/schemas";
+import { createProjectSchema } from "@/types/schemas/projects";
+import { z } from "zod";
+
+const inputSchema = {
+  name: z
+    .string()
+    .trim()
+    .min(1)
+    .max(120)
+    .describe("Project name (1-120 characters)."),
+  domain: z
+    .string()
+    .trim()
+    .max(255)
+    .optional()
+    .describe(
+      'Optional root domain for the project, e.g. "example.com" (host only, no scheme or path). Sets the default target for domain, backlink, and rank tools.',
+    ),
+  locationCode: locationCodeSchema
+    .optional()
+    .describe(
+      "Optional DataForSEO location code for the project's default market (e.g. 2840 = United States, 2504 = Morocco). Falls back to the organization default when omitted.",
+    ),
+  languageCode: languageCodeSchema
+    .optional()
+    .describe(
+      'Optional language code (e.g. "en", "fr"). Requires locationCode; derived from the location when omitted.',
+    ),
+} as const;
+
+type Args = z.infer<z.ZodObject<typeof inputSchema>>;
+
+export const createProjectTool = {
+  name: "create_project",
+  config: {
+    title: "Create project",
+    description:
+      "Create a new project in the user's organization. Uses no credits — does not call DataForSEO. Provide a name, and optionally a domain and default market (locationCode/languageCode; a languageCode requires a locationCode). Returns the created {id, name, domain, locationCode, languageCode, url}; pass the returned `id` as `projectId` to other OpenSEO tools. Call list_projects first to avoid creating a duplicate.",
+    inputSchema,
+    outputSchema: {
+      project: z
+        .object({
+          id: z.string(),
+          name: z.string(),
+          domain: z.string().nullable().optional(),
+          locationCode: z.number(),
+          languageCode: z.string(),
+          url: z.string(),
+        })
+        .passthrough(),
+      ...optionalMetaOutputSchema,
+    },
+    annotations: {
+      readOnlyHint: false,
+      openWorldHint: false,
+      destructiveHint: false,
+    },
+  },
+  handler: async (args: Args, extra: ToolExtra) => {
+    const { baseUrl, ...auth } = requireMcpToolAuthContext(extra);
+    // Reuse the app's create schema so the market pair rule (a languageCode
+    // requires a locationCode) is enforced identically to the dashboard, and
+    // the domain is normalized the same way.
+    const input = createProjectSchema.parse(args);
+    const project = await ProjectService.createProject(
+      auth.organizationId,
+      input,
+    );
+    return mcpResponse({
+      text: `Created project ${project.id}  ${project.name}${
+        project.domain ? ` (${project.domain})` : ""
+      }  market:${project.locationCode}/${project.languageCode}`,
+      meta: {
+        organizationId: auth.organizationId,
+        url: buildDashboardUrl(baseUrl, `/p/${project.id}`),
+      },
+      structuredContent: {
+        project: {
+          id: project.id,
+          name: project.name,
+          domain: project.domain,
+          locationCode: project.locationCode,
+          languageCode: project.languageCode,
+          url: buildDashboardUrl(baseUrl, `/p/${project.id}`),
+        },
+      },
+    });
+  },
+};


### PR DESCRIPTION
Closes #98.

## What

Adds a `create_project` MCP tool so agents can **create** a project, not just `list_projects`. This closes the one gap that breaks the most agent-shaped workflow — onboarding ("set up a project for example.com targeting Morocco/fr, then research keywords…") previously had to stop and ask a human to click through the dashboard.

## How

Thin wrapper over the existing `ProjectService.createProject`, registered right after `list_projects`:

- **Input**: `name` (required), `domain?`, `locationCode?`, `languageCode?`.
- Reuses `createProjectSchema` (`src/types/schemas/projects.ts`) via `.parse(args)` inside the handler, so the location/language **pair rule** (a `languageCode` requires a `locationCode`) and domain normalization behave identically to the dashboard.
- **Org-scoped** (`requireMcpToolAuthContext`), like `list_projects` — no `projectId` exists yet, so it does not use `withMcpProjectAuth`.
- Uses **no credits** (no DataForSEO call) — stated in the description like `list_projects`.
- **Output**: the created `{ id, name, domain, locationCode, languageCode, url }` (single `project` object, same fields as a `list_projects` item) so agents can chain straight into `projectId`-scoped tools.

Per the discussion on #98, `archive_project` is intentionally left out of scope.

## Tests

`src/server/mcp/tools/create-project.test.ts` (mirrors `saved-keywords-tools.test.ts`):

1. Creates a project scoped to the caller's org and returns it (forwards exactly the validated input; the service resolves `languageCode` from the location).
2. Creates a minimal project with only a `name` (org-default market).
3. Rejects a `languageCode` without a `locationCode` (the market pair rule) before hitting the service.

## Checks

- `tsc --noEmit`: 0 errors (project-wide).
- `tsc --noEmit -p badseo/tsconfig.json`: clean.
- `oxlint . --type-aware`: 0 warnings / 0 errors on the touched files.
- `prettier --check`: clean.
- `vitest` new file: 3/3 pass; `output-schema-validation.test.ts`: 9/9 pass.

> Note: `pnpm ci:check`'s `knip` step fails locally while *loading* `vite.config.ts` (`Cannot read properties of undefined (reading 'join')`) — this reproduces on a clean `main` with my changes stashed, so it's a pre-existing/environment issue unrelated to this PR.

## Manual verification

Ran against a self-hosted instance (`local_noauth`): `tools/call create_project { name, domain, locationCode }` returns the new project, and a follow-up `list_projects` shows it. Happy to add a short demo clip if useful.
