### PR TITLE
fix(backlinks): clamp the one-year overview range on a leap-day end

### DIFF
--- a/src/server/features/backlinks/services/backlinksDateRange.test.ts
+++ b/src/server/features/backlinks/services/backlinksDateRange.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { buildBacklinksDateRange } from "@/server/features/backlinks/services/backlinksDateRange";
+
+describe("buildBacklinksDateRange", () => {
+  it("spans one year ending yesterday", () => {
+    expect(buildBacklinksDateRange(new Date("2025-06-16T00:00:00Z"))).toEqual({
+      dateFrom: "2024-06-15",
+      dateTo: "2025-06-15",
+    });
+  });
+
+  it("clamps to the last valid day when yesterday is a leap day", () => {
+    expect(buildBacklinksDateRange(new Date("2024-03-01T00:00:00Z"))).toEqual({
+      dateFrom: "2023-02-28",
+      dateTo: "2024-02-29",
+    });
+  });
+
+  it("keeps a full-year span for a non-leap February end", () => {
+    expect(buildBacklinksDateRange(new Date("2025-03-01T00:00:00Z"))).toEqual({
+      dateFrom: "2024-02-28",
+      dateTo: "2025-02-28",
+    });
+  });
+});

--- a/src/server/features/backlinks/services/backlinksDateRange.ts
+++ b/src/server/features/backlinks/services/backlinksDateRange.ts
@@ -1,0 +1,30 @@
+type BacklinksDateRange = {
+  dateFrom: string;
+  dateTo: string;
+};
+
+export function buildBacklinksDateRange(now: Date): BacklinksDateRange {
+  const todayUtc = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+  );
+  const dateToUtc = new Date(todayUtc);
+  dateToUtc.setUTCDate(dateToUtc.getUTCDate() - 1);
+
+  const fromYear = dateToUtc.getUTCFullYear() - 1;
+  const fromMonth = dateToUtc.getUTCMonth();
+  const lastDayOfFromMonth = new Date(
+    Date.UTC(fromYear, fromMonth + 1, 0),
+  ).getUTCDate();
+  const dateFromUtc = new Date(
+    Date.UTC(
+      fromYear,
+      fromMonth,
+      Math.min(dateToUtc.getUTCDate(), lastDayOfFromMonth),
+    ),
+  );
+
+  return {
+    dateFrom: dateFromUtc.toISOString().slice(0, 10),
+    dateTo: dateToUtc.toISOString().slice(0, 10),
+  };
+}

--- a/src/server/features/backlinks/services/backlinksServiceData.ts
+++ b/src/server/features/backlinks/services/backlinksServiceData.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { BillingCustomerContext } from "@/server/billing/subscription";
 import type { CreditFeature } from "@/shared/billing-credit-features";
+import { buildBacklinksDateRange } from "@/server/features/backlinks/services/backlinksDateRange";
 import {
   createDataforseoClient,
   normalizeBacklinksTarget,
@@ -63,11 +64,6 @@ export type BacklinksCache = {
 
 type BacklinksOverviewProfile = {
   overview: BacklinksOverviewResult;
-};
-
-type BacklinksDateRange = {
-  dateFrom: string;
-  dateTo: string;
 };
 
 export async function profileBacklinksOverview(
@@ -249,22 +245,6 @@ function buildPageResult<TRow>(
     page: input.page,
     pageSize: input.pageSize,
     fetchedAt: new Date().toISOString(),
-  };
-}
-
-function buildBacklinksDateRange(now: Date): BacklinksDateRange {
-  const todayUtc = new Date(
-    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
-  );
-  const dateToUtc = new Date(todayUtc);
-  dateToUtc.setUTCDate(dateToUtc.getUTCDate() - 1);
-
-  const dateFromUtc = new Date(dateToUtc);
-  dateFromUtc.setUTCFullYear(dateFromUtc.getUTCFullYear() - 1);
-
-  return {
-    dateFrom: dateFromUtc.toISOString().slice(0, 10),
-    dateTo: dateToUtc.toISOString().slice(0, 10),
   };
 }
 


### PR DESCRIPTION
## Problem

`buildBacklinksDateRange` (in `backlinksServiceData.ts`) builds the one-year window for the backlinks history overview. `dateTo` is yesterday; `dateFrom` was derived by mutating that date:

```ts
const dateFromUtc = new Date(dateToUtc);
dateFromUtc.setUTCFullYear(dateFromUtc.getUTCFullYear() - 1);
```

`setUTCFullYear` doesn't clamp the day. When `dateTo` is **Feb 29** (i.e. the run happens on Mar 1 of a leap year), the previous year has no Feb 29, so the date rolls forward to Mar 1:

| `now` | `dateTo` | `dateFrom` (actual) | `dateFrom` (expected) |
|---|---|---|---|
| 2024-03-01 | 2024-02-29 | **2023-03-01** | 2023-02-28 |
| 2025-03-01 | 2025-02-28 | 2024-02-28 | 2024-02-28 |

So in leap years the window silently starts a day late and is a day short — the same `setUTC*` day-overflow class as the GSC date fix.

## Fix

Compute `dateFrom` from explicit `Date.UTC` components with the day clamped to the target month's length (Feb 29 → Feb 28). Non-leap cases are unchanged.

To make it testable without dragging in the service's Cloudflare/provider imports (`cloudflare:workers` can't resolve under the `node` vitest environment), the helper moves into its own dependency-free module `backlinksDateRange.ts`; the service imports it.

## Tests

New `backlinksDateRange.test.ts` covers the leap-day boundary (`2024-03-01` → `dateFrom 2023-02-28`), a non-leap February end, and an ordinary mid-year range.

## Verification

- `pnpm test` — 713 passed (89 files), including the new cases
- `pnpm ci:check` — prettier, knip, `tsc --noEmit` (×2), and oxlint all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)