### PR TITLE
fix(ai-search): drop null-metric rows when a brand-lookup range bound is set

### DIFF
--- a/src/client/features/ai-search/brandLookupFiltering.test.ts
+++ b/src/client/features/ai-search/brandLookupFiltering.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { filterQueries, filterTopPages } from "./brandLookupFiltering";
+import {
+  EMPTY_QUERIES_FILTERS,
+  EMPTY_TOP_PAGES_FILTERS,
+} from "./brandLookupFilterTypes";
+import type { BrandLookupResult } from "@/types/schemas/ai-search";
+
+type TopQuery = BrandLookupResult["topQueries"][number];
+type TopPage = BrandLookupResult["topPages"][number];
+
+function topQuery(question: string, aiSearchVolume: number | null): TopQuery {
+  return {
+    question,
+    platform: "chat_gpt",
+    aiSearchVolume,
+    firstSeenAt: null,
+    lastSeenAt: null,
+    citedSources: [],
+    brandsMentioned: [],
+  };
+}
+
+function topPage(url: string, mentions: number | null): TopPage {
+  return {
+    url,
+    domain: null,
+    platform: "chat_gpt",
+    mentions,
+    capturedVolume: null,
+    keywords: [],
+  };
+}
+
+describe("filterQueries", () => {
+  it("excludes null-volume rows when a min bound is set", () => {
+    const rows = [
+      topQuery("has volume", 500),
+      topQuery("unknown volume", null),
+    ];
+    const result = filterQueries(rows, {
+      ...EMPTY_QUERIES_FILTERS,
+      minVolume: "100",
+    });
+    expect(result.map((r) => r.question)).toEqual(["has volume"]);
+  });
+
+  it("keeps null-volume rows when no numeric bound is set", () => {
+    const rows = [topQuery("unknown volume", null)];
+    expect(filterQueries(rows, EMPTY_QUERIES_FILTERS)).toHaveLength(1);
+  });
+});
+
+describe("filterTopPages", () => {
+  it("excludes null-mention rows when a min bound is set", () => {
+    const rows = [topPage("/a", 20), topPage("/b", null)];
+    const result = filterTopPages(rows, {
+      ...EMPTY_TOP_PAGES_FILTERS,
+      minMentions: "5",
+    });
+    expect(result.map((r) => r.url)).toEqual(["/a"]);
+  });
+});

--- a/src/client/features/ai-search/brandLookupFiltering.ts
+++ b/src/client/features/ai-search/brandLookupFiltering.ts
@@ -10,7 +10,8 @@ function passesNumericFilter(
   min: string,
   max: string,
 ): boolean {
-  if (value == null) return true;
+  if (!min && !max) return true;
+  if (value == null) return false;
   const minN = Number(min);
   if (min && !Number.isNaN(minN) && value < minN) return false;
   const maxN = Number(max);


### PR DESCRIPTION
## Problem

`passesNumericFilter` in `brandLookupFiltering.ts` (used by the AI-search / brand-lookup citation tables) short-circuits on a null value **before** applying the bounds:

```ts
function passesNumericFilter(value, min, max) {
  if (value == null) return true; // returns before the min/max check
  ...
}
```

`mentions` and `aiSearchVolume` are nullable (`z.number().int().nonnegative().nullable()`). So a row whose metric is unknown passes through even when the user has set a "min mentions" / "min volume" bound — e.g. filtering queries with `minVolume: "100"` still shows rows with `aiSearchVolume: null`.

Every sibling numeric range filter in the app does the opposite once a bound is active:
- `RankTrackingFilters.logic.ts` `matchesMetricRangeFilter`: `if (!minValue && !maxValue) return true; if (value === null) return false;`
- the audit range filters exclude null rows too.

This function was the lone outlier, leaking rows the min/max UI implies should be hidden.

## Fix

Return early only when **no** bound is set; once a bound is active, exclude rows whose value is null — matching the established `matchesMetricRangeFilter` convention.

## Tests

`brandLookupFiltering` had no tests. Added `brandLookupFiltering.test.ts`:
- `filterQueries` with `minVolume: "100"` drops a `aiSearchVolume: null` row (fails on the old early-return)
- with no numeric bound, the null row is kept
- `filterTopPages` with `minMentions: "5"` drops a `mentions: null` row

## Verification

- `pnpm test` — 713 passed (88 files), including the new cases
- `pnpm ci:check` — prettier, knip, `tsc --noEmit` (×2), and oxlint all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)