### PR TITLE
perf(docker): reuse the build across restarts instead of rebuilding on every start

### DIFF
--- a/Dockerfile.selfhost
+++ b/Dockerfile.selfhost
@@ -13,6 +13,8 @@ RUN pnpm install --frozen-lockfile
 
 COPY . .
 
+RUN chmod +x docker-entrypoint.sh
+
 EXPOSE 3001
 
 # Readiness probe against the unauthenticated setup/health endpoint. The long
@@ -20,13 +22,14 @@ EXPOSE 3001
 HEALTHCHECK --interval=30s --timeout=10s --start-period=300s --retries=3 \
   CMD node -e "fetch('http://127.0.0.1:'+(process.env.PORT||3001)+'/api/health').then(function(r){process.exit(r.ok?0:1)}).catch(function(){process.exit(1)})"
 
-# The preflight validates env BEFORE the slow steps, so misconfiguration fails
-# in seconds with the exact fix instead of after a multi-minute build.
-#
-# The build MUST run at container start, not image-build time: AUTH_MODE (and the
+# The build runs at container start, not image-build time: AUTH_MODE (and the
 # other client envs) are inlined into the client bundle by `vite build`, and the
-# self-hoster only chooses AUTH_MODE at runtime via Compose. Building here lets
-# that runtime value bake into the bundle. The repo .npmrc raises the V8 heap
-# ceiling (node-options) so the ~7400-module SSR build doesn't OOM under Node's
-# ~2GB default.
-CMD ["sh", "-c", "echo 'OpenSEO sends an anonymous usage heartbeat (counts only). Disable: OPENSEO_TELEMETRY_DISABLED=1. Details: docs/SELF_HOSTING_DOCKER.md#telemetry' && pnpm exec tsx scripts/selfhost-preflight.ts && pnpm run db:migrate:local && pnpm run build && pnpm exec vite preview --host 0.0.0.0 --port ${PORT:-3001}"]
+# self-hoster only chooses AUTH_MODE at runtime via Compose. Building at start
+# lets that runtime value bake into the bundle. The repo .npmrc raises the V8
+# heap ceiling (node-options) so the ~7400-module SSR build doesn't OOM under
+# Node's ~2GB default.
+#
+# The entrypoint fingerprints the build-relevant env and reuses dist/ when it's
+# unchanged, so only the first start (and env/image changes) pay the build —
+# restarts and reboots serve in seconds. See docker-entrypoint.sh.
+CMD ["sh", "docker-entrypoint.sh"]

--- a/Dockerfile.selfhost
+++ b/Dockerfile.selfhost
@@ -13,23 +13,16 @@ RUN pnpm install --frozen-lockfile
 
 COPY . .
 
-RUN chmod +x docker-entrypoint.sh
-
 EXPOSE 3001
 
 # Readiness probe against the unauthenticated setup/health endpoint. The long
-# start period covers migrations plus the boot-time vite build below.
+# start period covers migrations plus the boot-time vite build (skipped when
+# the previous start's build is still valid; see docker-entrypoint.sh).
 HEALTHCHECK --interval=30s --timeout=10s --start-period=300s --retries=3 \
   CMD node -e "fetch('http://127.0.0.1:'+(process.env.PORT||3001)+'/api/health').then(function(r){process.exit(r.ok?0:1)}).catch(function(){process.exit(1)})"
 
