### PR TITLE
feat(chat): support a local / OpenAI-compatible chat model via CHAT_BASE_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,13 @@
 # the in-app SEO agent. Create a key at https://openrouter.ai/settings/keys.
 # OPENROUTER_API_KEY=replace-with-your-openrouter-api-key
 
+# Optional. Point the chat agent at any OpenAI-compatible endpoint (vLLM,
+# Ollama, LM Studio) instead of OpenRouter — the key above then becomes
+# optional. Set OPENROUTER_MODEL to a model id that endpoint serves.
+# See docs/SELF_HOSTING_LOCAL_CHAT_MODEL.md
+# CHAT_BASE_URL=http://localhost:11434/v1
+# OPENROUTER_MODEL=llama3.1
+
 # Optional in self-hosted modes. Required if you want Google Search Console
 # integration and MCP tools. BETTER_AUTH_SECRET is also required for GSC (it
 # encrypts the stored OAuth tokens). See docs/SELF_HOSTING_GOOGLE_SEARCH_CONSOLE.md.

--- a/compose.yaml
+++ b/compose.yaml
@@ -28,8 +28,12 @@ services:
       - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET:-}
       - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:-}
       # Optional: AI features (SAM, the in-app SEO agent)
-      - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
       - OPENROUTER_MODEL=${OPENROUTER_MODEL:-}
+      # Optional: point the chat agent at a local / OpenAI-compatible endpoint
+      # (vLLM, Ollama, LM Studio) instead of OpenRouter. When set,
+      # OPENROUTER_API_KEY becomes optional.
+      # See docs/SELF_HOSTING_LOCAL_CHAT_MODEL.md
+      - CHAT_BASE_URL=${CHAT_BASE_URL:-}
       - VITE_SHOW_DEVTOOLS=false
     ports:
       - "127.0.0.1:${PORT:-3001}:${PORT:-3001}"

--- a/docs/SELF_HOSTING_LOCAL_CHAT_MODEL.md
+++ b/docs/SELF_HOSTING_LOCAL_CHAT_MODEL.md
@@ -1,0 +1,79 @@
+# Self-hosting: use a local / OpenAI-compatible chat model
+
+The in-app chat agents (onboarding + SAM) use OpenRouter by default. Self-hosters
+can instead point them at any **OpenAI-compatible** endpoint — a local model
+(vLLM, Ollama, LM Studio) or a gateway (LiteLLM) — so chat prompts never leave
+your infrastructure.
+
+## Configuration
+
+Set two environment variables and restart OpenSEO:
+
+| Variable           | Purpose                                                                            | Example                     |
+| ------------------ | ---------------------------------------------------------------------------------- | --------------------------- |
+| `CHAT_BASE_URL`    | Base URL of your OpenAI-compatible endpoint (the part before `/chat/completions`). | `http://localhost:11434/v1` |
+| `OPENROUTER_MODEL` | The model id to request from that endpoint.                                        | `qwen3.5-9b`                |
+
+When `CHAT_BASE_URL` is set:
+
+- `OPENROUTER_API_KEY` becomes **optional** (local endpoints usually need no key).
+  If your endpoint does require one, set `OPENROUTER_API_KEY` and it is sent as the
+  bearer token.
+- The OpenRouter-only request options (usage/cost accounting, provider routing,
+  Zero-Data-Retention, and the reasoning channel) are dropped, since a generic
+  endpoint doesn't understand them. Usage-cost metering reports `0` for these
+  turns.
+
+## Ollama
+
+1. Pull a tool-calling capable model and start Ollama (it serves an
+   OpenAI-compatible API on `:11434`):
+
+   ```sh
+   ollama pull llama3.1
+   ollama serve
+   ```
+
+2. Configure OpenSEO:
+
+   ```sh
+   CHAT_BASE_URL=http://localhost:11434/v1
+   OPENROUTER_MODEL=llama3.1
+   # OPENROUTER_API_KEY is not needed
+   ```
+
+   From Docker, use the host address your container can reach (e.g.
+   `http://host.docker.internal:11434/v1`, or the host's LAN IP).
+
+## vLLM
+
+vLLM serves the OpenAI API on `:8000`. **Tool calling must be enabled** for the
+SAM agent to drive the MCP tools:
+
+```sh
+vllm serve Qwen/Qwen3.5-9B \
+  --served-model-name qwen3.5-9b \
+  --enable-auto-tool-choice \
+  --tool-call-parser hermes
+```
+
+```sh
+CHAT_BASE_URL=http://localhost:8000/v1
+OPENROUTER_MODEL=qwen3.5-9b
+```
+
+## Tool calling caveat
+
+The SAM agent is agentic — it calls the OpenSEO MCP tools. A local model only
+fully replaces OpenRouter if it supports **OpenAI-style function/tool calling**.
+Models without reliable tool calling still chat, but won't invoke tools. For
+Ollama pick a tool-calling model (e.g. `llama3.1`, `qwen2.5`); for vLLM launch
+with `--enable-auto-tool-choice` and the matching `--tool-call-parser`.
+
+## Verify
+
+1. Set the variables, restart OpenSEO.
+2. Open a project → the SAM chat should be enabled (no "configure a chat model"
+   gate).
+3. Ask it something that needs a tool, e.g. "list my projects" — you should see
+   it call `list_projects` and answer from your local model.

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -48,8 +48,15 @@ declare namespace Cloudflare {
 
     // OpenRouter API key for the in-app chat agents (onboarding + SAM).
     OPENROUTER_API_KEY?: string;
-    // Optional OpenRouter model slug override (defaults in openrouter.ts).
+    // Optional model slug/id override for the chat agents (defaults in
+    // openrouter.ts). With CHAT_BASE_URL this is the local model id, e.g.
+    // "qwen3.5-9b" (vLLM) or "llama3.1" (Ollama).
     OPENROUTER_MODEL?: string;
+    // Optional base URL of a self-hosted, OpenAI-compatible chat endpoint
+    // (vLLM, Ollama, LiteLLM, …), e.g. "http://localhost:11434/v1". When set,
+    // the chat agents route there instead of OpenRouter and OPENROUTER_API_KEY
+    // becomes optional. See docs/SELF_HOSTING_LOCAL_CHAT_MODEL.md.
+    CHAT_BASE_URL?: string;
   }
 }
 

