### PR TITLE
fix(mcp): send local-business search radius in meters, not kilometers

### DIFF
--- a/src/server/mcp/tools/dataforseo-research-tools.test.ts
+++ b/src/server/mcp/tools/dataforseo-research-tools.test.ts
@@ -110,7 +110,7 @@ describe("DataForSEO research MCP tools", () => {
 
     expect(businessListings).toHaveBeenCalledWith(
       expect.objectContaining({
-        locationCoordinate: "33.1234568,-84.9876543,5",
+        locationCoordinate: "33.1234568,-84.9876543,5000",
         categories: ["cafe"],
       }),
     );

--- a/src/server/mcp/tools/dataforseo-research-tools.ts
+++ b/src/server/mcp/tools/dataforseo-research-tools.ts
@@ -345,8 +345,8 @@ type GetGoogleBusinessQuestionsArgs = z.infer<
   z.ZodObject<typeof getGoogleBusinessQuestionsInputSchema>
 >;
 
-const QUESTIONS_ANSWERS_MIN_RADIUS = 200;
-const QUESTIONS_ANSWERS_MAX_RADIUS = 199999;
+const BUSINESS_DATA_MIN_RADIUS_METERS = 200;
+const BUSINESS_DATA_MAX_RADIUS_METERS = 199999;
 
 /**
  * Resolves the market selector to a Labs location + language. An explicit
@@ -368,16 +368,12 @@ function formatCoordinate(value: number): string {
   return Number(value.toFixed(7)).toString();
 }
 
-function formatBusinessLocationCoordinate(near: z.infer<typeof nearSchema>) {
-  return `${formatCoordinate(near.latitude)},${formatCoordinate(near.longitude)},${near.radiusKm}`;
-}
-
-function formatQuestionsAnswersCoordinate(near: z.infer<typeof nearSchema>) {
-  const radius = Math.min(
-    QUESTIONS_ANSWERS_MAX_RADIUS,
-    Math.max(QUESTIONS_ANSWERS_MIN_RADIUS, Math.round(near.radiusKm * 1000)),
+function formatBusinessDataCoordinate(near: z.infer<typeof nearSchema>) {
+  const radiusMeters = Math.min(
+    BUSINESS_DATA_MAX_RADIUS_METERS,
+    Math.max(BUSINESS_DATA_MIN_RADIUS_METERS, Math.round(near.radiusKm * 1000)),
   );
-  return `${formatCoordinate(near.latitude)},${formatCoordinate(near.longitude)},${radius}`;
+  return `${formatCoordinate(near.latitude)},${formatCoordinate(near.longitude)},${radiusMeters}`;
 }
 
 function formatLocalSerpCoordinate(near: z.infer<typeof localSerpNearSchema>) {
@@ -668,7 +664,7 @@ export const searchLocalBusinessesTool = {
       const businesses = await client.business.businessListings({
         categories: args.categories,
         title: args.query,
-        locationCoordinate: formatBusinessLocationCoordinate(args.near),
+        locationCoordinate: formatBusinessDataCoordinate(args.near),
         limit: args.limit ?? 20,
       });
 
@@ -750,7 +746,7 @@ export const getGoogleBusinessQuestionsTool = {
       const client = createDataforseoClient(context.billing);
       const questions = await client.business.questionsAnswers({
         keyword: args.keyword,
-        locationCoordinate: formatQuestionsAnswersCoordinate(args.near),
+        locationCoordinate: formatBusinessDataCoordinate(args.near),
         languageCode: args.languageCode ?? context.project.languageCode,
         depth: args.depth ?? 20,
       });


### PR DESCRIPTION
## Problem

The `search_local_businesses` MCP tool built its DataForSEO `business_data` `location_coordinate` like this:

```ts
function formatBusinessLocationCoordinate(near) {
  return `${formatCoordinate(near.latitude)},${formatCoordinate(near.longitude)},${near.radiusKm}`;
}
```

`radiusKm` is documented (and validated) as kilometers, but DataForSEO's `business_data` `location_coordinate` expects the radius in **meters** (200–199999). So the value was passed through 1000× too small: a `radiusKm: 5` request became a **5-meter** radius and returned almost nothing.

The sibling formatter for the *same* `nearSchema` — Google Business Q&A — already did the right thing:

```ts
const radius = Math.min(MAX, Math.max(MIN, Math.round(near.radiusKm * 1000))); // km -> m
```

The two contradicted each other; meters is correct (the 200–199999 clamp range is the `business_data` meter constraint).

## Fix

Both formatters are for `business_data` endpoints and, once corrected, are identical — so unify them into one `formatBusinessDataCoordinate` that converts kilometers to meters and clamps to the provider's range. Both call sites (`search_local_businesses`, `get_google_business_questions`) use it.

## Tests

The existing `dataforseo-research-tools.test.ts` asserted the un-converted value (`,5`) for the local-business path, locking in the bug — updated to `,5000`, matching the Q&A test that already asserts `,5000` for the same `radiusKm: 5`.

## Verification

- `pnpm test` — 710 passed (87 files)
- `pnpm ci:check` — prettier, knip, `tsc --noEmit` (×2), and oxlint all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)