### PR TITLE
fix(keywords): count rows actually written in refreshSavedKeywordMetrics

### DIFF
--- a/src/server/features/keywords/services/research/refresh-metrics.test.ts
+++ b/src/server/features/keywords/services/research/refresh-metrics.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  listSavedKeywordsByProject: vi.fn(),
+  upsertKeywordMetric: vi.fn(),
+  createDataforseoClient: vi.fn(),
+  fetchKeywordMetricsForList: vi.fn(),
+}));
+
+vi.mock(
+  "@/server/features/keywords/repositories/KeywordResearchRepository",
+  () => ({
+    KeywordResearchRepository: {
+      listSavedKeywordsByProject: mocks.listSavedKeywordsByProject,
+      upsertKeywordMetric: mocks.upsertKeywordMetric,
+    },
+  }),
+);
+
+vi.mock("@/server/lib/dataforseo", () => ({
+  createDataforseoClient: mocks.createDataforseoClient,
+  fetchKeywordMetricsForList: mocks.fetchKeywordMetricsForList,
+}));
+
+import { refreshSavedKeywordMetrics } from "@/server/features/keywords/services/research/refresh-metrics";
+import type { BillingCustomerContext } from "@/server/billing/subscription";
+
+const billingCustomer: BillingCustomerContext = {
+  organizationId: "org_1",
+  userEmail: "test@example.com",
+  userId: "user_1",
+};
+
+const savedRow = (keyword: string) => ({
+  row: { keyword, locationCode: 2840, languageCode: "en" },
+});
+
+const metric = (keyword: string) => ({
+  keyword,
+  searchVolume: 100,
+  cpc: 1,
+  competition: 0.5,
+  competitionLevel: "MEDIUM",
+  keywordDifficulty: 10,
+  intent: "informational",
+  monthlySearches: [],
+});
+
+describe("refreshSavedKeywordMetrics", () => {
+  beforeEach(() => {
+    for (const mock of Object.values(mocks)) mock.mockReset();
+    mocks.createDataforseoClient.mockReturnValue({});
+    mocks.upsertKeywordMetric.mockResolvedValue(undefined);
+  });
+
+  it("counts saved keywords actually written, not provider metrics returned", async () => {
+    mocks.listSavedKeywordsByProject.mockResolvedValue({
+      rows: [savedRow("café noir"), savedRow("green tea")],
+    });
+    mocks.fetchKeywordMetricsForList.mockResolvedValue([
+      metric("cafe noir"),
+      metric("green tea"),
+    ]);
+
+    const result = await refreshSavedKeywordMetrics(
+      { projectId: "project_1" },
+      billingCustomer,
+    );
+
+    expect(mocks.upsertKeywordMetric).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ updated: 1 });
+  });
+
+  it("reports zero when no saved keyword matches a returned metric", async () => {
+    mocks.listSavedKeywordsByProject.mockResolvedValue({
+      rows: [savedRow("café noir")],
+    });
+    mocks.fetchKeywordMetricsForList.mockResolvedValue([metric("cafe noir")]);
+
+    const result = await refreshSavedKeywordMetrics(
+      { projectId: "project_1" },
+      billingCustomer,
+    );
+
+    expect(mocks.upsertKeywordMetric).not.toHaveBeenCalled();
+    expect(result).toEqual({ updated: 0 });
+  });
+});

--- a/src/server/features/keywords/services/research/refresh-metrics.ts
+++ b/src/server/features/keywords/services/research/refresh-metrics.ts
@@ -48,11 +48,12 @@ export async function refreshSavedKeywordMetrics(
 
     for (let i = 0; i < groupRows.length; i += REFRESH_UPSERT_BATCH_SIZE) {
       const chunk = groupRows.slice(i, i + REFRESH_UPSERT_BATCH_SIZE);
-      await Promise.all(
-        chunk.map((r) => {
-          const metric = byKeyword.get(r.row.keyword.toLowerCase());
-          if (!metric) return Promise.resolve();
-          return KeywordResearchRepository.upsertKeywordMetric({
+      const writes: Promise<unknown>[] = [];
+      for (const r of chunk) {
+        const metric = byKeyword.get(r.row.keyword.toLowerCase());
+        if (!metric) continue;
+        writes.push(
+          KeywordResearchRepository.upsertKeywordMetric({
             projectId: input.projectId,
             keyword: r.row.keyword,
             locationCode,
@@ -63,12 +64,12 @@ export async function refreshSavedKeywordMetrics(
             keywordDifficulty: metric.keywordDifficulty,
             intent: normalizeIntent(metric.intent),
             monthlySearchesJson: JSON.stringify(metric.monthlySearches),
-          });
-        }),
-      );
+          }),
+        );
+      }
+      await Promise.all(writes);
+      updated += writes.length;
     }
-
-    updated += byKeyword.size;
   }
 
   return { updated };


### PR DESCRIPTION
## Problem

`refreshSavedKeywordMetrics` returns `{ updated }` to tell the caller how many saved keywords were refreshed. It computed:

```ts
updated += byKeyword.size;
```

`byKeyword` is keyed on the **provider's** returned metric keywords. But an upsert only happens when a *saved* keyword matches a returned metric:

```ts
const metric = byKeyword.get(r.row.keyword.toLowerCase());
if (!metric) return Promise.resolve(); // no write
```

So `updated` counts provider metrics, not rows written. The two diverge whenever the provider echoes a keyword string that doesn't equal a saved one — accent folding, casing differences, or metrics returned for keywords no longer saved — and can under-count when two returned metrics collapse to the same lower-cased key.

**Example:** one saved keyword `"café noir"`; the provider returns a metric for `"cafe noir"`. The match lookup misses, **0** rows are upserted, but the old code reports `{ updated: 1 }`.

The sibling `RankTrackingService.refreshKeywordMetrics` implements the same "refresh metrics, return `{updated}`" contract correctly by counting the actual writes (`updates.length`).

## Fix

Accumulate the number of upserts actually issued per chunk instead of the provider metric count.

## Tests

New `refresh-metrics.test.ts` (mocking the repository + dataforseo, matching the existing `saved-keywords.test.ts` pattern):
- provider returns 2 metrics but only 1 matches a saved keyword → `{ updated: 1 }` and exactly one upsert
- no saved keyword matches a returned metric → `{ updated: 0 }` and no upsert

Both fail on the old `byKeyword.size` logic (which returns 2 and 1).

## Verification

- `pnpm test` — 714 passed (90 files), including the new cases
- `pnpm ci:check` — prettier, knip, `tsc --noEmit` (×2), and oxlint all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)