### PR TITLE
fix(gsc): clamp month-based date ranges instead of overflowing short months

### DIFF
--- a/src/server/features/gsc/searchAnalytics.test.ts
+++ b/src/server/features/gsc/searchAnalytics.test.ts
@@ -46,6 +46,23 @@ describe("resolveDateRange", () => {
     );
     expect(startDate).toBe("2026-01-01");
   });
+
+  it("subtracts calendar months without overflowing short months", () => {
+    const { startDate, endDate } = resolveDateRange(
+      { dateRange: "last_3_months" },
+      new Date("2026-06-03T00:00:00Z"),
+    );
+    expect(startDate).toBe("2026-02-28");
+    expect(endDate).toBe("2026-05-31");
+  });
+
+  it("clamps the 16-month floor to the last valid day of a short month", () => {
+    const { startDate } = resolveDateRange(
+      { dateRange: "last_16_months" },
+      new Date("2026-06-30T00:00:00Z"),
+    );
+    expect(startDate).toBe("2025-02-28");
+  });
 });
 
 describe("buildSearchAnalyticsRequest", () => {

--- a/src/server/features/gsc/searchAnalytics.ts
+++ b/src/server/features/gsc/searchAnalytics.ts
@@ -72,6 +72,19 @@ function formatDate(date: Date): string {
   return date.toISOString().slice(0, 10);
 }
 
+// Subtract calendar months in UTC, clamping the day to the target month's length.
+function subtractUtcMonths(date: Date, months: number): Date {
+  const day = date.getUTCDate();
+  const d = new Date(date);
+  d.setUTCDate(1);
+  d.setUTCMonth(d.getUTCMonth() - months);
+  const daysInTargetMonth = new Date(
+    Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + 1, 0),
+  ).getUTCDate();
+  d.setUTCDate(Math.min(day, daysInTargetMonth));
+  return d;
+}
+
 function subtractRange(end: Date, range: GscDateRange): Date {
   const d = new Date(end);
   switch (range) {
@@ -82,25 +95,19 @@ function subtractRange(end: Date, range: GscDateRange): Date {
       d.setUTCDate(d.getUTCDate() - 28);
       break;
     case "last_3_months":
-      d.setUTCMonth(d.getUTCMonth() - 3);
-      break;
+      return subtractUtcMonths(d, 3);
     case "last_6_months":
-      d.setUTCMonth(d.getUTCMonth() - 6);
-      break;
+      return subtractUtcMonths(d, 6);
     case "last_12_months":
-      d.setUTCMonth(d.getUTCMonth() - 12);
-      break;
+      return subtractUtcMonths(d, 12);
     case "last_16_months":
-      d.setUTCMonth(d.getUTCMonth() - 16);
-      break;
+      return subtractUtcMonths(d, 16);
   }
   return d;
 }
 
 function sixteenMonthFloor(today: Date): string {
-  const d = new Date(today);
-  d.setUTCMonth(d.getUTCMonth() - 16);
-  return formatDate(d);
+  return formatDate(subtractUtcMonths(today, 16));
 }
 
 /** Resolve a convenience `dateRange` or explicit start/end into GSC dates.


### PR DESCRIPTION
## Problem

`resolveDateRange` in `src/server/features/gsc/searchAnalytics.ts` subtracts calendar months using `setUTCMonth`, which does **not** clamp the day-of-month. When the anchor date's day doesn't exist in the target month, JavaScript rolls the date *forward* into the next month.

Concrete repro (`last_3_months`, `today = 2026-06-03`):

- Lagged end = `2026-06-03 − 3 days` = **`2026-05-31`**
- `subtractRange(2026-05-31, "last_3_months")` runs `setUTCMonth(-3)` → Feb 31 2026 → overflows to **`2026-03-03`**
- Expected start ≈ **`2026-02-28`**

So the user silently loses ~3 days at the start of the window. The same bug affects `last_6/12/16_months` and `sixteenMonthFloor` (e.g. the 16-month floor from `2026-06-30` lands on `2025-03-02` instead of `2025-02-28`).

The sibling file `searchPerformanceReport.ts` does its date math in milliseconds and is correct, which suggests this was an oversight rather than intent.

## Fix

Add a small `subtractUtcMonths(date, months)` helper that shifts on the 1st of the month and re-applies the original day clamped to the target month's length, then route the month-based cases (`subtractRange` and `sixteenMonthFloor`) through it. Day- and week-based ranges are untouched.

## Tests

The existing `resolveDateRange` tests anchor on `TODAY = 2026-05-28` (day 25/28 after lag), which never overflows, so the overflow branch was completely untested. Added two cases:

- `last_3_months` from a 31-day lagged end → start clamps to `2026-02-28` (not `2026-03-03`)
- `last_16_months` 16-month floor into a short month → `2025-02-28` (not `2025-03-02`)

All existing assertions are unchanged and still pass.

## Verification

- `pnpm test` — 712 passed (87 files), including the 2 new cases
- `pnpm ci:check` — prettier, knip, `tsc --noEmit` (×2), and oxlint all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)