### PR TITLE
fix(backlinks): keep truncateMiddle within maxLength

### DIFF
--- a/src/client/features/backlinks/backlinksPageUtils.test.ts
+++ b/src/client/features/backlinks/backlinksPageUtils.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { truncateMiddle } from "./backlinksPageUtils";
+
+describe("truncateMiddle", () => {
+  it("returns the value unchanged when it already fits", () => {
+    expect(truncateMiddle("short", 10)).toBe("short");
+    expect(truncateMiddle("exactly-ten", "exactly-ten".length)).toBe(
+      "exactly-ten",
+    );
+  });
+
+  it("never returns a string longer than maxLength", () => {
+    const value = "/very/long/path/segment/that/keeps/going/here";
+    for (let maxLength = 0; maxLength <= value.length; maxLength++) {
+      expect(truncateMiddle(value, maxLength).length).toBeLessThanOrEqual(
+        maxLength,
+      );
+    }
+  });
+
+  it("keeps head and tail around a middle ellipsis", () => {
+    expect(truncateMiddle("abcdefghijklmno", 10)).toBe("abc...mno");
+    expect(truncateMiddle("/very/long/path/segment/here", 12)).toBe(
+      "/ver...here",
+    );
+  });
+
+  it("head-truncates when there is no room for both sides", () => {
+    expect(truncateMiddle("abcdefgh", 4)).toBe("a...");
+    expect(truncateMiddle("abcdefgh", 3)).toBe("abc");
+    expect(truncateMiddle("abcdefgh", 2)).toBe("ab");
+  });
+});

--- a/src/client/features/backlinks/backlinksPageUtils.ts
+++ b/src/client/features/backlinks/backlinksPageUtils.ts
@@ -114,8 +114,15 @@ export function extractUrlPath(url: string) {
   }
 }
 
+const ELLIPSIS = "...";
+
 export function truncateMiddle(value: string, maxLength: number) {
   if (value.length <= maxLength) return value;
-  const sideLength = Math.floor((maxLength - 1) / 2);
-  return `${value.slice(0, sideLength)}...${value.slice(-sideLength)}`;
+  if (maxLength <= ELLIPSIS.length)
+    return value.slice(0, Math.max(maxLength, 0));
+  const sideLength = Math.floor((maxLength - ELLIPSIS.length) / 2);
+  if (sideLength <= 0) {
+    return `${value.slice(0, maxLength - ELLIPSIS.length)}${ELLIPSIS}`;
+  }
+  return `${value.slice(0, sideLength)}${ELLIPSIS}${value.slice(-sideLength)}`;
 }


### PR DESCRIPTION
## Problem

`truncateMiddle` in `src/client/features/backlinks/backlinksPageUtils.ts` is meant to shorten a string to `maxLength` with a middle ellipsis, but it reserves only **1** character for the 3-character `"..."`:

```ts
const sideLength = Math.floor((maxLength - 1) / 2);
return `${value.slice(0, sideLength)}...${value.slice(-sideLength)}`;
```

The result length is `2 * sideLength + 3`, so **every truncated string overshoots `maxLength` by ~2 characters**. Verified against the real code:

| input | maxLength | actual | length |
|---|---|---|---|
| `abcdefghijklmno` | 10 | `abcd...lmno` | 11 |
| `/very/long/path/segment/here` | 12 | `/very.../here` | 13 |
| `abcdefgh` | 2 | `...abcdefgh` | 11 |

The last row is the sharp edge: when `maxLength <= 2`, `sideLength` rounds to `0` and `value.slice(-0)` is `value.slice(0)` — the **entire** string — so the output is longer than the *input*. This feeds the backlinks link labels (`BacklinksPageLinks.tsx`), so oversized labels leak into the UI.

## Fix

Reserve the full ellipsis width (`maxLength - 3`) and clamp the side slices, with a head-truncation fallback when `maxLength` is too small to hold content on both sides of the ellipsis. The result now always satisfies `result.length <= maxLength`.

## Tests

`truncateMiddle` had no test coverage. Added `backlinksPageUtils.test.ts`, including a sweep that asserts the length invariant (`result.length <= maxLength`) for **every** `maxLength` from `0` to the input length — which fails on the old implementation and passes on the new one.

## Verification

- `pnpm test` — 714 passed (88 files), including the new cases
- `pnpm ci:check` — prettier, knip, `tsc --noEmit` (×2), and oxlint all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)