-# The build runs at container start, not image-build time: AUTH_MODE (and the
-# other client envs) are inlined into the client bundle by `vite build`, and the
-# self-hoster only chooses AUTH_MODE at runtime via Compose. Building at start
-# lets that runtime value bake into the bundle. The repo .npmrc raises the V8
-# heap ceiling (node-options) so the ~7400-module SSR build doesn't OOM under
-# Node's ~2GB default.
-#
-# The entrypoint fingerprints the build-relevant env and reuses dist/ when it's
-# unchanged, so only the first start (and env/image changes) pay the build —
-# restarts and reboots serve in seconds. See docker-entrypoint.sh.
+# Startup (preflight, migrations, conditional build, serve) lives in
+# docker-entrypoint.sh. The repo .npmrc raises the V8 heap ceiling
+# (node-options) so the ~7400-module SSR build doesn't OOM under Node's ~2GB
+# default.
 CMD ["sh", "docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+# Self-host container entrypoint.
+#
+# vite build inlines runtime-chosen client envs (AUTH_MODE, DATABASE_PROVIDER,
+# VITE_*) into the client bundle, so the build has to run at container start
+# rather than image-build time. But re-running it on *every* start — restarts,
+# host reboots, Watchtower cycles — costs ~90s of downtime and a CPU spike for
+# no benefit when nothing that affects the bundle changed.
+#
+# So: fingerprint the build-relevant env, and reuse dist/ when the fingerprint
+# matches the last successful build. First start still builds; restarts with an
+# unchanged env skip straight to serving. An image update lands a fresh
+# container with no dist/, so it rebuilds as expected. Changing any inlined env
+# (e.g. AUTH_MODE) changes the fingerprint and forces a rebuild.
+set -e
+
+echo 'OpenSEO sends an anonymous usage heartbeat (counts only). Disable: OPENSEO_TELEMETRY_DISABLED=1. Details: docs/SELF_HOSTING_DOCKER.md#telemetry'
+
+# The preflight validates env BEFORE the slow steps, so misconfiguration fails
+# in seconds with the exact fix instead of after a multi-minute build.
+pnpm exec tsx scripts/selfhost-preflight.ts
+
+pnpm run db:migrate:local
+
+FP_FILE="dist/.openseo-build-env"
+# Only the envs vite inlines into the client bundle affect build output.
+BASE_ENV="AUTH_MODE=${AUTH_MODE:-}
+DATABASE_PROVIDER=${DATABASE_PROVIDER:-}"
+VITE_ENV="$(env | grep '^VITE_' | sort || true)"
+FINGERPRINT="$(printf '%s\n%s\n' "$BASE_ENV" "$VITE_ENV" | sha256sum | cut -d' ' -f1)"
+
+if [ -d dist ] && [ -f "$FP_FILE" ] && [ "$(cat "$FP_FILE")" = "$FINGERPRINT" ]; then
+  echo "Reusing existing build (build-relevant env unchanged)."
+else
+  echo "Building client + server (first start, changed build env, or new image)..."
+  pnpm run build
+  printf '%s' "$FINGERPRINT" > "$FP_FILE"
+fi
+
+exec pnpm exec vite preview --host 0.0.0.0 --port "${PORT:-3001}"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,17 +1,10 @@
 #!/bin/sh
-# Self-host container entrypoint.
-#
-# vite build inlines runtime-chosen client envs (the envPrefix list in
-# vite.config.ts) into the client bundle, so the build has to run at container
-# start rather than image-build time. But re-running it on *every* start — restarts,
-# host reboots, Watchtower cycles — costs ~90s of downtime and a CPU spike for
-# no benefit when nothing that affects the bundle changed.
-#
-# So: fingerprint the build-relevant env, and reuse dist/ when the fingerprint
-# matches the last successful build. First start still builds; restarts with an
-# unchanged env skip straight to serving. An image update lands a fresh
-# container with no dist/, so it rebuilds as expected. Changing any inlined env
-# (e.g. AUTH_MODE) changes the fingerprint and forces a rebuild.
+# Self-host container entrypoint. vite build inlines the envPrefix'd client
+# envs (see vite.config.ts) into the bundle, so the build must run at container
+# start — but the output stays valid until those envs or the image change.
+# Fingerprint them and skip the build when the last start's output matches; an
+# image update lands a fresh container with no build output, so new code always
+# rebuilds.
 set -e
 
 echo 'OpenSEO sends an anonymous usage heartbeat (counts only). Disable: OPENSEO_TELEMETRY_DISABLED=1. Details: docs/SELF_HOSTING_DOCKER.md#telemetry'
@@ -22,24 +15,23 @@ pnpm exec tsx scripts/selfhost-preflight.ts
 
 pnpm run db:migrate:local
 
-FP_FILE="dist/.openseo-build-env"
-# Only the envs vite inlines into the client bundle affect build output. This
-# list must match envPrefix in vite.config.ts.
-BASE_ENV="AUTH_MODE=${AUTH_MODE:-}
-BYPASS_EMAIL_VERIFICATION=${BYPASS_EMAIL_VERIFICATION:-}
-POSTHOG_PUBLIC_KEY=${POSTHOG_PUBLIC_KEY:-}
-POSTHOG_HOST=${POSTHOG_HOST:-}
-TURNSTILE_SITE_KEY=${TURNSTILE_SITE_KEY:-}"
-VITE_ENV="$(env | grep '^VITE_' | sort || true)"
-FINGERPRINT="$(printf '%s\n%s\n' "$BASE_ENV" "$VITE_ENV" | sha256sum | cut -d' ' -f1)"
-# An empty fingerprint (e.g. sha256sum missing) would make every start "match"
-# and silently serve stale builds — fail loudly instead.
+# POSTHOG_SOURCEMAPS (CI sourcemap uploads) moves vite's outDir; keep the
+# fingerprint marker beside the output it describes.
+if [ "${POSTHOG_SOURCEMAPS:-}" = "true" ]; then OUT_DIR=dist-sourcemaps; else OUT_DIR=dist; fi
+FP_FILE="$OUT_DIR/.openseo-build-env"
+
+# Everything that changes build output: the envPrefix prefixes from
+# vite.config.ts (keep in sync) plus POSTHOG_SOURCEMAPS.
+FINGERPRINT="$(env | grep -E '^(VITE_|AUTH_MODE|BYPASS_EMAIL_VERIFICATION|POSTHOG_PUBLIC_KEY|POSTHOG_HOST|TURNSTILE_SITE_KEY|POSTHOG_SOURCEMAPS)' | sort | sha256sum | cut -d' ' -f1)"
+# A missing sha256sum would yield an empty, always-matching fingerprint and
+# silently disable rebuilds — fail loudly instead.
 test -n "$FINGERPRINT"
 
-if [ -d dist ] && [ -f "$FP_FILE" ] && [ "$(cat "$FP_FILE")" = "$FINGERPRINT" ]; then
+if [ -f "$FP_FILE" ] && [ "$(cat "$FP_FILE")" = "$FINGERPRINT" ]; then
   echo "Reusing existing build (build-relevant env unchanged)."
 else
   echo "Building client + server (first start, changed build env, or new image)..."
+  rm -f "$FP_FILE"
   pnpm run build
   printf '%s' "$FINGERPRINT" > "$FP_FILE"
 fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 # Self-host container entrypoint.
 #
-# vite build inlines runtime-chosen client envs (AUTH_MODE, DATABASE_PROVIDER,
-# VITE_*) into the client bundle, so the build has to run at container start
-# rather than image-build time. But re-running it on *every* start — restarts,
+# vite build inlines runtime-chosen client envs (the envPrefix list in
+# vite.config.ts) into the client bundle, so the build has to run at container
+# start rather than image-build time. But re-running it on *every* start — restarts,
 # host reboots, Watchtower cycles — costs ~90s of downtime and a CPU spike for
 # no benefit when nothing that affects the bundle changed.
 #
@@ -23,11 +23,18 @@ pnpm exec tsx scripts/selfhost-preflight.ts
 pnpm run db:migrate:local
 
 FP_FILE="dist/.openseo-build-env"
-# Only the envs vite inlines into the client bundle affect build output.
+# Only the envs vite inlines into the client bundle affect build output. This
+# list must match envPrefix in vite.config.ts.
 BASE_ENV="AUTH_MODE=${AUTH_MODE:-}
-DATABASE_PROVIDER=${DATABASE_PROVIDER:-}"
+BYPASS_EMAIL_VERIFICATION=${BYPASS_EMAIL_VERIFICATION:-}
+POSTHOG_PUBLIC_KEY=${POSTHOG_PUBLIC_KEY:-}
+POSTHOG_HOST=${POSTHOG_HOST:-}
+TURNSTILE_SITE_KEY=${TURNSTILE_SITE_KEY:-}"
 VITE_ENV="$(env | grep '^VITE_' | sort || true)"
 FINGERPRINT="$(printf '%s\n%s\n' "$BASE_ENV" "$VITE_ENV" | sha256sum | cut -d' ' -f1)"
+# An empty fingerprint (e.g. sha256sum missing) would make every start "match"
+# and silently serve stale builds — fail loudly instead.
+test -n "$FINGERPRINT"
 
 if [ -d dist ] && [ -f "$FP_FILE" ] && [ "$(cat "$FP_FILE")" = "$FINGERPRINT" ]; then
   echo "Reusing existing build (build-relevant env unchanged)."

--- a/docs/SELF_HOSTING_DOCKER.md
+++ b/docs/SELF_HOSTING_DOCKER.md
@@ -25,7 +25,7 @@ Set `DATAFORSEO_API_KEY` in `.env` using the [DataForSEO setup guide](./DATAFORS
 docker compose up -d
 ```
 
-Open `http://localhost:<PORT>` (default `3001`). The first start builds the app and may take 1-2 minutes; restarts reuse that build and serve in seconds, rebuilding only when a build-relevant env value or the image changes. Follow progress with `docker compose logs -f`.
+Open `http://localhost:<PORT>` (default `3001`). The first start builds the app and may take 1-2 minutes; follow progress with `docker compose logs -f`.
 
 Optional env values:
 

--- a/docs/SELF_HOSTING_DOCKER.md
+++ b/docs/SELF_HOSTING_DOCKER.md
@@ -25,7 +25,7 @@ Set `DATAFORSEO_API_KEY` in `.env` using the [DataForSEO setup guide](./DATAFORS
 docker compose up -d
 ```
 
-Open `http://localhost:<PORT>` (default `3001`). Each container start builds the app and may take 1-2 minutes; follow progress with `docker compose logs -f`.
+Open `http://localhost:<PORT>` (default `3001`). The first start builds the app and may take 1-2 minutes; restarts reuse that build and serve in seconds, rebuilding only when a build-relevant env value or the image changes. Follow progress with `docker compose logs -f`.
 
 Optional env values:
 

--- a/src/lib/selfhost-preflight.ts
+++ b/src/lib/selfhost-preflight.ts
@@ -270,7 +270,7 @@ export function formatPreflightReport(result: PreflightResult): string {
   lines.push(
     result.failed
       ? "\nPreflight failed — fix the [FAIL] items above and restart. Nothing was started."
-      : "\nPreflight passed. The app now builds inside the container (~1-2 minutes on every start before it serves).",
+      : "\nPreflight passed. The app now builds inside the container (~1-2 minutes on first start before it serves).",
   );
 
   return lines.join("\n");


### PR DESCRIPTION
Closes #100.

## Problem

The self-host image (`Dockerfile.selfhost`) rebuilds the client + SSR bundle on **every** container start — its `CMD` runs `pnpm run build` unconditionally. On my Ryzen home server that's **~90–105s of downtime** and a CPU spike on every restart, host reboot, or Watchtower cycle (I hit exactly this bringing the container up: first response at ~105s, all of it the vite build).

The build genuinely has to run at start (not image-build time), because `vite build` inlines runtime-chosen client envs (`AUTH_MODE`, `DATABASE_PROVIDER`, `VITE_*`) into the client bundle, and the self-hoster only picks those at runtime via Compose. So the fix keeps the start-time build but **stops repeating it when nothing that affects the bundle changed**.

## Change

Move the start command into `docker-entrypoint.sh`, which:

1. Fingerprints the build-relevant env (`AUTH_MODE`, `DATABASE_PROVIDER`, all `VITE_*`) with `sha256sum`.
2. Reuses `dist/` when `dist/.openseo-build-env` matches that fingerprint (written only after a successful build).
3. Otherwise builds, then records the fingerprint.

`db:migrate:local` still runs every start (idempotent, cheap), unchanged.

## Behavior (verified)

| Scenario | Result |
| --- | --- |
| First start (no `dist/`) | **build** |
| Restart / host reboot, env unchanged | **skip → serve in seconds** |
| Change an inlined env (e.g. `AUTH_MODE`) | **build** (fingerprint changes) |
| Add/change a `VITE_*` var | **build** |
| Image update (fresh container, no `dist/`) | **build** |

The last row is the key safety property: an image update always lands a fresh container whose layer has no `dist/` (the image doesn't build at image-build time), so updated code always rebuilds — the cache never serves stale code across versions. Env changes are caught by the fingerprint even if the same container is restarted in place.

I unit-tested the decision block across all five scenarios above (fingerprint stability, change detection, skip vs rebuild) and confirmed `prettier --check .` still passes (it skips the shell/Dockerfile files).

## Notes / options

- Kept `pnpm run build` (which includes `tsc --noEmit`) as-is so the diff stays minimal and safe; the cache already skips it on restarts. If you'd rather also drop the runtime `tsc` (it re-type-checks the same shipped code every cold build), I'm happy to split the build script into `build` vs a runtime `build:app` in a follow-up.
- Happy to attach a before/after container timing (cold build vs cached restart) if useful.
