### PR TITLE
fix(audit): seed the start page's template into the Lighthouse sample groups

### DIFF
--- a/src/server/lib/audit/lighthouse.test.ts
+++ b/src/server/lib/audit/lighthouse.test.ts
@@ -42,4 +42,21 @@ describe("selectLighthouseSample", () => {
 
     expect(selected[0]).toBe("https://example.com/services");
   });
+
+  it("does not sample another page that shares the start page's URL pattern", () => {
+    const selected = selectLighthouseSample(
+      [
+        { url: "https://example.com/products/123", statusCode: 200 },
+        { url: "https://example.com/products/456", statusCode: 200 },
+        { url: "https://example.com/about", statusCode: 200 },
+      ],
+      "https://example.com/products/123",
+      "auto",
+    );
+
+    expect(selected).toEqual([
+      "https://example.com/products/123",
+      "https://example.com/about",
+    ]);
+  });
 });

--- a/src/server/lib/audit/lighthouse.ts
+++ b/src/server/lib/audit/lighthouse.ts
@@ -153,6 +153,12 @@ export function selectLighthouseSample(
 
   // Group by URL template pattern
   const templateGroups = new Map<string, LighthouseSamplePage>();
+  if (startPage) {
+    templateGroups.set(
+      detectUrlTemplate(new URL(startPage.url).pathname),
+      startPage,
+    );
+  }
   for (const page of validPages) {
     if (selected.has(page.url)) continue;
     const template = detectUrlTemplate(new URL(page.url).pathname);


### PR DESCRIPTION
## Problem

`selectLighthouseSample` (auto strategy) samples "the start page + one page per URL-template pattern, capped at 10". It adds the start page by exact URL:

```ts
if (startPage) selected.add(startPage.url);

const templateGroups = new Map<string, LighthouseSamplePage>();
for (const page of validPages) {
  if (selected.has(page.url)) continue;      // excludes only the exact start URL
  const template = detectUrlTemplate(new URL(page.url).pathname);
  if (!templateGroups.has(template)) templateGroups.set(template, page);
}
```

But the start page's **template** is never seeded into `templateGroups` — only its exact URL is excluded. So when the start URL is itself a templated content page, a sibling page sharing that template forms a "new" group and gets sampled too.

**Example:** start `https://ex.com/products/123`, plus `https://ex.com/products/456` — both map to `/products/:id`. The sampler returns *both* (same pattern, sampled twice), running and billing an extra Lighthouse call and consuming one of the 10 slots that should go to a distinct pattern. The homepage-rooted common case never surfaces it because the start template (`/`) is unique.

## Fix

Seed the start page's template into `templateGroups` before scanning the rest, so no sibling of that pattern is added.

## Tests

Added a case to `lighthouse.test.ts`: start URL `/products/123` with a `/products/456` sibling and a distinct `/about` page → only the start page and `/about` are sampled (the old code also returned `/products/456`).

## Verification

- `pnpm test` — 711 passed (87 files)
- `pnpm ci:check` — prettier, knip, `tsc --noEmit` (×2), and oxlint all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)