### PR TITLE
fix(docker): skip vite build on container start when build env is unchanged

### DIFF
--- a/Dockerfile.selfhost
+++ b/Dockerfile.selfhost
@@ -13,12 +13,17 @@ RUN pnpm install --frozen-lockfile
 
 COPY . .
 
+# Feeds the client-build fingerprint so a dist/ carried over in a volume from an
+# older image is rebuilt once instead of being served stale.
+RUN date +%s%N >.image-build-id
+
 EXPOSE 3001
 
 # The build MUST run at container start, not image-build time: AUTH_MODE (and the
 # other client envs) are inlined into the client bundle by `vite build`, and the
-# self-hoster only chooses AUTH_MODE at runtime via Compose. Building here lets
-# that runtime value bake into the bundle. The repo .npmrc raises the V8 heap
-# ceiling (node-options) so the ~7400-module SSR build doesn't OOM under Node's
-# ~2GB default.
-CMD ["sh", "-c", "echo 'OpenSEO sends an anonymous usage heartbeat (counts only). Disable: OPENSEO_TELEMETRY_DISABLED=1. Details: docs/SELF_HOSTING_DOCKER.md#telemetry' && pnpm run db:migrate:local && pnpm run build && pnpm exec vite preview --host 0.0.0.0 --port ${PORT:-3001}"]
+# self-hoster only chooses AUTH_MODE at runtime via Compose. The start script
+# fingerprints those envs and reuses the previous build when they are unchanged,
+# so only the first start (or an env/image change) pays for the build. The repo
+# .npmrc raises the V8 heap ceiling (node-options) so the ~7400-module SSR build
+# doesn't OOM under Node's ~2GB default.
+CMD ["sh", "scripts/docker-selfhost-start.sh"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -22,5 +22,9 @@ services:
       - "127.0.0.1:${PORT:-3001}:${PORT:-3001}"
     volumes:
       - open_seo_data:/app/.wrangler
+      # Keeps the built client bundle across container recreation so restarts
+      # skip the ~90s vite build when build-relevant env is unchanged.
+      - open_seo_build:/app/dist
 volumes:
   open_seo_data:
+  open_seo_build:

--- a/docs/SELF_HOSTING_DOCKER.md
+++ b/docs/SELF_HOSTING_DOCKER.md
@@ -39,6 +39,24 @@ ALLOWED_HOST=yourdomain.com docker compose up -d
 
 You can also persist it in `.env`.
 
+## Startup time and build caching
+
+The first container start builds the client bundle (~90s on typical hardware)
+because env like `AUTH_MODE` and `VITE_*` is inlined into the bundle at build
+time. The result is kept in the `open_seo_build` volume, so later starts and
+restarts reuse it and reach first HTTP response in seconds.
+
+A rebuild happens automatically only when:
+
+- the image changes (update or tag pin), or
+- a build-inlined env value changes (`AUTH_MODE`, `VITE_*`,
+  `POSTHOG_PUBLIC_KEY`, `POSTHOG_HOST`, `TURNSTILE_SITE_KEY`,
+  `BYPASS_EMAIL_VERIFICATION`).
+
+Other env changes (for example `DATAFORSEO_API_KEY` or `PORT`) never trigger a
+rebuild. `docker compose down -v` removes the cached build along with the data
+volume.
+
 ## Telemetry
 
 OpenSEO collects anonymized telemetry for core usage events: heartbeats with aggregate counts (installs, users, projects, feature usage) tied to a random install ID, sent every 5 minutes during the first two hours after install, then at most once daily. No URLs, keywords, prompts, emails, or IP-derived location are collected, and idle installs send nothing.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev:agents": "mkdir -p .logs && portless run vite dev 2>&1 | tee .logs/dev-server.log",
     "dev:agents:force": "mkdir -p .logs && portless --force run vite dev 2>&1 | tee .logs/dev-server.log",
     "build": "vite build && tsc --noEmit",
+    "build:client": "vite build",
     "lint": "oxlint . --type-aware",
     "lint:fix": "oxlint . --type-aware --fix",
     "preview": "npm run build && vite preview --port 3001",

--- a/scripts/docker-selfhost-start.sh
+++ b/scripts/docker-selfhost-start.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# Container start for Docker self-hosting (Dockerfile.selfhost).
+#
+# `vite build` inlines the client-exposed env (vite.config.ts envPrefix) into
+# the bundle, so dist is only valid for the exact values it was built with.
+# Fingerprint those values plus the image build id and skip the ~90s rebuild
+# when they match the previous start, instead of rebuilding on every start.
+set -eu
+
+cd "$(dirname "$0")/.."
+
+# Lives inside dist so `vite build` wiping the outDir also invalidates the
+# cache marker, and a freshly created (empty) dist volume never claims a hit.
+FINGERPRINT_FILE="dist/.selfhost-build-fingerprint"
+
+build_fingerprint() {
+  {
+    # Rebuild once when the image changes under a dist volume carried over
+    # from an older container.
+    cat .image-build-id 2>/dev/null || true
+    echo "AUTH_MODE=${AUTH_MODE:-}"
+    echo "BYPASS_EMAIL_VERIFICATION=${BYPASS_EMAIL_VERIFICATION:-}"
+    echo "POSTHOG_HOST=${POSTHOG_HOST:-}"
+    echo "POSTHOG_PUBLIC_KEY=${POSTHOG_PUBLIC_KEY:-}"
+    echo "TURNSTILE_SITE_KEY=${TURNSTILE_SITE_KEY:-}"
+    env | grep "^VITE_" | LC_ALL=C sort
+  } | sha256sum | cut -d " " -f 1
+}
+
+if [ "${1:-}" = "--print-fingerprint" ]; then
+  build_fingerprint
+  exit 0
+fi
+
+echo "OpenSEO sends an anonymous usage heartbeat (counts only). Disable: OPENSEO_TELEMETRY_DISABLED=1. Details: docs/SELF_HOSTING_DOCKER.md#telemetry"
+
+pnpm run db:migrate:local
+
+current_fingerprint="$(build_fingerprint)"
+if [ -f "$FINGERPRINT_FILE" ] && [ "$(cat "$FINGERPRINT_FILE")" = "$current_fingerprint" ]; then
+  echo "Client bundle already built for this env; skipping vite build."
+else
+  pnpm run build:client
+  printf '%s\n' "$current_fingerprint" >"$FINGERPRINT_FILE"
+fi
+
+exec pnpm exec vite preview --host 0.0.0.0 --port "${PORT:-3001}"

--- a/scripts/docker-selfhost-start.test.ts
+++ b/scripts/docker-selfhost-start.test.ts
@@ -1,0 +1,59 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(__dirname, "..");
+const script = path.join("scripts", "docker-selfhost-start.sh");
+
+// Only the env vite.config.ts exposes to the client bundle (envPrefix) may
+// change the fingerprint; everything else must not force a rebuild.
+const baseEnv = {
+  PATH: process.env.PATH ?? "",
+  AUTH_MODE: "local_noauth",
+  VITE_SHOW_DEVTOOLS: "false",
+};
+
+function fingerprint(env: Record<string, string>): string {
+  const result = spawnSync("sh", [script, "--print-fingerprint"], {
+    cwd: repoRoot,
+    env: env as NodeJS.ProcessEnv,
+    encoding: "utf8",
+  });
+  expect(result.status).toBe(0);
+  const output = result.stdout.trim();
+  expect(output).toMatch(/^[0-9a-f]{64}$/);
+  return output;
+}
+
+describe.skipIf(process.platform === "win32")(
+  "docker-selfhost-start.sh --print-fingerprint",
+  () => {
+    it("is stable for identical env", () => {
+      expect(fingerprint(baseEnv)).toBe(fingerprint({ ...baseEnv }));
+    });
+
+    it("changes when a build-inlined env value changes", () => {
+      const base = fingerprint(baseEnv);
+      expect(
+        fingerprint({ ...baseEnv, AUTH_MODE: "cloudflare_access" }),
+      ).not.toBe(base);
+      expect(fingerprint({ ...baseEnv, VITE_SHOW_DEVTOOLS: "true" })).not.toBe(
+        base,
+      );
+      expect(fingerprint({ ...baseEnv, POSTHOG_PUBLIC_KEY: "phc_x" })).not.toBe(
+        base,
+      );
+    });
+
+    it("ignores env that is not inlined into the client bundle", () => {
+      const base = fingerprint(baseEnv);
+      expect(
+        fingerprint({
+          ...baseEnv,
+          DATAFORSEO_API_KEY: "changed",
+          PORT: "4000",
+        }),
+      ).toBe(base);
+    });
+  },
+);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   plugins: [tsConfigPaths()],
   test: {
     environment: "node",
-    include: ["src/**/*.test.ts"],
+    include: ["src/**/*.test.ts", "scripts/**/*.test.ts"],
     restoreMocks: true,
     clearMocks: true,
   },


### PR DESCRIPTION
Fixes #100

## Problem

The self-host image runs `pnpm run build` (vite build **and** `tsc --noEmit`) on every container start, so every restart — updates, power cycles, `docker compose start` — pays ~75–90s before first HTTP 200, even when nothing changed.

The build genuinely can't move to image-build time: `AUTH_MODE` and the other `envPrefix` values from `vite.config.ts` are inlined into the client bundle, and self-hosters only choose them at runtime via Compose.

## Approach (option 1 from the issue: env-keyed caching)

- New `scripts/docker-selfhost-start.sh` replaces the inline `CMD`. It hashes the build-relevant env — `AUTH_MODE`, `BYPASS_EMAIL_VERIFICATION`, `POSTHOG_PUBLIC_KEY`, `POSTHOG_HOST`, `TURNSTILE_SITE_KEY`, and all `VITE_*` (exactly the `envPrefix` list in `vite.config.ts`) — plus an image build id, and skips `vite build` when the fingerprint matches the previous start.
- The fingerprint marker lives **inside `dist/`**, so `vite build` wiping the outDir also invalidates the cache, and an empty `dist` volume can never claim a false hit.
- `.image-build-id` is stamped at image build time, so a `dist/` carried over in a volume from an older image is rebuilt once instead of served stale.
- `compose.yaml` adds an `open_seo_build:/app/dist` volume so the cache also survives container recreation (`--force-recreate` after `.env` changes, image restarts).
- Runtime `tsc --noEmit` is dropped (new `build:client` script): type-checking can't change the shipped code and CI already runs it.
- `docs/SELF_HOSTING_DOCKER.md` documents when a rebuild happens.

## Result

- First start: unchanged (~90s build).
- Every later start/restart with unchanged build env: build skipped, first HTTP 200 in seconds.
- Changing `AUTH_MODE`/`VITE_*`/PostHog/Turnstile env or updating the image: exactly one rebuild.
- Changing `DATAFORSEO_API_KEY`, `PORT`, `ALLOWED_HOST`, telemetry flags: no rebuild (these are runtime-only).

## Testing

- `scripts/docker-selfhost-start.test.ts` (vitest, skipped on Windows) covers the fingerprint: stable for identical env, changes for each build-inlined var, ignores runtime-only env.
- Manually verified the fingerprint behavior with `--print-fingerprint` (stable / sensitive / insensitive as above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
