### PR TITLE
feat(indexnow): add IndexNow key + URL submission MCP tools

### DIFF
--- a/docs/INDEXNOW.md
+++ b/docs/INDEXNOW.md
@@ -9,6 +9,11 @@ indexing also means faster appearance in those AI answers.
 OpenSEO exposes IndexNow through two MCP tools, so agents can close the
 publish → index loop without leaving the chat.
 
+> **Google does not participate in IndexNow.** Submitting notifies Bing,
+> Yandex, Seznam, Naver, and Yep — a single submission is shared between them.
+> Google indexing is unaffected and still relies on crawling / sitemaps. This
+> catches people out, so the tool description says it too.
+
 ## How the key works
 
 IndexNow proves you control a host by having you serve a **verification file**
@@ -30,6 +35,23 @@ Submits up to 10,000 URLs to IndexNow for the project's host. URLs that aren't o
 that host are skipped and reported (IndexNow only accepts same-host lists). The
 verification file must already be live, or engines ignore the submission. Uses no
 credits.
+
+**Response contract.** The engine's HTTP status is returned as _data_
+(`{ status, ok }`), not raised as a tool error — the call itself succeeded, the
+engine just may not have accepted the list. `ok` tracks 2xx, so `202`
+("accepted, key validation pending") is a success. A `403` means the key file
+isn't published (or doesn't match) — the agent can read that and fix it. Only a
+malformed request throws: no domain on the project, or no submitted URL on the
+project's host.
+
+| Status | Meaning                                                            |
+| ------ | ------------------------------------------------------------------ |
+| `200`  | Accepted                                                           |
+| `202`  | Accepted, key validation pending (normal before the file is live)  |
+| `400`  | Invalid format                                                     |
+| `403`  | Key not valid — file missing or contents don't match               |
+| `422`  | URLs don't belong to the host, or the key doesn't match the schema |
+| `429`  | Too many requests                                                  |
 
 ## Setup (one time per project)
 

