### PR TITLE
feat: include last checked date in rank tracking exports (fixes #70)

### DIFF
--- a/src/client/features/rank-tracking/RankTrackingDomainDetail.tsx
+++ b/src/client/features/rank-tracking/RankTrackingDomainDetail.tsx
@@ -271,6 +271,7 @@ export function RankTrackingDomainDetail({
               showMobile,
               config.domain,
               config.locationName,
+              latestRun?.lastCheckedAt,
             )
           }
           onExportToSheets={() =>
@@ -279,6 +280,7 @@ export function RankTrackingDomainDetail({
               showDesktop,
               showMobile,
               config.locationName,
+              latestRun?.lastCheckedAt,
             )
           }
           onCopyKeywords={() => {

--- a/src/client/features/rank-tracking/RankTrackingTableParts.tsx
+++ b/src/client/features/rank-tracking/RankTrackingTableParts.tsx
@@ -175,6 +175,7 @@ export function buildRankTrackingExport(
   showDesktop: boolean,
   showMobile: boolean,
   locationName?: string | null,
+  lastCheckedAt?: string | null,
 ): { headers: string[]; rows: (string | number)[][] } {
   const headers = [
     "Keyword",
@@ -200,6 +201,7 @@ export function buildRankTrackingExport(
           "Mobile SERP Features",
         ]
       : []),
+    "Last checked at",
   ];
   // Emit empty cells (not "Not ranking" strings) so Sheets infers a numeric
   // column type and the user can sort by position.
@@ -224,6 +226,7 @@ export function buildRankTrackingExport(
           row.mobile.serpFeatures.join(", "),
         ]
       : []),
+    lastCheckedAt ?? "",
   ]);
   return { headers, rows };
 }
@@ -233,12 +236,14 @@ export function exportRankTrackingToSheets(
   showDesktop: boolean,
   showMobile: boolean,
   locationName?: string | null,
+  lastCheckedAt?: string | null,
 ) {
   const { headers, rows } = buildRankTrackingExport(
     sorted,
     showDesktop,
     showMobile,
     locationName,
+    lastCheckedAt,
   );
   void exportTableToSheets({ headers, rows, feature: "rank_tracking" });
 }
@@ -249,6 +254,7 @@ export function exportRankTrackingCsv(
   showMobile: boolean,
   domain: string,
   locationName?: string | null,
+  lastCheckedAt?: string | null,
 ) {
   if (sorted.length === 0) {
     toast.error("No data to export");
@@ -259,6 +265,7 @@ export function exportRankTrackingCsv(
     showDesktop,
     showMobile,
     locationName,
+    lastCheckedAt,
   );
   // CSV file download keeps cents-formatted CPC for human readability;
   // clipboard/Sheets export uses raw numbers (see buildRankTrackingExport).


### PR DESCRIPTION
## Summary
Fixes #70

Adds `Last checked at` column to rank tracking CSV and Sheets exports.

## Changes
- `buildRankTrackingExport`: new `lastCheckedAt` param, threaded to headers + each row
- `exportRankTrackingCsv` / `exportRankTrackingToSheets`: accept + pass through `lastCheckedAt`
- `RankTrackingDomainDetail`: passes `latestRun.lastCheckedAt` to both export callbacks

The timestamp already exists in `latestRun` — this just carries it through to exports. ISO format for spreadsheet sortability.