--- a/src/server/features/sam/SamChatAgent.ts
+++ b/src/server/features/sam/SamChatAgent.ts
@@ -122,13 +122,17 @@ export class SamChatAgent extends Think {
   }
 
   getModel() {
+    const baseURL = getEnvValueSync(this.env, "CHAT_BASE_URL");
     const apiKey = getEnvValueSync(this.env, "OPENROUTER_API_KEY");
-    if (!apiKey) {
-      throw new Error("OPENROUTER_API_KEY is required for the SAM agent");
+    if (!apiKey && !baseURL) {
+      throw new Error(
+        "OPENROUTER_API_KEY or CHAT_BASE_URL is required for the SAM agent",
+      );
     }
     return buildChatAgentModel(
-      apiKey,
+      apiKey ?? "",
       getEnvValueSync(this.env, "OPENROUTER_MODEL"),
+      baseURL,
     );
   }
 

--- a/src/server/lib/openrouter.test.ts
+++ b/src/server/lib/openrouter.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const modelFactory = vi.fn((..._args: unknown[]) => "model-instance");
+  const createOpenRouter = vi.fn((..._args: unknown[]) => modelFactory);
+  return { modelFactory, createOpenRouter };
+});
+
+vi.mock("@openrouter/ai-sdk-provider", () => ({
+  createOpenRouter: mocks.createOpenRouter,
+}));
+
+describe("buildChatAgentModel", () => {
+  beforeEach(() => {
+    mocks.createOpenRouter.mockClear();
+    mocks.modelFactory.mockClear();
+  });
+
+  it("uses OpenRouter with usage metering + provider routing by default", async () => {
+    const { buildChatAgentModel } = await import("./openrouter");
+
+    buildChatAgentModel("sk-test", "vendor/model");
+
+    expect(mocks.createOpenRouter).toHaveBeenCalledWith({ apiKey: "sk-test" });
+    const firstCall = mocks.modelFactory.mock.calls[0];
+    expect(firstCall?.[0]).toBe("vendor/model");
+    expect(firstCall?.[1]).toMatchObject({
+      usage: { include: true },
+      provider: { zdr: true },
+    });
+  });
+
+  it("routes to a local endpoint and drops OpenRouter-only options when a base URL is set", async () => {
+    const { buildChatAgentModel } = await import("./openrouter");
+
+    buildChatAgentModel("", "qwen3.5-9b", "http://localhost:11434/v1");
+
+    expect(mocks.createOpenRouter).toHaveBeenCalledWith({
+      apiKey: "local",
+      baseURL: "http://localhost:11434/v1",
+    });
+    const firstCall = mocks.modelFactory.mock.calls[0];
+    expect(firstCall?.[0]).toBe("qwen3.5-9b");
+    // No OpenRouter-only options are passed to a generic endpoint.
+    expect(firstCall?.[1]).toBeUndefined();
+  });
+
+  it("forwards an explicit key to the local endpoint when provided", async () => {
+    const { buildChatAgentModel } = await import("./openrouter");
+
+    buildChatAgentModel("sk-local", undefined, "http://vllm:8000/v1");
+
+    expect(mocks.createOpenRouter).toHaveBeenCalledWith({
+      apiKey: "sk-local",
+      baseURL: "http://vllm:8000/v1",
+    });
+  });
+});

