### PR TITLE
fix(dashboard): count rank summary per keyword, not per device

### DIFF
--- a/src/server/features/dashboard/services/DashboardService.ts
+++ b/src/server/features/dashboard/services/DashboardService.ts
@@ -3,6 +3,7 @@ import { ActivationRepository } from "@/server/features/activation/repositories/
 import { AuditRepository } from "@/server/features/audit/repositories/AuditRepository";
 import { getIssueTypePageCountsForAudit } from "@/server/features/audit/repositories/auditSummaryQueries";
 import { BacklinkSnapshotRepository } from "@/server/features/dashboard/repositories/BacklinkSnapshotRepository";
+import { summarizeRankRows } from "@/server/features/dashboard/services/rankSummary";
 import { GscConnectionRepository } from "@/server/features/gsc/repositories/GscConnectionRepository";
 import { RankTrackingRepository } from "@/server/features/rank-tracking/repositories/RankTrackingRepository";
 import { getLatestResults } from "@/server/features/rank-tracking/services/rankTrackingResults";
@@ -125,23 +126,17 @@ async function getRankSummary(
   };
 
   for (const result of results) {
-    summary.trackedKeywords += result.rows.length;
+    const counts = summarizeRankRows(result.rows);
+    summary.trackedKeywords += counts.trackedKeywords;
+    summary.improved += counts.improved;
+    summary.declined += counts.declined;
+    summary.top10 += counts.top10;
     if (
       result.run &&
       (!summary.lastCheckedAt ||
         result.run.lastCheckedAt > summary.lastCheckedAt)
     ) {
       summary.lastCheckedAt = result.run.lastCheckedAt;
-    }
-    for (const row of result.rows) {
-      for (const device of ["desktop", "mobile"] as const) {
-        const { position, previousPosition } = row[device];
-        if (position !== null && position <= 10) summary.top10 += 1;
-        if (position === null || previousPosition === null) continue;
-        // Lower position number = better ranking.
-        if (position < previousPosition) summary.improved += 1;
-        else if (position > previousPosition) summary.declined += 1;
-      }
     }
   }
 

--- a/src/server/features/dashboard/services/rankSummary.test.ts
+++ b/src/server/features/dashboard/services/rankSummary.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { summarizeRankRows } from "@/server/features/dashboard/services/rankSummary";
+
+const device = (position: number | null, previousPosition: number | null) => ({
+  position,
+  previousPosition,
+});
+
+describe("summarizeRankRows", () => {
+  it("counts a keyword ranking on both devices once, not once per device", () => {
+    const counts = summarizeRankRows([
+      { desktop: device(3, 8), mobile: device(9, null) },
+    ]);
+
+    expect(counts.trackedKeywords).toBe(1);
+    expect(counts.top10).toBe(1);
+    expect(counts.improved).toBe(1);
+    expect(counts.declined).toBe(0);
+  });
+
+  it("never lets top10 exceed the tracked keyword count", () => {
+    const counts = summarizeRankRows([
+      { desktop: device(2, 2), mobile: device(4, 4) },
+      { desktop: device(5, 5), mobile: device(6, 6) },
+    ]);
+
+    expect(counts.trackedKeywords).toBe(2);
+    expect(counts.top10).toBe(2);
+  });
+
+  it("uses the best device position for the top-10 check", () => {
+    const counts = summarizeRankRows([
+      { desktop: device(40, 40), mobile: device(7, 7) },
+    ]);
+
+    expect(counts.top10).toBe(1);
+  });
+
+  it("ignores a keyword with no current position on either device", () => {
+    const counts = summarizeRankRows([
+      { desktop: device(null, 4), mobile: device(null, null) },
+    ]);
+
+    expect(counts.trackedKeywords).toBe(1);
+    expect(counts.top10).toBe(0);
+    expect(counts.improved).toBe(0);
+    expect(counts.declined).toBe(0);
+  });
+
+  it("returns zeroed counts for no rows", () => {
+    expect(summarizeRankRows([])).toEqual({
+      trackedKeywords: 0,
+      improved: 0,
+      declined: 0,
+      top10: 0,
+    });
+  });
+});

--- a/src/server/features/dashboard/services/rankSummary.ts
+++ b/src/server/features/dashboard/services/rankSummary.ts
@@ -1,0 +1,46 @@
+type DeviceObservation = {
+  position: number | null;
+  previousPosition: number | null;
+};
+
+type RankSummaryRow = {
+  desktop: DeviceObservation;
+  mobile: DeviceObservation;
+};
+
+type RankRowCounts = {
+  trackedKeywords: number;
+  improved: number;
+  declined: number;
+  top10: number;
+};
+
+function bestPosition(a: number | null, b: number | null): number | null {
+  if (a === null) return b;
+  if (b === null) return a;
+  return Math.min(a, b);
+}
+
+export function summarizeRankRows(rows: RankSummaryRow[]): RankRowCounts {
+  const counts: RankRowCounts = {
+    trackedKeywords: rows.length,
+    improved: 0,
+    declined: 0,
+    top10: 0,
+  };
+
+  for (const row of rows) {
+    const position = bestPosition(row.desktop.position, row.mobile.position);
+    const previousPosition = bestPosition(
+      row.desktop.previousPosition,
+      row.mobile.previousPosition,
+    );
+
+    if (position !== null && position <= 10) counts.top10 += 1;
+    if (position === null || previousPosition === null) continue;
+    if (position < previousPosition) counts.improved += 1;
+    else if (position > previousPosition) counts.declined += 1;
+  }
+
+  return counts;
+}


### PR DESCRIPTION
## Problem

`getRankSummary` builds the dashboard rank scorecard. It counts the denominator per keyword but the numerators per device:

```ts
summary.trackedKeywords += result.rows.length;        // one row = one keyword
for (const row of result.rows) {
  for (const device of ["desktop", "mobile"] as const) {  // both devices
    const { position, previousPosition } = row[device];
    if (position !== null && position <= 10) summary.top10 += 1;
    ...
  }
}
```

Each row carries both a `desktop` and a `mobile` result for the **same** keyword, so a keyword ranking in the top 10 on both devices adds **2** to `top10` but **1** to `trackedKeywords`. The summary can therefore report *more top-10 keywords than tracked keywords* (e.g. "2 in top 10 out of 1 tracked"). `improved`/`declined` have the same cross-basis inflation.

The tested sibling `computeScorecards` computes these per keyword **for a single device** (it takes a `device` param), confirming the intended unit is per-keyword — not both devices summed into a per-keyword denominator.

## Fix

Extract a pure `summarizeRankRows` helper that classifies each keyword **once**, using its best (lowest) position across devices, and use it in `getRankSummary`. All four numbers now share the per-keyword basis, so `top10`/`improved`/`declined` can never exceed `trackedKeywords`.

**Semantic note for reviewers:** I collapsed the two devices to the keyword's best position — the natural reading for an overview scorecard ("how many of my keywords rank in the top 10"). The existing null-handling is preserved (a keyword only counts toward improved/declined when it has both a current and a previous position). If you'd prefer a different aggregation (e.g. a fixed primary device, or counting "new"/"lost" like `computeScorecards` does), the helper is the single place to change it.

## Tests

New `rankSummary.test.ts`: a both-device top-10 keyword counted once; `top10` never exceeding `trackedKeywords`; best-device position used for the top-10 check; a null-current keyword ignored; empty input zeroed.

## Verification

- `pnpm test` — 715 passed (88 files)
- `pnpm ci:check` — prettier, knip, `tsc --noEmit` (×2), and oxlint all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)