--- a/docs/INDEXNOW.md
+++ b/docs/INDEXNOW.md
@@ -1,0 +1,44 @@
+# IndexNow
+
+[IndexNow](https://www.indexnow.org/) is a free, push-based protocol: instead of
+waiting for search engines to re-crawl, you notify **Bing, Yandex**, and other
+participating engines that URLs are new or updated, and they pick them up within
+seconds. Because Bing's index feeds Copilot and ChatGPT search, faster Bing
+indexing also means faster appearance in those AI answers.
+
+OpenSEO exposes IndexNow through two MCP tools, so agents can close the
+publish → index loop without leaving the chat.
+
+## How the key works
+
+IndexNow proves you control a host by having you serve a **verification file**
+(`<key>.txt`, containing the key) at the host root. The key itself is not a
+secret. OpenSEO derives a **deterministic** 32-char key from the project id, so
+it's stable across restarts and needs no storage — you publish the file once.
+
+## Tools
+
+### `get_indexnow_key`
+
+Returns `{ host, key, keyLocation, keyFileContent }` for a project (requires the
+project to have a domain). Publish a file at `keyLocation` whose entire contents
+are `keyFileContent`. Uses no credits.
+
+### `submit_urls_indexnow`
+
+Submits up to 10,000 URLs to IndexNow for the project's host. URLs that aren't on
+that host are skipped and reported (IndexNow only accepts same-host lists). The
+verification file must already be live, or engines ignore the submission. Uses no
+credits.
+
+## Setup (one time per project)
+
+1. Ensure the project has a `domain`.
+2. `get_indexnow_key` → publish the returned file at `https://<domain>/<key>.txt`.
+3. Verify it resolves: `curl https://<domain>/<key>.txt` returns the key.
+
+## Usage
+
+After publishing or updating pages, call `submit_urls_indexnow` with the affected
+URLs. Re-run it whenever content changes — there's no cost and no rate concern for
+normal volumes.

--- a/src/server/lib/indexnow.ts
+++ b/src/server/lib/indexnow.ts
@@ -1,0 +1,90 @@
+// IndexNow (https://www.indexnow.org/) — push-based (re)indexing that notifies
+// Bing, Yandex, and other participating engines within seconds, for free.
+//
+// IndexNow keys are not secrets: control of a host is proven by serving
+// `<key>.txt` (containing the key) at the host root. A key derived
+// deterministically from the project id is therefore safe, stable across
+// restarts, and needs no storage — the only per-project state IndexNow needs.
+
+const INDEXNOW_ENDPOINT = "https://api.indexnow.org/indexnow";
+
+// Bare host from a stored project domain (tolerates a scheme/path/trailing
+// slash if one slipped in). Returns null when there's nothing usable.
+export function indexNowHostFromDomain(
+  domain: string | null | undefined,
+): string | null {
+  if (!domain) return null;
+  const trimmed = domain.trim().replace(/^https?:\/\//i, "");
+  const host = trimmed.split("/")[0]?.trim().toLowerCase();
+  return host ? host : null;
+}
+
+// 32 hex chars derived from the project id. Deterministic (SHA-256), so the
+// same project always yields the same key and hosted `<key>.txt` stays valid.
+export async function deriveIndexNowKey(projectId: string): Promise<string> {
+  const bytes = new TextEncoder().encode(`indexnow:${projectId}`);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("")
+    .slice(0, 32);
+}
+
+export function indexNowKeyLocation(host: string, key: string): string {
+  return `https://${host}/${key}.txt`;
+}
+
+// URLs must all belong to the host (IndexNow rejects cross-host lists).
+export function partitionUrlsByHost(
+  urls: string[],
+  host: string,
+): { matching: string[]; mismatched: string[] } {
+  const matching: string[] = [];
+  const mismatched: string[] = [];
+  for (const url of urls) {
+    let urlHost: string | null = null;
+    try {
+      urlHost = new URL(url).host.toLowerCase();
+    } catch {
+      urlHost = null;
+    }
+    if (urlHost && urlHost === host) {
+      matching.push(url);
+    } else {
+      mismatched.push(url);
+    }
+  }
+  return { matching, mismatched };
+}
+
+export type IndexNowSubmitResult = {
+  submitted: number;
+  status: number;
+  ok: boolean;
+  endpoint: string;
+};
+
+export async function submitToIndexNow(input: {
+  host: string;
+  key: string;
+  keyLocation: string;
+  urlList: string[];
+}): Promise<IndexNowSubmitResult> {
+  const response = await fetch(INDEXNOW_ENDPOINT, {
+    method: "POST",
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+    body: JSON.stringify({
+      host: input.host,
+      key: input.key,
+      keyLocation: input.keyLocation,
+      urlList: input.urlList,
+    }),
+  });
+  return {
+    submitted: input.urlList.length,
+    status: response.status,
+    // 200 = accepted; 202 = accepted, key validation pending.
+    ok: response.status === 200 || response.status === 202,
+    endpoint: INDEXNOW_ENDPOINT,
+  };
+}

--- a/src/server/mcp/server.ts
+++ b/src/server/mcp/server.ts
@@ -53,6 +53,10 @@ import {
   getAuditStatusTool,
   runSiteAuditTool,
 } from "@/server/mcp/tools/site-audit-tools";
+import {
+  getIndexNowKeyTool,
+  submitUrlsIndexNowTool,
+} from "@/server/mcp/tools/indexnow-tools";
 import { whoamiTool } from "@/server/mcp/tools/whoami";
 
 type ToolSchema = z.ZodType | z.ZodRawShape;
@@ -102,6 +106,24 @@ function registerOpenSeoTool<Input extends ToolSchema>(
     (args, context) =>
       // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- args were validated against the tool's own inputSchema just above
       handler(args as ToolArgs<Input>, createMcpToolContext(context)),
+  );
+  server.registerTool(
+    getIndexNowKeyTool.name,
+    getIndexNowKeyTool.config,
+    instrumentMcpToolHandler(
+      getIndexNowKeyTool.name,
+      getIndexNowKeyTool.config.outputSchema,
+      getIndexNowKeyTool.handler,
+    ),
+  );
+  server.registerTool(
+    submitUrlsIndexNowTool.name,
+    submitUrlsIndexNowTool.config,
+    instrumentMcpToolHandler(
+      submitUrlsIndexNowTool.name,
+      submitUrlsIndexNowTool.config.outputSchema,
+      submitUrlsIndexNowTool.handler,
+    ),
   );
 }
 

--- a/src/server/mcp/server.ts
+++ b/src/server/mcp/server.ts
@@ -107,24 +107,6 @@ function registerOpenSeoTool<Input extends ToolSchema>(
       // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- args were validated against the tool's own inputSchema just above
       handler(args as ToolArgs<Input>, createMcpToolContext(context)),
   );
-  server.registerTool(
-    getIndexNowKeyTool.name,
-    getIndexNowKeyTool.config,
-    instrumentMcpToolHandler(
-      getIndexNowKeyTool.name,
-      getIndexNowKeyTool.config.outputSchema,
-      getIndexNowKeyTool.handler,
-    ),
-  );
-  server.registerTool(
-    submitUrlsIndexNowTool.name,
-    submitUrlsIndexNowTool.config,
-    instrumentMcpToolHandler(
-      submitUrlsIndexNowTool.name,
-      submitUrlsIndexNowTool.config.outputSchema,
-      submitUrlsIndexNowTool.handler,
-    ),
-  );
 }
 
 export function createOpenSeoMcpServer() {
@@ -189,6 +171,8 @@ export function createOpenSeoMcpServer() {
   registerOpenSeoTool(server, getAuditStatusTool);
   registerOpenSeoTool(server, getAuditIssuesTool);
   registerOpenSeoTool(server, getAuditPagesTool);
+  registerOpenSeoTool(server, getIndexNowKeyTool);
+  registerOpenSeoTool(server, submitUrlsIndexNowTool);
 
   return server;
 }

--- a/src/server/mcp/tools/indexnow-tools.test.ts
+++ b/src/server/mcp/tools/indexnow-tools.test.ts
@@ -1,0 +1,154 @@
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import type { ToolExtra } from "@/server/mcp/context";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { MCP_AUTH_CONTEXT_PROP } from "@/server/mcp/context";
+import { deriveIndexNowKey } from "@/server/lib/indexnow";
+
+const mocks = vi.hoisted(() => ({
+  getProjectForOrganization: vi.fn(),
+}));
+
+vi.mock("@/server/features/projects/services/ProjectService", () => ({
+  ProjectService: {
+    getProjectForOrganization: mocks.getProjectForOrganization,
+  },
+}));
+
+const authContext = {
+  userId: "user_123",
+  userEmail: "alice@example.com",
+  organizationId: "org_123",
+  clientId: "client_123",
+  scopes: ["mcp"],
+  audience: "https://open-seo.test/mcp",
+  subject: "user_123",
+  baseUrl: "https://open-seo.test",
+};
+
+const toolExtra: ToolExtra = {
+  signal: new AbortController().signal,
+  requestId: 1,
+  sendNotification: vi.fn(),
+  sendRequest: vi.fn(),
+  authInfo: {
+    token: "token",
+    clientId: "client_123",
+    scopes: ["mcp"],
+    resource: new URL("https://open-seo.test/mcp"),
+    extra: { [MCP_AUTH_CONTEXT_PROP]: authContext },
+  } satisfies AuthInfo,
+};
+
+const indexNowBodySchema = z.object({
+  host: z.string(),
+  key: z.string(),
+  keyLocation: z.string(),
+  urlList: z.array(z.string()),
+});
+
+describe("IndexNow MCP tools", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.getProjectForOrganization.mockReset();
+    mocks.getProjectForOrganization.mockResolvedValue({
+      id: "project_1",
+      name: "Acme",
+      domain: "acme.com",
+      locationCode: 2840,
+      languageCode: "en",
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns the deterministic key + verification file location", async () => {
+    const { getIndexNowKeyTool } = await import("./indexnow-tools");
+    const expectedKey = await deriveIndexNowKey("project_1");
+
+    const result = await getIndexNowKeyTool.handler(
+      { projectId: "project_1" },
+      toolExtra,
+    );
+
+    expect(expectedKey).toMatch(/^[0-9a-f]{32}$/);
+    expect(result.structuredContent).toMatchObject({
+      host: "acme.com",
+      key: expectedKey,
+      keyFileContent: expectedKey,
+      keyLocation: `https://acme.com/${expectedKey}.txt`,
+    });
+  });
+
+  it("errors when the project has no domain", async () => {
+    mocks.getProjectForOrganization.mockResolvedValue({
+      id: "project_1",
+      name: "Acme",
+      domain: null,
+      locationCode: 2840,
+      languageCode: "en",
+    });
+    const { getIndexNowKeyTool } = await import("./indexnow-tools");
+
+    await expect(
+      getIndexNowKeyTool.handler({ projectId: "project_1" }, toolExtra),
+    ).rejects.toThrow(/domain/i);
+  });
+
+  it("submits on-host URLs and skips cross-host ones", async () => {
+    let capturedUrl: string | undefined;
+    let capturedBody: string | undefined;
+    const fetchMock = vi.fn((input: unknown, init?: { body?: unknown }) => {
+      capturedUrl = typeof input === "string" ? input : undefined;
+      capturedBody = typeof init?.body === "string" ? init.body : undefined;
+      return Promise.resolve(new Response(null, { status: 200 }));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { submitUrlsIndexNowTool } = await import("./indexnow-tools");
+    const expectedKey = await deriveIndexNowKey("project_1");
+
+    const result = await submitUrlsIndexNowTool.handler(
+      {
+        projectId: "project_1",
+        urls: [
+          "https://acme.com/a",
+          "https://acme.com/b",
+          "https://other.com/c",
+        ],
+      },
+      toolExtra,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(capturedUrl).toBe("https://api.indexnow.org/indexnow");
+    const body = indexNowBodySchema.parse(JSON.parse(capturedBody ?? "{}"));
+    expect(body.host).toBe("acme.com");
+    expect(body.urlList).toEqual(["https://acme.com/a", "https://acme.com/b"]);
+    expect(body.key).toBe(expectedKey);
+    expect(body.keyLocation).toBe(`https://acme.com/${expectedKey}.txt`);
+
+    expect(result.structuredContent).toMatchObject({
+      host: "acme.com",
+      submitted: 2,
+      skipped: ["https://other.com/c"],
+      status: 200,
+      ok: true,
+    });
+  });
+
+  it("errors when no submitted URL is on the project host", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const { submitUrlsIndexNowTool } = await import("./indexnow-tools");
+
+    await expect(
+      submitUrlsIndexNowTool.handler(
+        { projectId: "project_1", urls: ["https://elsewhere.com/x"] },
+        toolExtra,
+      ),
+    ).rejects.toThrow(/acme\.com/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/mcp/tools/indexnow-tools.test.ts
+++ b/src/server/mcp/tools/indexnow-tools.test.ts
@@ -1,9 +1,7 @@
-import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
-import type { ToolExtra } from "@/server/mcp/context";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
-import { MCP_AUTH_CONTEXT_PROP } from "@/server/mcp/context";
 import { deriveIndexNowKey } from "@/server/lib/indexnow";
+import { makeToolContext } from "./tool-test-support";
 
 const mocks = vi.hoisted(() => ({
   getProjectForOrganization: vi.fn(),
@@ -15,30 +13,7 @@ vi.mock("@/server/features/projects/services/ProjectService", () => ({
   },
 }));
 
-const authContext = {
-  userId: "user_123",
-  userEmail: "alice@example.com",
-  organizationId: "org_123",
-  clientId: "client_123",
-  scopes: ["mcp"],
-  audience: "https://open-seo.test/mcp",
-  subject: "user_123",
-  baseUrl: "https://open-seo.test",
-};
-
-const toolExtra: ToolExtra = {
-  signal: new AbortController().signal,
-  requestId: 1,
-  sendNotification: vi.fn(),
-  sendRequest: vi.fn(),
-  authInfo: {
-    token: "token",
-    clientId: "client_123",
-    scopes: ["mcp"],
-    resource: new URL("https://open-seo.test/mcp"),
-    extra: { [MCP_AUTH_CONTEXT_PROP]: authContext },
-  } satisfies AuthInfo,
-};
+const toolContext = makeToolContext();
 
 const indexNowBodySchema = z.object({
   host: z.string(),
@@ -70,7 +45,7 @@ describe("IndexNow MCP tools", () => {
 
     const result = await getIndexNowKeyTool.handler(
       { projectId: "project_1" },
-      toolExtra,
+      toolContext,
     );
 
     expect(expectedKey).toMatch(/^[0-9a-f]{32}$/);
@@ -93,7 +68,7 @@ describe("IndexNow MCP tools", () => {
     const { getIndexNowKeyTool } = await import("./indexnow-tools");
 
     await expect(
-      getIndexNowKeyTool.handler({ projectId: "project_1" }, toolExtra),
+      getIndexNowKeyTool.handler({ projectId: "project_1" }, toolContext),
     ).rejects.toThrow(/domain/i);
   });
 
@@ -118,7 +93,7 @@ describe("IndexNow MCP tools", () => {
           "https://other.com/c",
         ],
       },
-      toolExtra,
+      toolContext,
     );
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -138,6 +113,40 @@ describe("IndexNow MCP tools", () => {
     });
   });
 
+  // Contract: a non-2xx from the IndexNow endpoint is reported as data
+  // (ok:false + the status), NOT raised as a tool error. The submission was
+  // well-formed; the engine simply rejected it — most often because the key
+  // file isn't published yet (403), which the agent should be able to read and
+  // act on rather than see as a tool failure. Engines also answer 202 for
+  // "accepted, key validation pending", so ok tracks 2xx, not strictly 200.
+  it.each([
+    { status: 202, ok: true, label: "202 accepted / validation pending" },
+    { status: 403, ok: false, label: "403 key not valid" },
+    { status: 422, ok: false, label: "422 URLs do not belong to host" },
+    { status: 500, ok: false, label: "500 engine error" },
+  ])("reports HTTP $label as data, not a thrown error", async (scenario) => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(new Response(null, { status: scenario.status })),
+      ),
+    );
+    const { submitUrlsIndexNowTool } = await import("./indexnow-tools");
+
+    const result = await submitUrlsIndexNowTool.handler(
+      { projectId: "project_1", urls: ["https://acme.com/a"] },
+      toolContext,
+    );
+
+    expect(result.structuredContent).toMatchObject({
+      host: "acme.com",
+      submitted: 1,
+      status: scenario.status,
+      ok: scenario.ok,
+    });
+    expect(result.isError).toBeFalsy();
+  });
+
   it("errors when no submitted URL is on the project host", async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
@@ -146,7 +155,7 @@ describe("IndexNow MCP tools", () => {
     await expect(
       submitUrlsIndexNowTool.handler(
         { projectId: "project_1", urls: ["https://elsewhere.com/x"] },
-        toolExtra,
+        toolContext,
       ),
     ).rejects.toThrow(/acme\.com/);
     expect(fetchMock).not.toHaveBeenCalled();

--- a/src/server/mcp/tools/indexnow-tools.ts
+++ b/src/server/mcp/tools/indexnow-tools.ts
@@ -1,0 +1,127 @@
+import { z } from "zod";
+import { mcpResponse } from "@/server/mcp/formatters";
+import { buildProjectMeta } from "@/server/mcp/context";
+import { optionalMetaOutputSchema } from "@/server/mcp/output-schemas";
+import { withMcpProjectAuth } from "@/server/mcp/project-auth";
+import { projectIdSchema } from "@/server/mcp/schemas";
+import {
+  deriveIndexNowKey,
+  indexNowHostFromDomain,
+  indexNowKeyLocation,
+  partitionUrlsByHost,
+  submitToIndexNow,
+} from "@/server/lib/indexnow";
+
+const DOMAIN_REQUIRED_MESSAGE =
+  "This project has no domain set. Add a domain to the project first, then retry.";
+
+export const getIndexNowKeyTool = {
+  name: "get_indexnow_key",
+  config: {
+    title: "Get IndexNow key",
+    description:
+      "Return the project's IndexNow key and the verification file to publish. Uses no credits. The key is derived deterministically from the project (stable across restarts). To activate IndexNow, host a file at the returned keyLocation whose entire contents are the key; then submit URLs with submit_urls_indexnow. Requires the project to have a domain.",
+    inputSchema: { projectId: projectIdSchema },
+    outputSchema: {
+      host: z.string(),
+      key: z.string(),
+      keyLocation: z.string(),
+      keyFileContent: z.string(),
+      ...optionalMetaOutputSchema,
+    },
+    annotations: {
+      readOnlyHint: true,
+      openWorldHint: false,
+      destructiveHint: false,
+    },
+  },
+  handler: withMcpProjectAuth(async (args: { projectId: string }, context) => {
+    const host = indexNowHostFromDomain(context.project.domain);
+    if (!host) {
+      throw new Error(DOMAIN_REQUIRED_MESSAGE);
+    }
+    const key = await deriveIndexNowKey(context.project.id);
+    const keyLocation = indexNowKeyLocation(host, key);
+    return mcpResponse({
+      text: `IndexNow key for ${host}: ${key}\nPublish ${keyLocation} containing exactly:\n${key}\nThen call submit_urls_indexnow to notify Bing/Yandex.`,
+      meta: buildProjectMeta(context, args.projectId),
+      structuredContent: {
+        host,
+        key,
+        keyLocation,
+        keyFileContent: key,
+      },
+    });
+  }),
+};
+
+export const submitUrlsIndexNowTool = {
+  name: "submit_urls_indexnow",
+  config: {
+    title: "Submit URLs to IndexNow",
+    description:
+      "Notify Bing, Yandex, and other IndexNow engines that URLs are new or updated — free, no DataForSEO credits, typically indexed within seconds. All URLs must be on the project's domain (cross-host URLs are skipped and reported). The verification file from get_indexnow_key must already be published at the domain root, or engines will ignore the submission.",
+    inputSchema: {
+      projectId: projectIdSchema,
+      urls: z
+        .array(z.string().url())
+        .min(1)
+        .max(10000)
+        .describe(
+          "Absolute URLs on the project's domain to (re)index (1-10000).",
+        ),
+    },
+    outputSchema: {
+      host: z.string(),
+      submitted: z.number(),
+      skipped: z.array(z.string()),
+      status: z.number(),
+      ok: z.boolean(),
+      keyLocation: z.string(),
+      ...optionalMetaOutputSchema,
+    },
+    annotations: {
+      readOnlyHint: false,
+      openWorldHint: true,
+      destructiveHint: false,
+    },
+  },
+  handler: withMcpProjectAuth(
+    async (args: { projectId: string; urls: string[] }, context) => {
+      const host = indexNowHostFromDomain(context.project.domain);
+      if (!host) {
+        throw new Error(DOMAIN_REQUIRED_MESSAGE);
+      }
+      const { matching, mismatched } = partitionUrlsByHost(args.urls, host);
+      if (matching.length === 0) {
+        throw new Error(
+          `None of the submitted URLs are on ${host}. IndexNow only accepts URLs for the project's own host.`,
+        );
+      }
+      const key = await deriveIndexNowKey(context.project.id);
+      const keyLocation = indexNowKeyLocation(host, key);
+      const result = await submitToIndexNow({
+        host,
+        key,
+        keyLocation,
+        urlList: matching,
+      });
+      const skippedNote =
+        mismatched.length > 0
+          ? ` Skipped ${mismatched.length} URL(s) not on ${host}.`
+          : "";
+      return mcpResponse({
+        text: `Submitted ${result.submitted} URL(s) for ${host} to IndexNow (HTTP ${result.status}).${skippedNote}`,
+        meta: buildProjectMeta(context, args.projectId),
+        structuredContent: {
+          host,
+          submitted: result.submitted,
+          skipped: mismatched,
+          status: result.status,
+          ok: result.ok,
+          keyLocation,
+        },
+      });
+    },
+  ),
+};

--- a/src/server/mcp/tools/indexnow-tools.ts
+++ b/src/server/mcp/tools/indexnow-tools.ts
@@ -60,7 +60,7 @@ export const submitUrlsIndexNowTool = {
   config: {
     title: "Submit URLs to IndexNow",
     description:
-      "Notify Bing, Yandex, and other IndexNow engines that URLs are new or updated — free, no DataForSEO credits, typically indexed within seconds. All URLs must be on the project's domain (cross-host URLs are skipped and reported). The verification file from get_indexnow_key must already be published at the domain root, or engines will ignore the submission.",
+      "Notify Bing, Yandex, and other IndexNow engines that URLs are new or updated — free, no DataForSEO credits, typically indexed within seconds. Google does NOT participate in IndexNow, so this does not affect Google indexing. All URLs must be on the project's domain (cross-host URLs are skipped and reported). The verification file from get_indexnow_key must already be published at the domain root, or engines will ignore the submission. The engine's HTTP status is returned as data (`status`, `ok`), not a tool error: 202 = accepted with key validation pending, 403 = key file not published yet.",
     inputSchema: {
       projectId: projectIdSchema,
       urls: z


### PR DESCRIPTION
Partially addresses #101 — this lands the MCP surface only; the key-management UI is deliberately left out (see discussion below).

## What

Adds **IndexNow** so agents can push new/updated URLs to Bing, Yandex, and other IndexNow engines — free, typically indexed within seconds. Since Bing's index feeds Copilot and ChatGPT search, this also shortens time-to-appearance in those AI answers, which lines up with what Prompt Explorer measures.

Kept it **MCP-first** (matching the agent-first design): two project-scoped tools, so the publish → index loop closes from chat. No UI in this PR — happy to add a settings card as a follow-up if you'd like one.

## Tools

- **`get_indexnow_key`** — returns `{ host, key, keyLocation, keyFileContent }` for a project (requires a domain). Uses no credits.
- **`submit_urls_indexnow`** — submits up to 10,000 same-host URLs to `https://api.indexnow.org/indexnow`; cross-host URLs are skipped and reported (IndexNow only accepts same-host lists). Uses no credits.

## Design note — no DB, no migration

IndexNow keys **aren't secrets**: control of a host is proven by serving `<key>.txt` at its root. So the key is **derived deterministically** from the project id (SHA-256 → 32 hex), which is stable across restarts and needs no storage. This avoided touching the schema (and the D1 + Postgres dual-migration surface) entirely — the feature is fully functional with zero persistence.

## Files

- `src/server/lib/indexnow.ts` — key derivation, host parsing, same-host partitioning, the submit POST.
- `src/server/mcp/tools/indexnow-tools.ts` — the two tools, registered in `server.ts`.
- `docs/INDEXNOW.md` — setup (publish the key file) + usage.

## Tests

`indexnow-tools.test.ts` (4): deterministic key + key-file location; errors when the project has no domain; submits on-host URLs and skips cross-host ones (asserts the exact POST body); errors when nothing is on-host (no fetch made).

## Checks

- `tsc --noEmit`: 0 errors (project-wide) · `oxlint --type-aware`: 0/0 · `prettier --check`: clean · `vitest`: 4/4 new, `output-schema-validation` 9/9.
- (`pnpm ci:check`'s `knip` step fails locally while loading `vite.config.ts` — reproduces on clean `main`, unrelated to this PR.)

## Demo

I'll add a short screen recording (agent calls `get_indexnow_key`, I publish the file, `curl` shows it live, then `submit_urls_indexnow` returns HTTP 200) against my self-hosted instance.