### PR TITLE
fix: treat SQLite rank-tracking timestamps as UTC in client views (fixes #94)

### DIFF
--- a/src/client/features/rank-tracking/KeywordTrendModal.tsx
+++ b/src/client/features/rank-tracking/KeywordTrendModal.tsx
@@ -10,6 +10,7 @@ import type { RankKeywordHistoryPoint } from "@/serverFunctions/rank-tracking";
 import { LOCATIONS } from "@/client/features/keywords/locations";
 import { formatLocationLabel } from "@/shared/keyword-locations";
 import { csvChange, DeviceRankCell } from "./RankTrackingTableParts";
+import { parseTimestamp } from "./utils";
 import {
   RankTrendChart,
   TrendRangeToggle,
@@ -104,7 +105,7 @@ export function KeywordTrendModal({
     const keys = new Set<string>();
     for (const p of points) {
       if (p.position === null) {
-        keys.add(`${new Date(p.checkedAt).getTime()}:${p.device}`);
+        keys.add(`${new Date(parseTimestamp(String(p.checkedAt))).getTime()}:${p.device}`);
       }
     }
     return keys;
@@ -114,7 +115,7 @@ export function KeywordTrendModal({
 
   const exportRows = () =>
     historyRows.map((r) => [
-      new Date(r.checkedAt).toISOString(),
+      new Date(parseTimestamp(String(r.checkedAt))).toISOString(),
       DEVICE_STYLE[r.device].label,
       r.position ?? "",
       csvChange(r.position, r.previousPosition),
@@ -216,7 +217,7 @@ export function KeywordTrendModal({
                   return (
                     <tr key={`${r.device}-${r.checkedAt}-${idx}`}>
                       <td className="whitespace-nowrap text-xs">
-                        {new Date(r.checkedAt).toLocaleDateString()}
+                        {new Date(parseTimestamp(String(r.checkedAt))).toLocaleDateString()}
                       </td>
                       {devices.length > 1 && (
                         <td className="text-xs">
@@ -301,7 +302,7 @@ function ChartTooltip({
   return (
     <div className="rounded-md border border-base-300 bg-base-100 px-3 py-2 shadow-sm space-y-0.5">
       <p className="text-xs text-base-content/60">
-        {new Date(label).toLocaleDateString("en-US", {
+        {new Date(parseTimestamp(String(label))).toLocaleDateString("en-US", {
           month: "short",
           day: "numeric",
           year: "numeric",
@@ -358,7 +359,7 @@ function buildChartData(
 ): ChartRow[] {
   const byTime = new Map<number, ChartRow>();
   for (const p of points) {
-    const ts = new Date(p.checkedAt).getTime();
+    const ts = new Date(parseTimestamp(String(p.checkedAt))).getTime();
     const row = byTime.get(ts) ?? { checkedAt: ts };
     row[p.device] = p.position === null ? serpDepth : p.position;
     byTime.set(ts, row);

--- a/src/client/features/rank-tracking/RankTrackingDetailHeader.tsx
+++ b/src/client/features/rank-tracking/RankTrackingDetailHeader.tsx
@@ -3,6 +3,7 @@ import { SegmentedToggle } from "@/client/components/SegmentedToggle";
 import { LOCATIONS } from "@/client/features/keywords/locations";
 import { devicesLabel, scheduleLabel } from "@/shared/rank-tracking";
 import { formatLocationLabel } from "@/shared/keyword-locations";
+import { parseTimestamp } from "./utils";
 import type {
   ComparePeriod,
   RankTrackingConfig,
@@ -54,7 +55,7 @@ export function RankTrackingDetailHeader({
           {run && (
             <>
               {" "}
-              &middot; Last: {new Date(run.lastCheckedAt).toLocaleDateString()}
+              &middot; Last: {new Date(parseTimestamp(String(run.lastCheckedAt))).toLocaleDateString()}
             </>
           )}
           {costEstimate && costEstimate.keywordCount > 0 && (

--- a/src/client/features/rank-tracking/RankTrackingDomainList.tsx
+++ b/src/client/features/rank-tracking/RankTrackingDomainList.tsx
@@ -18,6 +18,7 @@ import {
 import { devicesLabel, scheduleLabel } from "@/shared/rank-tracking";
 import { formatLocationLabel } from "@/shared/keyword-locations";
 import { Modal } from "@/client/components/Modal";
+import { parseTimestamp } from "./utils";
 import {
   applyDomainListFilters,
   countActiveDomainListFilters,
@@ -215,7 +216,7 @@ function DomainRow({
             <>
               {" "}
               &middot; Last:{" "}
-              {new Date(summary.lastRunCompletedAt).toLocaleDateString()}
+              {new Date(parseTimestamp(String(summary.lastRunCompletedAt))).toLocaleDateString()}
             </>
           )}
         </p>

--- a/src/client/features/rank-tracking/RankTrackingHistoryMatrix.tsx
+++ b/src/client/features/rank-tracking/RankTrackingHistoryMatrix.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { Loader2 } from "lucide-react";
 import type { RankPositionMatrixCell } from "@/serverFunctions/rank-tracking";
+import { parseTimestamp } from "./utils";
 
 /**
  * "By date" view: keyword rows × recent check columns, each cell the position
@@ -138,7 +139,7 @@ function buildMatrix(cells: RankPositionMatrixCell[]): {
 }
 
 function formatDate(value: string): string {
-  return new Date(value).toLocaleDateString("en-US", {
+  return new Date(parseTimestamp(String(value))).toLocaleDateString("en-US", {
     month: "short",
     day: "numeric",
   });

--- a/src/client/features/rank-tracking/RankTrackingOverview.tsx
+++ b/src/client/features/rank-tracking/RankTrackingOverview.tsx
@@ -11,6 +11,7 @@ import {
 } from "recharts";
 import type { TooltipContentProps } from "recharts";
 import { getRankConfigTrend } from "@/serverFunctions/rank-tracking";
+import { parseTimestamp } from "./utils";
 import {
   formatDateTick,
   TrendRangeToggle,
@@ -52,7 +53,7 @@ export function RankTrackingOverview({
   const chartData = useMemo(
     () =>
       (trend ?? []).map((p) => ({
-        checkedAt: new Date(p.checkedAt).getTime(),
+        checkedAt: new Date(parseTimestamp(String(p.checkedAt))).getTime(),
         top3: p.top3,
         top4to10: p.top4to10,
         top11to20: p.top11to20,
@@ -185,7 +186,7 @@ function DistributionTooltip({
   return (
     <div className="rounded-md border border-base-300 bg-base-100 px-3 py-2 shadow-sm space-y-0.5">
       <p className="text-xs text-base-content/60">
-        {new Date(label).toLocaleDateString("en-US", {
+        {new Date(parseTimestamp(String(label))).toLocaleDateString("en-US", {
           month: "short",
           day: "numeric",
           year: "numeric",

--- a/src/client/features/rank-tracking/utils.ts
+++ b/src/client/features/rank-tracking/utils.ts
@@ -1,0 +1,14 @@
+/**
+ * Parse a database timestamp string into a UTC-respecting form.
+ *
+ * SQLite's current_timestamp produces "YYYY-MM-DD HH:mm:ss" with no timezone
+ * marker, so browsers interpret it as local time. This function detects that
+ * shape and appends the Z marker for UTC interpretation. ISO-8601 timestamps
+ * (from Postgres / JavaScript) pass through unchanged.
+ */
+export function parseTimestamp(ts: string): string {
+  if (/^\d{4}-\d{2}-\d{2} /.test(ts)) {
+    return `${ts.replace(" ", "T")}Z`;
+  }
+  return ts;
+}


### PR DESCRIPTION
## Summary
Fixes #94

SQLite's `current_timestamp` produces `YYYY-MM-DD HH:mm:ss` with no timezone marker, so browsers interpret it as local time. This shifts rank-check timestamps by the browser's timezone offset and can misrender dates around midnight.

## Changes
- **`utils.ts`** (new): Added `parseTimestamp()` — detects SQLite format and appends `Z` for UTC; ISO timestamps pass through unchanged.
- Applied to all `new Date()` call sites in 5 rank-tracking client views:
  - `RankTrackingDetailHeader.tsx`
  - `RankTrackingDomainList.tsx`
  - `KeywordTrendModal.tsx`
  - `RankTrackingOverview.tsx`
  - `RankTrackingHistoryMatrix.tsx`
- Uses `String()` coercion at call sites to satisfy `no-unsafe-argument` lint rule for pre-existing `any`-typed API values.

## Verification
- Lint: 0 warnings, 0 errors (`pnpm run lint`)
- Follows the same pattern as `formatDay()` in `cardParts.tsx`