--- a/src/server/lib/openrouter.ts
+++ b/src/server/lib/openrouter.ts
@@ -34,21 +34,40 @@ const DEFAULT_CHAT_AGENT_MODEL = "minimax/minimax-m3";
  * is configured.
  */
 export async function getChatAgentModel(): Promise<LanguageModelV3> {
-  const apiKey = await getRequiredEnvValue("OPENROUTER_API_KEY");
+  const baseURL = await getOptionalEnvValue("CHAT_BASE_URL");
+  // A self-hosted / OpenAI-compatible endpoint (CHAT_BASE_URL) usually needs no
+  // key; OpenRouter still requires one.
+  const apiKey = baseURL
+    ? ((await getOptionalEnvValue("OPENROUTER_API_KEY")) ?? "")
+    : await getRequiredEnvValue("OPENROUTER_API_KEY");
   const modelId = await getOptionalEnvValue("OPENROUTER_MODEL");
-  return buildChatAgentModel(apiKey, modelId);
+  return buildChatAgentModel(apiKey, modelId, baseURL);
 }
 
 /**
  * Synchronous variant for callers that already hold the env values. Think's
  * `getModel()` hook is sync and runs on every turn, so the SAM agent reads the
  * key/model from its DO env and builds the model here.
+ *
+ * When `baseURL` (CHAT_BASE_URL) is set, the model is served from a self-hosted,
+ * OpenAI-compatible endpoint (vLLM, Ollama, LiteLLM, …). In that mode we point
+ * the provider at the custom base URL and drop the OpenRouter-only request
+ * options (usage accounting, provider routing/ZDR, the reasoning channel) that
+ * a generic endpoint doesn't understand — cost metering then falls back to 0
+ * because there's no OpenRouter usage metadata to read. The API key is optional
+ * for local endpoints; a placeholder is sent so the SDK still builds an auth
+ * header (vLLM/Ollama ignore it).
  */
 export function buildChatAgentModel(
   apiKey: string,
   modelId?: string,
+  baseURL?: string,
 ): LanguageModelV3 {
-  return createOpenRouter({ apiKey })(modelId ?? DEFAULT_CHAT_AGENT_MODEL, {
+  const model = modelId ?? DEFAULT_CHAT_AGENT_MODEL;
+  if (baseURL) {
+    return createOpenRouter({ apiKey: apiKey || "local", baseURL })(model);
+  }
+  return createOpenRouter({ apiKey })(model, {
     usage: { include: true },
     reasoning: { effort: "medium" },
     provider: {

--- a/src/serverFunctions/samAccess.ts
+++ b/src/serverFunctions/samAccess.ts
@@ -6,8 +6,8 @@ import {
 } from "@/server/lib/runtime-env";
 import { requireProjectContext } from "@/serverFunctions/middleware";
 
-const OPENROUTER_KEY_MISSING_MESSAGE =
-  "OPENROUTER_API_KEY is not set for this deployment yet. Add it to your environment, restart OpenSEO, then confirm here.";
+const CHAT_MODEL_MISSING_MESSAGE =
+  "No chat model is configured yet. Set OPENROUTER_API_KEY (OpenRouter), or CHAT_BASE_URL for a local / OpenAI-compatible model (vLLM, Ollama), then restart OpenSEO and confirm here.";
 
 const projectScopedSchema = z.object({ projectId: z.string().min(1) });
 
@@ -16,9 +16,11 @@ type SamAccessStatus = {
   errorMessage: string | null;
 };
 
-// Gates the in-app AI agent (SAM) on an OpenRouter key being configured, the
-// same way backlinks/AI-search gate on their DataForSEO subscriptions. Hosted
-// deployments always have the key provisioned, so only self-hosted is checked.
+// Gates the in-app AI agent (SAM) on a chat model being configured, the same
+// way backlinks/AI-search gate on their DataForSEO subscriptions. A model is
+// available when either an OpenRouter key or a local endpoint (CHAT_BASE_URL)
+// is set. Hosted deployments always have OpenRouter provisioned, so only
+// self-hosted is checked.
 export const getSamAccessSetupStatus = createServerFn({ method: "GET" })
   .middleware(requireProjectContext)
   .validator(projectScopedSchema)
@@ -27,9 +29,13 @@ export const getSamAccessSetupStatus = createServerFn({ method: "GET" })
       return { enabled: true, errorMessage: null };
     }
 
-    const enabled = Boolean(await getOptionalEnvValue("OPENROUTER_API_KEY"));
+    const [apiKey, baseURL] = await Promise.all([
+      getOptionalEnvValue("OPENROUTER_API_KEY"),
+      getOptionalEnvValue("CHAT_BASE_URL"),
+    ]);
+    const enabled = Boolean(apiKey || baseURL);
     return {
       enabled,
-      errorMessage: enabled ? null : OPENROUTER_KEY_MISSING_MESSAGE,
+      errorMessage: enabled ? null : CHAT_MODEL_MISSING_MESSAGE,
     };
   });


### PR DESCRIPTION
Closes #102.

## What

Lets self-hosters run the in-app chat agents (onboarding + SAM) on **any OpenAI-compatible endpoint** — a local model (vLLM, Ollama, LM Studio) or a gateway (LiteLLM) — instead of forcing OpenRouter. For a privacy-conscious self-host, this closes the one place chat prompts (project domains, keywords, GSC-derived context) still had to leave the box.

Per your note on #102: went with `CHAT_BASE_URL`, kept OpenRouter as the default, and included Ollama + vLLM setup docs.

## How

- **`buildChatAgentModel(apiKey, modelId?, baseURL?)`** — when `baseURL` is set, points the existing `@openrouter/ai-sdk-provider` at the custom base URL (it already accepts `baseURL`, so no new dependency) and **drops the OpenRouter-only request options** (usage accounting, `provider` routing/ZDR, the `reasoning` channel) that a generic endpoint doesn't understand. Cost metering falls back to `0` because there's no OpenRouter usage metadata to read (`openRouterCostUsd` already returns 0 when absent).
- **`getChatAgentModel()` / `SamChatAgent.getModel()`** — read `CHAT_BASE_URL`; `OPENROUTER_API_KEY` becomes optional when it's set (local endpoints usually need no key; a placeholder is sent so the SDK still builds an auth header, which vLLM/Ollama ignore).
- **SAM access gate (`samAccess.ts`)** — enables on **either** an OpenRouter key **or** `CHAT_BASE_URL`, so a self-hoster with only a local model isn't told "configure a chat model".
- **`env.d.ts`** — documents `CHAT_BASE_URL`; `OPENROUTER_MODEL` doubles as the local model id.
- The default OpenRouter path is byte-for-byte unchanged.

`OPENROUTER_MODEL` is reused as the model id (e.g. `qwen3.5-9b`) rather than adding a new var, to keep the surface small — happy to rename to `CHAT_MODEL` if you'd prefer symmetry with `CHAT_BASE_URL`.

## Docs

`docs/SELF_HOSTING_LOCAL_CHAT_MODEL.md` — Ollama and vLLM setup, and the important **tool-calling caveat**: the SAM agent is agentic (it drives the MCP tools), so a local model only fully replaces OpenRouter if it supports OpenAI-style function calling (Ollama: a tool-calling model like `llama3.1`; vLLM: launch with `--enable-auto-tool-choice --tool-call-parser hermes`).

## Ollama quick test

```sh
ollama pull llama3.1 && ollama serve
```
```sh
CHAT_BASE_URL=http://localhost:11434/v1
OPENROUTER_MODEL=llama3.1
```
Restart OpenSEO → open a project → SAM is enabled → ask "list my projects" → it calls `list_projects` and answers from the local model.

## Tests

`src/server/lib/openrouter.test.ts` (new) mocks `createOpenRouter` and asserts:
1. Default path → `{ apiKey }` + the OpenRouter options (`usage.include`, `provider.zdr`).
2. `CHAT_BASE_URL` path → `{ apiKey: "local", baseURL }` and **no** per-model options.
3. Explicit key + base URL is forwarded as the bearer.

## Checks

- `tsc --noEmit`: 0 errors (project-wide) · `oxlint --type-aware`: 0/0 · `prettier --check`: clean · `vitest`: 3/3.
- (`pnpm ci:check`'s `knip` step fails locally while loading `vite.config.ts` — reproduces on clean `main`, unrelated to this PR.)
