### PR TITLE
Strategy Library fixes: revert unfinished redesign, honest pricing copy, content-review skill

### DIFF
--- a/.agents/skills/deslop/LICENSE
+++ b/.agents/skills/deslop/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Stephen D. Turner
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.agents/skills/deslop/SKILL.md
+++ b/.agents/skills/deslop/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: deslop
+description: Remove AI writing patterns from prose. Use this skill when writing, drafting, editing, reviewing, or revising any text to eliminate predictable AI tells, slop, and formulaic patterns. Trigger this skill whenever the user asks to "deslop", "de-AI", "make it sound human," "remove AI patterns," "remove AI tropes," "clean up AI writing," fix "slop," "deslop" text, or review prose for authenticity. Also use when the user asks you to write or draft anything and wants it to sound natural rather than AI-generated. Common use cases include scientific writing (manuscripts, abstracts, cover letters, grant narratives, discussion sections, peer review responses), blog posts, newsletters, memos, reports, and any other substantial prose.
+---
+
+# Deslop: Remove AI Writing Patterns from Prose
+
+Strip predictable AI patterns from writing. Make prose sound like a specific human wrote it, not like a language model generated it.
+
+## When to Apply
+
+- Any request to "make it sound human" or "deslop" writing
+- Any prose (articles, blog posts, essays, memos, newsletters, reports) or scientific writing (manuscripts, abstracts, cover letters, grant narratives, discussion sections, peer review responses) where the user wants it to sound natural rather than AI-generated
+- Editing or revising existing text where the user wants it to sound natural rather than AI-generated
+- Reviewing text for AI tells
+
+## Core Rules
+
+### 1. Cut filler phrases
+
+Remove throat-clearing openers ("Here's the thing:"), emphasis crutches ("Let that sink in."), business jargon ("navigate the landscape"), and meta-commentary ("In this section, we'll explore..."). See [references/phrases.md](references/phrases.md) for the full catalog.
+
+### 2. Break formulaic structures
+
+Avoid binary contrasts ("Not X. Y."), negative listings ("Not a X. Not a Y. A Z."), dramatic fragmentation ("Speed. That's it. That's the tradeoff."), self-posed rhetorical questions ("The result? Devastating."), and anaphora/tricolon abuse. See [references/structures.md](references/structures.md) for patterns and fixes.
+
+### 3. Eliminate AI tropes
+
+Watch for the full catalog of AI writing tells: "quietly" and other magic adverbs, "delve" and its cousins, the "serves as" dodge, false ranges ("from X to Y" where the range is meaningless), superficial participle analyses ("highlighting its importance"), invented concept labels ("the supervision paradox"), grandiose stakes inflation, patronizing analogies, and false vulnerability. See [references/tropes.md](references/tropes.md) for the complete list with examples.
+
+### 4. Use active voice with human subjects
+
+Prefer active constructions with named actors. "The complaint becomes a fix" is wrong. "The team fixed it" is right. If no specific person fits, use "we" in scientific prose or "you" in blog posts.
+
+### 5. Be specific
+
+No vague declaratives ("The reasons are structural"). Name the specific thing. No lazy extremes ("every," "always," "never") doing vague work. No vague attributions ("Experts argue..."). If you cannot name the expert, you do not have a source.
+
+In scientific writing, domain terminology is fine and expected. "Weighted interval score" is precise language, not jargon. The problem is business buzzwords ("leverage," "landscape," "ecosystem") and AI vocabulary tells ("delve," "tapestry," "nuanced") leaking into technical prose.
+
+### 6. Match register to context
+
+In blog posts and newsletters, put the reader in the room. "You" beats "People." Specifics beat abstractions. No narrator-from-a-distance voice.
+
+In scientific writing, maintain appropriate formality. Use "we" for your own work, cite specific authors instead of "researchers have shown," and avoid both the distant narrator ("It has long been recognized that...") and the overly casual blog voice. State claims and back them with citations.
+
+### 7. Vary rhythm
+
+Mix sentence lengths. Two items beat three. End paragraphs differently. No em dashes. Do not stack short punchy fragments for manufactured emphasis. Do not write listicles disguised as prose ("The first wall... The second wall...").
+
+### 8. Trust readers
+
+State facts directly. Skip softening, justification, hand-holding. No "Let's break this down." No "Think of it as..." No pedagogical voice unless the audience genuinely needs it. No fractal summaries (telling the reader what you are about to say, saying it, then summarizing what you said).
+
+### 9. Watch formatting tells
+
+No bold-first bullets (every list item starting with a bolded keyword). No unicode arrows. No em dashes. No signposted conclusions ("In conclusion..."). No "Despite these challenges..." formulas. These are strong AI signals.
+
+### 10. Do not dilute
+
+One point per section. Do not restate the same argument in ten different ways across thousands of words. Do not beat a single metaphor to death. Do not stack historical analogies for false authority ("Apple didn't build Uber. Facebook didn't build Spotify...").
+
+## Quick Checks
+
+Run these before delivering any prose:
+
+- Heavy use of adverbs or -ly words? Cut them.
+- Any passive voice? Find the actor, make them the subject. 
+- Inanimate thing doing a human verb? Name the person.
+- Any "here's what/this/that" throat-clearing? Cut to the point.
+- Any "not X, it's Y" contrasts? State Y directly.
+- Any self-posed rhetorical question answered immediately? Fold into a statement.
+- Three consecutive sentences match length? Break one.
+- Paragraph ends with a punchy one-liner? Vary it.
+- Em dash anywhere? Remove it. Use a comma or period or a parenthetical.
+- Vague declarative ("The implications are significant")? Name the specific implication.
+- Any sentence starting with What/When/Where/Which/Who/Why/How as a crutch? Restructure.
+- Meta-joiners ("The rest of this essay...")? Delete.
+- "It's worth noting" or similar filler transitions? Delete.
+- Same metaphor used more than twice? Replace or cut repeats.
+- "Despite these challenges..." formula? Rewrite.
+- Bold-first bullet pattern? Remove bold leads.
+- Tricolon (three-item list)? Use two items or one.
+
+## Scoring
+
+When reviewing text, rate 1-10 on each dimension:
+
+| Dimension | Question |
+|-----------|----------|
+| Directness | Statements or announcements? |
+| Rhythm | Varied or metronomic? |
+| Trust | Respects reader intelligence? |
+| Authenticity | Sounds like a specific human wrote it? |
+| Density | Anything cuttable? |
+
+Below 35/50: revise.
+
+## Reference Files
+
+Consult these for detailed catalogs when writing or editing:
+
+- [references/phrases.md](references/phrases.md): Phrases to remove or replace (throat-clearing, emphasis crutches, business jargon, adverbs, meta-commentary, vague declaratives)
+- [references/structures.md](references/structures.md): Structural patterns to avoid (binary contrasts, negative listings, dramatic fragmentation, rhetorical setups, false agency, passive voice, rhythm problems)
+- [references/tropes.md](references/tropes.md): Full catalog of AI writing tropes (word choice, sentence structure, paragraph structure, tone, formatting, composition)
+- [references/examples.md](references/examples.md): Before/after transformations showing how to fix common patterns
+
+## Examples
+
+See [references/examples.md](references/examples.md) for before/after transformations.
+
+**Quick inline example (scientific writing):**
+
+Before:
+> "It's worth noting that these findings have important implications for how we navigate the challenges of forecast ensembling moving forward. Despite these challenges, this work contributes meaningfully to the growing body of literature, highlighting the need for continued evaluation."
+
+After:
+> "If individual model rankings are unstable across geography and time, ensemble methods that weight models by past performance may not improve on equal-weight approaches."
+
+Changes: Replaced filler transition, vague declarative, "despite these challenges" formula, and superficial participle analysis with the specific implication.
+
+**Quick inline example (blog post):**
+
+Before:
+> "Here's the thing: most bioinformatics pipelines break in production. Not because the code is bad. Because the data is bad. Let that sink in."
+
+After:
+> "Most bioinformatics pipelines break in production. The code runs fine. The data doesn't match the assumptions baked into it."
+
+Changes: Removed opener, binary contrast, and emphasis crutch. Named the specific problem.

--- a/.agents/skills/deslop/SKILL.md
+++ b/.agents/skills/deslop/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: deslop
 description: Remove AI writing patterns from prose. Use this skill when writing, drafting, editing, reviewing, or revising any text to eliminate predictable AI tells, slop, and formulaic patterns. Trigger this skill whenever the user asks to "deslop", "de-AI", "make it sound human," "remove AI patterns," "remove AI tropes," "clean up AI writing," fix "slop," "deslop" text, or review prose for authenticity. Also use when the user asks you to write or draft anything and wants it to sound natural rather than AI-generated. Common use cases include scientific writing (manuscripts, abstracts, cover letters, grant narratives, discussion sections, peer review responses), blog posts, newsletters, memos, reports, and any other substantial prose.
+metadata:
+  internal: true
 ---
 
 # Deslop: Remove AI Writing Patterns from Prose

--- a/.agents/skills/deslop/references/examples.md
+++ b/.agents/skills/deslop/references/examples.md
@@ -1,0 +1,179 @@
+# Before/After Examples
+
+## Example 1: Throat-Clearing + Binary Contrast (Scientific)
+
+**Before:**
+> "Here's the thing: forecasting infectious disease is hard. Not because the models are complex. Because the data is complex. Let that sink in."
+
+**After:**
+> "Forecasting infectious disease is hard. The models are tractable. The data, collected under shifting surveillance definitions and reporting lags, is not."
+
+**Changes:** Removed opener, binary contrast structure, and emphasis crutch. Named the specific problem with the data.
+
+---
+
+## Example 2: Filler + "Despite These Challenges" (Cover Letter)
+
+**Before:**
+> "It's worth noting that these findings have important implications for how we navigate the challenges of forecast ensembling moving forward. Despite these challenges, this work contributes meaningfully to the growing body of literature, highlighting the need for continued evaluation and underscoring the importance of robust benchmarking."
+
+**After:**
+> "If individual model rankings are unstable across geography and time, ensemble methods that weight models by past performance may not improve on equal-weight approaches."
+
+**Changes:** Replaced filler transition, vague declarative, "despite these challenges" formula, and two superficial participle phrases with the specific implication of the findings.
+
+---
+
+## Example 3: Grandiose Stakes + Landscape (Scientific)
+
+**Before:**
+> "In today's rapidly evolving genomic landscape, single-cell RNA sequencing has fundamentally reshaped how we think about cellular heterogeneity. This paradigm shift has far-reaching implications for our understanding of disease."
+
+**After:**
+> "Single-cell RNA sequencing reveals cell-type-specific expression patterns that bulk methods average out. In tumor samples, this distinction matters: rare resistant subpopulations visible in single-cell data disappear in bulk profiles."
+
+**Changes:** Eliminated "landscape," "paradigm shift," "fundamentally," and the vague stakes claim. Replaced with a concrete example of why the method matters.
+
+---
+
+## Example 4: Passive Voice + False Agency (Discussion Section)
+
+**Before:**
+> "It was observed that model performance degraded at longer forecast horizons. The uncertainty naturally increased as the prediction window expanded. These results emerged from our analysis of 54 state-level forecasts."
+
+**After:**
+> "We observed that model performance degraded at longer forecast horizons. Each additional week of lead time added roughly 15% to the mean WIS. We saw this pattern across all 54 state-level forecasts."
+
+**Changes:** Named the actor ("we"). Replaced false agency ("uncertainty naturally increased," "results emerged") with specific claims and a number.
+
+---
+
+## Example 5: Self-Posed Rhetorical Question (Blog Post)
+
+**Before:**
+> "What if I told you that most bioinformatics pipelines break in production? The result? Wasted compute and silent errors. The worst part? Nobody checks the intermediate outputs. Here's why that matters:"
+
+**After:**
+> "Most bioinformatics pipelines break in production, and the failures are quiet. The FASTQ passes QC. The alignment runs. But the reference genome version changed between runs, and the variant calls shift without warning."
+
+**Changes:** Removed rhetorical setup and three self-posed questions. Replaced with a specific failure scenario the reader can picture.
+
+---
+
+## Example 6: "Serves As" + Superficial Participle Analysis (Abstract)
+
+**Before:**
+> "The FluSight initiative serves as a foundational framework for influenza forecasting in the United States, contributing to public health preparedness and underscoring the importance of collaborative forecasting efforts."
+
+**After:**
+> "The FluSight initiative coordinates influenza forecasting across dozens of modeling groups in the United States. Since 2013, it has standardized targets, submission formats, and evaluation metrics."
+
+**Changes:** Replaced "serves as a foundational framework" with what FluSight does. Replaced two participle phrases with a specific fact.
+
+---
+
+## Example 7: Narrator Distance + Vague Declarative (Blog Post)
+
+**Before:**
+> "Nobody designed the current state of genomic data sharing. The reasons are structural. This is genuinely hard, and the implications are significant."
+
+**After:**
+> "You inherit a genomic data sharing system that grew by accretion: dbGaP for controlled access, GEO for expression, SRA for raw reads, ClinVar for variants. Each solves one problem. None talks to the others without custom glue code."
+
+**Changes:** Replaced narrator distance ("Nobody designed...") with "you." Replaced two vague declaratives with the specific structural problem.
+
+---
+
+## Example 8: Listicle in a Trench Coat (Discussion Section)
+
+**Before:**
+> "The first limitation of our study is the relatively short evaluation window. The second limitation is the lack of a standardized baseline across all forecasters. The third limitation is the potential for overfitting to the specific characteristics of the 2021-22 and 2022-23 seasons."
+
+**After:**
+> "Our evaluation covers only two seasons, and both followed the unusual post-COVID influenza dynamics that may not generalize. We also lacked a standardized baseline: each forecaster chose their own training data and feature set, making apples-to-apples comparison difficult."
+
+**Changes:** Replaced the numbered listicle structure with woven prose. Combined related points and added specificity about why the limitations matter.
+
+---
+
+## Example 9: One-Point Dilution (Blog Post)
+
+**Before:**
+> "Reproducibility matters. In fact, reproducibility is the most underrated quality in computational biology. When you make your analysis reproducible, you reduce errors. Fewer errors mean more trust. More trust means faster adoption. The lesson? Make it reproducible. Irreproducible analyses are the enemy of science. The best papers are the reproducible ones."
+
+**After:**
+> "Reproducible analyses catch errors earlier. When Beaulieu-Jones and Greene re-ran 68 papers from the PharmacoGenomics Knowledge Base, only 40% reproduced. The ones that failed had no shared code or pinned dependency versions."
+
+**Changes:** Eight sentences restating one point became three sentences with a specific supporting example and a number.
+
+---
+
+## Example 10: Historical Analogy Stacking (General)
+
+**Before:**
+> "Apple didn't build Uber. Facebook didn't build Spotify. Stripe didn't build Shopify. AWS didn't build Airbnb. Every major technological shift follows the same pattern."
+
+**After:**
+> "AWS sold infrastructure. Airbnb built a business on top of it. That split between platform and product repeats across the industry."
+
+**Changes:** One concrete example examined in depth instead of four name-drops. Named the specific pattern.
+
+---
+
+## Example 11: Anaphora Abuse (Grant Narrative)
+
+**Before:**
+> "We will develop novel computational methods. We will apply these methods to large-scale genomic datasets. We will validate our findings using independent cohorts. We will disseminate our tools through open-source repositories. We will train the next generation of computational biologists."
+
+**After:**
+> "We will develop and validate statistical methods for multi-ancestry fine-mapping using UK Biobank and TOPMed cohorts, then release them as an R package with documentation and tutorials suitable for graduate training."
+
+**Changes:** Collapsed five anaphoric sentences into one that names specific methods, datasets, and deliverables.
+
+---
+
+## Example 12: Dramatic Fragmentation (General)
+
+**Before:**
+> "Speed. Quality. Cost. You can only pick two. That's it. That's the tradeoff."
+
+**After:**
+> "Speed, quality, cost: pick two."
+
+**Changes:** Single sentence. No performative emphasis.
+
+---
+
+## Example 13: False Vulnerability + Meta-Commentary (Blog Post)
+
+**Before:**
+> "And yes, since we're being honest: I've run plenty of analyses where the p-value was borderline and I squinted at it until it cooperated. I want to explore why that impulse is so common. In this post, I'll walk you through what I've learned."
+
+**After:**
+> "I've nudged a borderline p-value along by trying one more covariate. You probably have too. The question is what makes that feel acceptable in the moment, and the answer is usually that the rest of the analysis already 'looks right.'"
+
+**Changes:** Replaced false vulnerability with a specific, honest admission. Cut the meta-commentary ("In this post, I'll walk you through"). Stated the point instead of announcing it.
+
+---
+
+## Example 14: "It's Worth Noting" + Invented Concept Label (Scientific)
+
+**Before:**
+> "It's worth noting that this creates what might be called the 'calibration paradox': models that are well-calibrated at the national level may be poorly calibrated at the state level, reflecting broader trends in the tension between aggregation and granularity."
+
+**After:**
+> "National-level calibration does not guarantee state-level calibration. A model can produce well-calibrated 90% intervals for the US overall while consistently undercovering in states with smaller populations and noisier surveillance data."
+
+**Changes:** Cut the filler transition and the invented concept label. Replaced the superficial participle analysis with the specific mechanism (small states, noisy data).
+
+---
+
+## Example 15: "Imagine a World" + Patronizing Analogy (General)
+
+**Before:**
+> "Imagine a world where every meeting had a clear agenda. Think of it like a recipe: you wouldn't start cooking without knowing the ingredients. That's the promise of async-first communication. Let's unpack why this matters."
+
+**After:**
+> "Meetings without agendas waste time. A 15-person sync with no written agenda averages 47 minutes and produces no decisions (Atlassian, 2019). Writing the agenda forces the organizer to decide whether the meeting is necessary at all."
+
+**Changes:** Removed the "imagine" opener, the cooking analogy (which adds nothing), and the pedagogical "let's unpack." Replaced with a specific claim, a number, and the mechanism that makes agendas work.

--- a/.agents/skills/deslop/references/phrases.md
+++ b/.agents/skills/deslop/references/phrases.md
@@ -1,0 +1,215 @@
+# Phrases to Remove or Replace
+
+## Throat-Clearing Openers
+
+Remove these. State the content directly.
+
+- "Here's the thing:"
+- "Here's what [X]"
+- "Here's this [X]"
+- "Here's that [X]"
+- "Here's why [X]"
+- "Here's the kicker"
+- "Here's where it gets interesting"
+- "Here's what most people miss"
+- "Here's the deal"
+- "The uncomfortable truth is"
+- "It turns out"
+- "The real [X] is"
+- "Let me be clear"
+- "The truth is,"
+- "I'll say it again:"
+- "I'm going to be honest"
+- "Can we talk about"
+- "Here's what I find interesting"
+- "Here's the problem though"
+
+Any "here's what/this/that" construction is throat-clearing before the point. Cut it and state the point.
+
+## Emphasis Crutches
+
+These add no meaning. Delete them.
+
+- "Full stop." / "Period."
+- "Let that sink in."
+- "This matters because"
+- "Make no mistake"
+- "Here's why that matters"
+
+## Pedagogical Hand-Holding
+
+Phrases that assume the reader needs a teacher. Cut them.
+
+- "Let's break this down"
+- "Let's unpack this"
+- "Let's explore"
+- "Let's dive in"
+- "Let's delve into"
+- "Think of it as..."
+- "Think of it like..."
+- "Imagine a world where..."
+
+## Business Jargon
+
+Replace with plain language.
+
+| Avoid | Use instead |
+|-------|-------------|
+| Navigate (challenges) | Handle, address |
+| Unpack (analysis) | Explain, examine |
+| Lean into | Accept, embrace |
+| Landscape (context) | Situation, field |
+| Game-changer | Significant, important |
+| Double down | Commit, increase |
+| Deep dive | Analysis, examination |
+| Take a step back | Reconsider |
+| Moving forward | Next, from now |
+| Circle back | Return to, revisit |
+| On the same page | Aligned, agreed |
+| Leverage (verb) | Use |
+| Utilize | Use |
+| Robust | Strong, solid |
+| Streamline | Simplify |
+| Harness | Use, apply |
+| Paradigm | Model, approach |
+| Synergy | Cooperation, combined effect |
+| Ecosystem | System, field, community |
+| Framework | Structure, approach |
+
+## AI Vocabulary Tells
+
+Words that became dramatically overrepresented in AI-generated text. Avoid or replace.
+
+- "delve" (use: examine, look at, explore)
+- "tapestry" (use: mix, combination, range)
+- "certainly" (usually deletable)
+- "landscape" when meaning "field" or "situation"
+- "nuanced" (use: complex, subtle, specific)
+
+## The "Serves As" Dodge
+
+AI replaces simple "is" or "are" with pompous alternatives. Use the simple verb.
+
+| Avoid | Use instead |
+|-------|-------------|
+| serves as | is |
+| stands as | is |
+| marks (when meaning "is") | is |
+| represents (when meaning "is") | is |
+
+## Adverbs
+
+Kill all adverbs. No -ly words. No softeners, no intensifiers, no hedges.
+
+Specific offenders:
+
+- "really"
+- "just"
+- "literally"
+- "genuinely"
+- "honestly"
+- "simply"
+- "actually"
+- "deeply"
+- "truly"
+- "fundamentally"
+- "inherently"
+- "inevitably"
+- "interestingly"
+- "importantly"
+- "crucially"
+- "quietly" (AI's favorite for conveying subtle importance)
+- "remarkably"
+- "arguably"
+
+Also cut these filler phrases:
+
+- "At its core"
+- "In today's [X]"
+- "It's worth noting"
+- "It bears mentioning"
+- "Notably"
+- "At the end of the day"
+- "When it comes to"
+- "In a world where"
+- "The reality is"
+
+## Meta-Commentary
+
+Remove self-referential asides. The text should move, not announce its own structure.
+
+- "Hint:"
+- "Plot twist:" / "Spoiler:"
+- "You already know this, but"
+- "But that's another post"
+- "X is a feature, not a bug"
+- "Dressed up as"
+- "The rest of this essay explains..."
+- "Let me walk you through..."
+- "In this section, we'll..."
+- "As we'll see..."
+- "I want to explore..."
+- "In conclusion" / "To sum up" / "In summary"
+- "As we've seen in this section..."
+- "And so we return to where we began."
+
+## Performative Emphasis
+
+False intimacy or manufactured sincerity:
+
+- "creeps in"
+- "I promise"
+- "They exist, I promise"
+
+## False Vulnerability
+
+Simulated self-awareness that reads as performative:
+
+- "And yes, I'm openly..."
+- "And yes, since we're being honest..."
+- "This is not a rant; it's a diagnosis"
+
+## Telling Instead of Showing
+
+Announcing difficulty or significance rather than demonstrating it:
+
+- "This is genuinely hard"
+- "This is what leadership actually looks like"
+- "This is what X actually looks like"
+- "actually matters"
+
+## "The Truth Is Simple"
+
+Asserting clarity instead of demonstrating it:
+
+- "The reality is simpler"
+- "History is unambiguous on this point"
+- "History is clear, the metrics are clear, the examples are clear"
+- "but none of them is the real story. The real story is..."
+
+## Vague Declaratives
+
+Sentences that announce importance without naming the specific thing. Kill these or replace with the specific thing.
+
+- "The reasons are structural"
+- "The implications are significant"
+- "This is the deepest problem"
+- "The stakes are high"
+- "The consequences are real"
+
+## Vague Attributions
+
+Attributing claims to unnamed authorities. If you cannot name the source, you do not have one.
+
+- "Experts argue that..."
+- "Industry reports suggest that..."
+- "Observers have cited..."
+- "Several publications have noted..."
+
+## Grandiose Stakes Inflation
+
+Inflating every argument to world-historical significance. Scale claims to match the actual stakes.
+
+- "This will fundamentally reshape how we think about everything."
+- "will define the next era of computing"
+- "something entirely new"

--- a/.agents/skills/deslop/references/structures.md
+++ b/.agents/skills/deslop/references/structures.md
@@ -1,0 +1,257 @@
+# Structures to Avoid
+
+## Binary Contrasts (Negative Parallelism)
+
+The single most commonly identified AI writing tell. Creates false drama by framing everything as a surprising reframe. One in a piece can work; multiple instances per piece is a strong AI signal. Before LLMs, people did not write like this at scale.
+
+| Pattern | Problem |
+|---------|---------|
+| "Not because X. Because Y." / "Not because X, but because Y." | Telegraphed reversal |
+| "[X] isn't the problem. [Y] is." | Formulaic reframe |
+| "The answer isn't X. It's Y." | Predictable pivot |
+| "It feels like X. It's actually Y." | Setup/reveal cliche |
+| "The question isn't X. It's Y." | Rhetorical misdirection |
+| "Not X. But Y." / "not X, it's Y" / "isn't X, it's Y" | Mechanical contrast |
+| "It's not this. It's that." | Same formula, different words |
+| "stops being X and starts being Y" | False transformation arc |
+| "doesn't mean X, but actually Y" | Negation-then-assertion crutch |
+| "is about X but not Y" | False distinction |
+| "not just X but also Y" | Additive hedge |
+
+**Fix:** State Y directly. "The problem is Y." Drop the negation entirely.
+
+## Negative Listing
+
+Listing what something is *not* before revealing what it *is*. A dramatic countdown through negation.
+
+| Pattern | Problem |
+|---------|---------|
+| "Not a X... Not a Y... A Z." | Dramatic buildup through negation |
+| "It wasn't X. It wasn't Y. It was Z." | Same structure, past tense |
+| "Not ten. Not fifty. Five hundred." | Numerical countdown reveal |
+| "not recklessly, not completely, but enough" | Hedging disguised as precision |
+
+**Fix:** State Z. The reader does not need the runway.
+
+## Dramatic Fragmentation
+
+Sentence fragments for emphasis read as manufactured profundity. RLHF training has pushed models toward "writing for readability" aimed at the lowest common denominator: one thought per sentence, no mental state-keeping required. No human writes first drafts this way.
+
+| Pattern | Problem |
+|---------|---------|
+| "[Noun]. That's it. That's the [thing]." | Performative simplicity |
+| "X. And Y. And Z." | Staccato drama |
+| "This unlocks something. [Word]." | Artificial revelation |
+| "He published this. Openly. In a book." | Fragment stacking for emphasis |
+| "Platforms do." | Orphaned fragment as punchline |
+
+**Fix:** Complete sentences. Trust content over presentation.
+
+## Self-Posed Rhetorical Questions
+
+The model asks a question nobody was asking, then answers it for dramatic effect.
+
+| Pattern | Problem |
+|---------|---------|
+| "The result? Devastating." | Manufactured suspense |
+| "The worst part? Nobody saw it coming." | Same formula |
+| "What if [reframe]?" | Socratic posturing |
+| "Here's what I mean:" | Redundant preview |
+| "Think about it:" | Condescending prompt |
+| "And that's okay." | Unnecessary permission |
+
+**Fix:** Make the point. Let readers draw conclusions.
+
+## Anaphora Abuse
+
+Repeating the same sentence opening multiple times in quick succession.
+
+| Pattern | Problem |
+|---------|---------|
+| "They assume that... They assume that... They assume that..." | Mechanical repetition |
+| "They could expose... They could offer... They could provide..." | List disguised as prose |
+| "They have built X, but not Y. They have built A, but not B." | Parallel structure stacking |
+
+**Fix:** Vary sentence openings. Combine related points into single sentences.
+
+## Tricolon Abuse
+
+Overuse of the rule-of-three pattern. A single tricolon is fine; multiple back-to-back tricolons are an AI pattern.
+
+| Pattern | Problem |
+|---------|---------|
+| "Products impress; platforms empower. Products solve; platforms create." | Parallel tricolon stacking |
+| "identity, payments, compute, distribution" | Extended lists masquerading as analysis |
+| "workflows, decisions, and interactions" | Three-item groupings everywhere |
+
+**Fix:** Use two items or one. Break the three-item habit.
+
+## False Agency
+
+Giving inanimate things human verbs. AI loves this because it avoids naming the actor.
+
+| Pattern | Problem |
+|---------|---------|
+| "a complaint becomes a fix" | Someone fixed it. |
+| "a bet lives or dies in days" | Someone kills or ships the project. |
+| "the decision emerges" | Someone decides. |
+| "the culture shifts" | People change behavior. |
+| "the conversation moves toward" | Someone steers. |
+| "the data tells us" | Someone reads it and draws a conclusion. |
+| "the market rewards" | Buyers pay for things. |
+
+**Fix:** Name the human. "The team fixed it that week" beats "the complaint becomes a fix." If no specific person fits, use "you" to put the reader in the seat.
+
+## Narrator-from-a-Distance
+
+Floating above the scene instead of putting the reader in it.
+
+| Pattern | Problem |
+|---------|---------|
+| "Nobody designed this." | Disembodied observation |
+| "This happens because..." | Lecturer voice |
+| "This is why..." | Same |
+| "People tend to..." | Armchair sociologist |
+
+**Fix:** Put the reader in the room. "You don't sit down one day and decide to..." beats "Nobody designed this."
+
+## Passive Voice
+
+Every sentence needs a subject doing something. Passive voice hides the actor and drains energy.
+
+| Pattern | Fix |
+|---------|-----|
+| "X was created" | Name who created it |
+| "It is believed that" | Name who believes it |
+| "Mistakes were made" | Name who made them |
+| "The decision was reached" | Name who decided |
+
+**Fix:** Find the actor. Put them at the front of the sentence.
+
+## Listicle in a Trench Coat
+
+Numbered or labeled points dressed up as continuous prose. The model writes a listicle but wraps each point in a paragraph starting with "The first... The second... The third..." to disguise the format.
+
+| Pattern | Problem |
+|---------|---------|
+| "The first wall is... The second wall is... The third wall is..." | Numbered list pretending to be prose |
+| "The second takeaway is... The third takeaway is..." | Same |
+
+**Fix:** If the content is a list, present it as a list. If it should be prose, weave the points together without numbering.
+
+## Superficial Participle Analyses
+
+Tacking a present participle phrase onto the end of a sentence to inject shallow analysis.
+
+| Pattern | Problem |
+|---------|---------|
+| "contributing to the region's rich cultural heritage" | Hollow significance-signaling |
+| "highlighting its enduring legacy" | Same |
+| "underscoring its role as a dynamic hub" | Same |
+| "reflecting broader trends in..." | Same |
+
+**Fix:** Either make a specific analytical claim or delete the participle phrase.
+
+## False Ranges
+
+"From X to Y" constructions where X and Y are not on any real scale. In legitimate use, "from X to Y" implies a spectrum with a meaningful middle. AI uses it to list two loosely related things.
+
+| Pattern | Problem |
+|---------|---------|
+| "From innovation to implementation to cultural transformation." | No real spectrum |
+| "From the singularity of the Big Bang to the grand cosmic web." | Grandiose range with nothing in between |
+| "From problem-solving to scientific discovery to artistic expression." | Fancy list, not a range |
+
+**Fix:** If the items are a list, list them. If there is a real spectrum, describe it.
+
+## Historical Analogy Stacking
+
+Rapid-fire listing of historical companies or tech revolutions to build false authority. Common in technical writing.
+
+| Pattern | Problem |
+|---------|---------|
+| "Apple didn't build Uber. Facebook didn't build Spotify." | Shotgun historical references |
+| "Every major shift -- the web, mobile, social, cloud -- followed..." | Revolution-listing |
+| "Take Spotify... Or consider Uber... Airbnb followed... Shopify is another..." | Sequential name-dropping |
+
+**Fix:** Use one example, examine it in depth. One well-analyzed case beats five name-drops.
+
+## "Despite Its Challenges..."
+
+AI acknowledges problems only to immediately dismiss them. Always follows the same beat.
+
+| Pattern | Problem |
+|---------|---------|
+| "Despite these challenges, the initiative continues to thrive." | Formulaic optimism |
+| "Despite its prosperity, [X] faces challenges typical of..." | Structured dismiss-and-pivot |
+
+**Fix:** If challenges are worth mentioning, analyze them. If they are not, skip them.
+
+## Sentence Starters to Avoid
+
+| Pattern | Fix |
+|---------|-----|
+| Sentences starting with What, When, Where, Which, Who, Why, How | Restructure. Lead with the subject or the verb. |
+| Paragraphs starting with "So" | Start with content |
+| Sentences starting with "Look," | Remove |
+
+Wh- openers become a crutch. "What makes this hard is..." becomes "The constraint is..." or better, name the specific constraint.
+
+## Formulaic Constructions
+
+| Pattern | Problem |
+|---------|---------|
+| "By the time X, I was Y." | Narrative template |
+| "X that isn't Y" | Indirect. Say "X is broken" |
+
+## Rhythm Patterns
+
+| Pattern | Fix |
+|---------|-----|
+| Three-item lists | Use two items or one |
+| Questions answered immediately | Let questions breathe or cut them |
+| Every paragraph ends punchily | Vary endings |
+| Em dashes | Remove. Use commas or periods. |
+| Staccato fragmentation | Do not stack short punchy sentences |
+| "Not always. Not perfectly." | Hedging disguised as reassurance |
+
+## Formatting Tells
+
+| Pattern | Problem |
+|---------|---------|
+| Bold-first bullets | Every list item starting with a bolded keyword is an AI signal |
+| Unicode arrows (→) | Use -> or => or plain text instead |
+| Smart/curly quotes | Use straight quotes |
+| Signposted conclusions ("In conclusion...") | Let the writing conclude naturally |
+| Fractal summaries | Do not summarize what you are about to say, say it, then summarize what you said |
+
+## One-Point Dilution
+
+Making a single argument and restating it in ten different ways. The model pads a simple thesis to feel comprehensive by rephrasing the same idea with different metaphors, examples, and framings.
+
+**Fix:** State the point once, support it, move on. If the piece circles back to the same claim more than twice, cut the repetitions.
+
+## The Dead Metaphor
+
+Latching onto a single metaphor and using it in every paragraph. A human writer introduces a metaphor, uses it, and moves on. AI repeats the same metaphor 5-10 times.
+
+**Fix:** Use a metaphor once or twice. Then drop it.
+
+## Invented Concept Labels
+
+AI clusters invented compound labels that sound analytical without being grounded. It appends abstract problem-nouns (paradox, trap, creep, divide, vacuum, inversion) to domain words and uses them as if they are established terms.
+
+| Pattern | Problem |
+|---------|---------|
+| "the supervision paradox" | Invented term treated as established |
+| "the acceleration trap" | Same |
+| "workload creep" | Same |
+
+**Fix:** If the concept needs a name, define it. If it does not need a name, describe it in plain language.
+
+## Word Patterns
+
+| Pattern | Problem |
+|---------|---------|
+| Lazy extremes (every, always, never, everyone, everybody, nobody) | False authority. Use specifics instead of sweeping claims. |
+| All adverbs (-ly words, "really," "just," "literally," "genuinely," "honestly," "simply," "actually") | Empty emphasis. See phrases.md for full list. |

--- a/.agents/skills/deslop/references/tropes.md
+++ b/.agents/skills/deslop/references/tropes.md
@@ -1,0 +1,327 @@
+# AI Writing Tropes to Avoid
+
+Add this file to your AI assistant's system prompt or context to help it avoid
+common AI writing patterns. Source: [tropes.fyi](https://tropes.fyi) by [ossama.is](https://ossama.is)
+
+---
+
+## Word Choice
+
+### "Quietly" and Other Magic Adverbs
+
+Overuse of "quietly" and similar adverbs to convey subtle importance or understated power. AI reaches for these adverbs to make mundane descriptions feel significant. Also includes: "deeply", "fundamentally", "remarkably", "arguably".
+
+**Avoid patterns like:**
+- "quietly orchestrating workflows, decisions, and interactions"
+- "the one that quietly suffocates everything else"
+- "a quiet intelligence behind it"
+
+### "Delve" and Friends
+
+Used to be the most infamous AI tell. "Delve" went from an uncommon English word to appearing in a staggering percentage of AI-generated text. Part of a family of overused AI vocabulary including "certainly", "utilize", "leverage" (as a verb), "robust", "streamline", and "harness".
+
+**Avoid patterns like:**
+- "Let's delve into the details..."
+- "Delving deeper into this topic..."
+- "We certainly need to leverage these robust frameworks..."
+
+### "Tapestry" and "Landscape"
+
+Overuse of ornate or grandiose nouns where simpler words would do. "Tapestry" is used to describe anything interconnected. "Landscape" is used to describe any field or domain. Other offenders: "paradigm", "synergy", "ecosystem", "framework".
+
+**Avoid patterns like:**
+- "The rich tapestry of human experience..."
+- "Navigating the complex landscape of modern AI..."
+- "The ever-evolving landscape of technology..."
+
+### The "Serves As" Dodge
+
+Replacing simple "is" or "are" with pompous alternatives like "serves as", "stands as", "marks", or "represents". AI avoids basic copulas because its repetition penalty pushes it toward fancier constructions (I've studied this!).
+
+**Avoid patterns like:**
+- "The building serves as a reminder of the city's heritage."
+- "Gallery 825 serves as LAAA's exhibition space for contemporary art."
+- "The station marks a pivotal moment in the evolution of regional transit."
+
+---
+
+## Sentence Structure
+
+### Negative Parallelism
+
+The "It's not X -- it's Y" pattern, often with an em dash. The single most commonly identified AI writing tell. Man I f*cking hate it. AI uses this to create false profundity by framing everything as a surprising reframe. One in a piece can be effective; ten in a blog post is a genuine insult to the reader. Before LLMs, people simply did not write like this at scale. Includes the causal variant "not because X, but because Y" where every explanation is framed as a surprise reveal, the em-dash dismissal "X -- not Y", and the cross-sentence reframe where the same noun is negated then repositioned: "The question isn't X. The question is Y."
+
+**Avoid patterns like:**
+- "It's not bold. It's backwards."
+- "Feeding isn't nutrition. It's dialysis."
+- "Half the bugs you chase aren't in your code. They're in your head."
+
+### "Not X. Not Y. Just Z."
+
+The dramatic countdown pattern. AI builds tension by negating two or more things before revealing the actual point. Creates a false sense of narrowing down to the truth.
+
+**Avoid patterns like:**
+- "Not a bug. Not a feature. A fundamental design flaw."
+- "Not ten. Not fifty. Five hundred and twenty-three lint violations across 67 files."
+- "not recklessly, not completely, but enough"
+
+### "The X? A Y."
+
+Self-posed rhetorical questions answered immediately in the next sentence or clause. The model asks a question nobody was asking, then answers it for dramatic effect. Thinks this is the epitome of great writing.
+
+**Avoid patterns like:**
+- "The result? Devastating."
+- "The worst part? Nobody saw it coming."
+- "The scary part? This attack vector is perfect for developers."
+
+### Anaphora Abuse
+
+Repeating the same sentence opening multiple times in quick succession.
+
+**Avoid patterns like:**
+- "They assume that users will pay... They assume that developers will build... They assume that ecosystems will emerge... They assume that..."
+- "They could expose... They could offer... They could provide... They could create... They could let... They could unlock..."
+- "They have built engines, but not vehicles. They have built power, but not leverage. They have built walls, but not doors."
+
+### Tricolon Abuse
+
+Overuse of the rule-of-three pattern, often extended to four or five. A single tricolon is elegant; three back-to-back tricolons are a pattern recognition failure.
+
+**Avoid patterns like:**
+- "Products impress people; platforms empower them. Products solve problems; platforms create worlds. Products scale linearly; platforms scale exponentially."
+- "identity, payments, compute, distribution"
+- "workflows, decisions, and interactions"
+
+### "It's Worth Noting"
+
+Filler transitions that signal nothing. AI uses these phrases to introduce new points without actually connecting them to the previous argument. Also includes: "It bears mentioning", "Importantly", "Interestingly", "Notably".
+
+**Avoid patterns like:**
+- "It's worth noting that this approach has limitations."
+- "Importantly, we must consider the broader implications."
+- "Interestingly, this pattern repeats across industries."
+
+### Superficial Analyses
+
+Tacking a present participle ("-ing") phrase onto the end of a sentence to inject shallow analysis that says nothing. The model attaches significance, legacy, or broader meaning to mundane facts using phrases like "highlighting its importance", "reflecting broader trends", or "contributing to the development of...".
+
+**Avoid patterns like:**
+- "contributing to the region's rich cultural heritage"
+- "This etymology highlights the enduring legacy of the community's resistance and the transformative power of unity in shaping its identity."
+- "underscoring its role as a dynamic hub of activity and culture"
+
+### False Ranges
+
+Using "from X to Y" constructions where X and Y aren't on any real scale. In legitimate use, "from X to Y" implies a spectrum with a meaningful middle. AI uses it as a fancy way to list two loosely related things. "From innovation to cultural transformation" -- what's in between???? Nothing!
+
+**Avoid patterns like:**
+- "From innovation to implementation to cultural transformation."
+- "From the singularity of the Big Bang to the grand cosmic web."
+- "From problem-solving and tool-making to scientific discovery, artistic expression, and technological innovation."
+
+---
+
+## Paragraph Structure
+
+### Short Punchy Fragments
+
+Excessive use of very short sentences or sentence fragments as standalone paragraphs for manufactured emphasis. RLHF training has pushed models toward "writing for readability" aimed at the lowest common denominator: one thought per sentence, no mental state-keeping required. It's an inhuman style. No real person writes first drafts this way because it doesn't match how humans think or speak.
+
+**Avoid patterns like:**
+- "He published this. Openly. In a book. As a priest."
+- "These weren't just products. And the software side matched. Then it professionalised. But I adapted."
+- "Platforms do."
+
+### Listicle in a Trench Coat
+
+Numbered or labeled points dressed up as continuous prose. The model writes what is essentially a listicle but wraps each point in a paragraph that starts with "The first... The second... The third..." to disguise the format. Perhaps you told it to stop generating lists and it decided to do this instead... still very common.
+
+**Avoid patterns like:**
+- "The first wall is the absence of a free, scoped API... The second wall is the lack of delegated access... The third wall is the absence of scoped permissions..."
+- "The second takeaway is that... The third takeaway is that... The fourth takeaway is that..."
+
+---
+
+## Tone
+
+### "Here's the Kicker"
+
+False suspense transitions that promise a revelation but deliver a point that did NOT need the buildup. The model uses these phrases to manufacture drama before an otherwise unremarkable observation LOL. Also includes: "Here's the thing", "Here's where it gets interesting", "Here's what most people miss", "Here's the starting point", "Here's the deal".
+
+**Avoid patterns like:**
+- "Here's the kicker."
+- "Here's the thing about AI adoption."
+- "Here's where it gets interesting."
+
+### "Think of It As..."
+
+The patronizing analogy. AI constantly reaches for "Think of it as..." or "It's like a..." to simplify concepts. The model defaults to teacher mode and assumes the reader needs a metaphor to understand anything. Often produces analogies that are less clear than the original concept.
+
+**Avoid patterns like:**
+- "Think of it like a highway system for data."
+- "Think of it as a Swiss Army knife for your workflow."
+- "It's like asking someone to buy a car they're only allowed to sit in while it's parked."
+
+### "Imagine a World Where..."
+
+The classic AI invitation to futurism. To sell the argument usually begins with "Imagine" followed by a list of wonderful things that will happen if the reader agrees with the premise.
+
+**Avoid patterns like:**
+- "Imagine a world where every tool you use -- your calendar, your inbox, your documents, your CRM, your code editor -- has a quiet intelligence behind it..."
+- "In that world, workflows stop being collections of manual steps and start becoming orchestrations."
+
+### False Vulnerability
+
+Simulated self-awareness or honesty that reads as performative. The model pretends to break the fourth wall or admit a bias, creating a false sense of authenticity. Real vulnerability is specific and uncomfortable; AI vulnerability is polished and risk-free!!!!
+
+**Avoid patterns like:**
+- "And yes, I'm openly in love with the platform model"
+- "And yes, since we're being honest: I'm looking at you, OpenAI, Google, Anthropic, Meta"
+- "This is not a rant; it's a diagnosis"
+
+### "The Truth Is Simple"
+
+Asserting that something is obvious, clear or simple instead of actually proving it. If you have to tell the reader your point is clear, it very likely isn't. Also includes the dramatic reveal variant: "but none of them is the real story. The real story is..." -- claiming privileged insight while waving away everything before it.
+
+**Avoid patterns like:**
+- "The reality is simpler and less flattering"
+- "History is unambiguous on this point"
+- "History is clear, the metrics are clear, the examples are clear"
+
+### Grandiose Stakes Inflation
+
+Everything is the most important thing ever. AI inflates the stakes of every argument to world-historical significance. A blog post about API pricing becomes a meditation on the fate of civilization.
+
+**Avoid patterns like:**
+- "This will fundamentally reshape how we think about everything."
+- "will define the next era of computing"
+- "something entirely new"
+
+### "Let's Break This Down"
+
+The pedagogical voice that assumes the reader needs hand-holding. AI defaults to a teacher-student dynamic even when writing for expert audiences. Also includes: "Let's unpack this", "Let's explore", "Let's dive in".
+
+**Avoid patterns like:**
+- "Let's break this down step by step."
+- "Let's unpack what this really means."
+- "Let's explore this idea further."
+
+### Vague Attributions
+
+Attributing claims to unnamed authorities instead of being specific. AI loves to invoke "experts", "observers", "industry reports", and "several publications" without naming anyone. It also inflates the quantity of sources -- presenting what one person said as a widely held view, or writing "several publications have cited" when it means two. If you can't name the expert, you don't have a source.
+
+**Avoid patterns like:**
+- "Experts argue that this approach has significant drawbacks."
+- "Industry reports suggest that adoption is accelerating."
+- "Observers have cited the initiative as a turning point."
+
+### Invented Concept Labels
+
+AI clusters invented compound labels that sound analytical without being grounded. It appends abstract problem-nouns (paradox, trap, creep, divide, vacuum, inversion) to domain words — "supervision paradox", "acceleration trap", "workload creep" — and uses them as if they're established, rigorously defined terms. They function as rhetorical shorthand: name a thing, skip the argument. Multiple such labels in the same piece is a strong signal of AI slop.
+
+**Avoid patterns like:**
+- "the supervision paradox"
+- "the acceleration trap"
+- "workload creep"
+
+---
+
+## Formatting
+
+### Em-Dash Addiction
+
+Compulsive overuse of em dashes for dramatic pauses, parenthetical asides and pivot points. A human writer might use 2-3 per piece (and naturally); AI will use 20+.
+
+**Avoid patterns like:**
+- "The problem -- and this is the part nobody talks about -- is systemic."
+- "The tinkerer spirit didn't die of natural causes -- it was bought out."
+- "Not recklessly, not completely -- but enough -- enough to matter."
+
+### Bold-First Bullets
+
+Every bullet point or list item starts with a bolded phrase or sentence. Extremely common in Claude and ChatGPT markdown output. Almost nobody formats lists this way when writing by hand. It's a telltale sign of AI-generated documentation and blog posts AND README files (especially with emojis).
+
+**Avoid patterns like:**
+- "Every single bullet point begins with a bold keyword."
+- "**Security**: Environment-based configuration with..."
+- "**Performance**: Lazy loading of expensive resources..."
+
+### Unicode Decoration
+
+Use of unicode arrows (->), smart/curly quotes, and other special characters that can't be easily typed on a standard keyboard. Real writers typing in a text editor produce straight quotes and -> or =>. Claude in particular loves the -> arrow.
+
+**Avoid patterns like:**
+- "Input → Processing → Output"
+- "This leads to better outcomes → which means higher engagement"
+- "“Smart quotes” instead of straight "quotes" that you’d actually type"
+
+---
+
+## Composition
+
+### Fractal Summaries
+
+"What I'm going to tell you; what I'm telling you; what I just told you" -- applied at every level of the document. Every subsection gets a summary. Every section gets a summary. The document itself gets a summary.
+
+**Avoid patterns like:**
+- "In this section, we'll explore... [3000 words later] ...as we've seen in this section."
+- "A conclusion that restates every point already made in the previous 3000 words"
+- "And so we return to where we began."
+
+### The Dead Metaphor
+
+Latching onto a single metaphor and beating it into the ground across the entire thing. A human writer would introduce a metaphor, use it then move on. AI will repeat the same metaphor 5-10 times.
+
+**Avoid patterns like:**
+- "The ecosystem needs ecosystems to build ecosystem value."
+- "Walls and doors used 30+ times in the same article"
+- "Every paragraph finds a way to say "primitives" again"
+
+### Historical Analogy Stacking
+
+ESPECIALLY COMMON IN TECHNICAL WRITING: Rapid-fire listing of historical companies or tech revolutions to build false authority.
+
+**Avoid patterns like:**
+- "Apple didn't build Uber. Facebook didn't build Spotify. Stripe didn't build Shopify. AWS didn't build Airbnb."
+- "Every major technological shift -- the web, mobile, social, cloud -- followed the same pattern."
+- "Take Spotify... Or consider Uber... Airbnb followed a similar path... Shopify is another example... Even Discord..."
+
+### One-Point Dilution
+
+Making a single argument and restating it in 10 different ways across thousands of words. The model pads a simple thesis to feel "comprehensive" by rephrasing the same idea with different metaphors, examples, and framings. An 800-word argument becomes 4000 words of circular repetition.
+
+**Avoid patterns like:**
+- "The same point, restated eight ways across 4000 words."
+- "Each section rephrases the thesis with a different metaphor but adds nothing new"
+
+### Content Duplication
+
+Repeating entire sections or paragraphs verbatim within the same piece. This happens when the model loses track of what it has already written, especially in longer pieces. A dead giveaway of unedited AI output. Less common nowadays.
+
+**Avoid patterns like:**
+- "The same section appeared twice, word-for-word identical."
+- "Paragraph 3 and paragraph 17 are the same sentence reworded"
+
+### The Signposted Conclusion
+
+Explicitly announcing the conclusion with "In conclusion", "To sum up", or "In summary". Competent writing doesn't need to tell you it's concluding. The reader can feel it. AI signals its structural moves because it's following a template, not writing organically.
+
+**Avoid patterns like:**
+- "In conclusion, the future of AI depends on..."
+- "To sum up, we've explored three key themes..."
+- "In summary, the evidence suggests..."
+
+### "Despite Its Challenges..."
+
+The rigid formula where AI acknowledges problems only to immediately dismiss them. Always follows the same beat: "Despite its [positive words], [subject] faces challenges..." then ends with "Despite these challenges, [optimistic conclusion].".
+
+**Avoid patterns like:**
+- "Despite these challenges, the initiative continues to thrive."
+- "Despite its industrial and residential prosperity, Korattur faces challenges typical of urban areas."
+- "Despite their promising applications, pyroelectric materials face several challenges that must be addressed for broader adoption."
+
+---
+
+Remember: any of these patterns used once might be fine. The problem is when
+multiple tropes appear together or when a single trope is used repeatedly.
+Write like a human: varied, imperfect, specific.

--- a/.agents/skills/maintain-greptile-rules/SKILL.md
+++ b/.agents/skills/maintain-greptile-rules/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: maintain-greptile-rules
 description: Evaluate verified findings from merge-ready, Greptile, pull-request, CI, security, billing, and other code reviews, then promote durable review gaps into the version-controlled .greptile configuration. Use when a review uncovers a recurring or high-risk repository invariant that Greptile does not capture, when Greptile repeatedly produces a false positive, or when asked to audit or update OpenSEO's Greptile rules and context.
+metadata:
+  internal: true
 ---
 
 # Maintain Greptile rules

--- a/.agents/skills/merge-ready/SKILL.md
+++ b/.agents/skills/merge-ready/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: merge-ready
 description: Take a branch from "code exists (or is about to)" to "ready for the maintainer's final review" — multi-axis subagent review with verified findings, fixes, ci:check, checkpoint commits, and an updated PR. Use whenever the user says a feature/fix/branch should be "merge ready", asks to get changes ready for review, or appends this to a build request ("build X and make it merge-ready").
+metadata:
+  internal: true
 ---
 
 # Merge ready

--- a/.agents/skills/merge-ready/SKILL.md
+++ b/.agents/skills/merge-ready/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: merge-ready
-description: Take a branch from "code exists (or is about to)" to "ready for Ben's final review" — multi-axis subagent review with verified findings, fixes, ci:check, checkpoint commits, and an updated PR. Use whenever the user says a feature/fix/branch should be "merge ready", asks to get changes ready for review, or appends this to a build request ("build X and make it merge-ready").
+description: Take a branch from "code exists (or is about to)" to "ready for the maintainer's final review" — multi-axis subagent review with verified findings, fixes, ci:check, checkpoint commits, and an updated PR. Use whenever the user says a feature/fix/branch should be "merge ready", asks to get changes ready for review, or appends this to a build request ("build X and make it merge-ready").
 ---
 
 # Merge ready
 
-Drive the current work to the point where the only remaining step is Ben's own review and merge. The deliverable is a pushed branch with a clean `pnpm ci:check`, checkpoint commits along the way, and an open PR with a high-level description plus review instructions.
+Drive the current work to the point where the only remaining step is the maintainer's own review and merge. The deliverable is a pushed branch with a clean `pnpm ci:check`, checkpoint commits along the way, and an open PR with a high-level description plus review instructions.
 
-**Never merge the PR. Ben always reviews last.**
+**Never merge the PR. The maintainer always reviews last.**
 
 ## 0. Figure out the starting point
 
@@ -54,7 +54,7 @@ After verification, route durable learnings without forcing every review to chan
 
 ## 4. Fix, check, loop
 
-- Apply verified `blocker`/`should-fix` fixes. Apply nitpicks only when trivial and clearly right; otherwise list them in the PR for Ben to judge.
+- Apply verified `blocker`/`should-fix` fixes. Apply nitpicks only when trivial and clearly right; otherwise list them in the PR for the maintainer to judge.
 - **Checkpoint:** commit fixes in logical groups (e.g. one commit per axis or per concern) so the fix history is reviewable on its own.
 - Run `pnpm ci:check` (prettier, knip, tsc, oxlint). Fix failures and re-run until clean. If a fix was substantial (not formatting/lint), run a quick re-review of just that change.
 - Loop until ci:check passes and no verified findings remain unaddressed.
@@ -66,4 +66,4 @@ After verification, route durable learnings without forcing every review to chan
   - **High-level** — what changed and why, written for a human skimming. No file paths, no per-file changelog.
   - **How to review** — a short ordered guide: what to look at first, what the risky/judgment-call areas are, what was deliberately left out of scope.
   - **Review notes** — unfixed nitpicks and any REJECT verdicts worth a second opinion, clearly labeled as such.
-- Report back to Ben: PR link, one-paragraph summary, and anything that still needs his judgment. Do not merge.
+- Report back: PR link, one-paragraph summary, and anything that still needs the maintainer's judgment. Do not merge.

--- a/.agents/skills/openseo-release-notes/SKILL.md
+++ b/.agents/skills/openseo-release-notes/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: openseo-release-notes
 description: 'Cut an OpenSEO release — bump the version, draft user-facing release notes from commits since the last tag, run a review + subagent-verification pass, and open a "release: vX.X.X" PR. Use when the user asks to prepare a release, bump the version, or write release notes.'
+metadata:
+  internal: true
 ---
 
 # OpenSEO release notes

--- a/.agents/skills/openseo-review-web-content/SKILL.md
+++ b/.agents/skills/openseo-review-web-content/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: openseo-review-web-content
+description: Review or write copy for the OpenSEO marketing site (web/) — blog posts, library guides, feature pages, FAQs. Covers voice, deslop rules, directness, honest pricing framing, and verifying every product claim against the code. Use whenever adding or editing user-facing prose in web/content or web/src.
+---
+
+# OpenSEO Web Content Review
+
+## Goal
+
+Ship marketing copy that reads like a practitioner wrote it, answers questions directly, and never claims something the product doesn't do or a price it doesn't have.
+
+Run this before merging any PR that adds or edits prose in:
+
+- `web/content/blogs/` — blog posts
+- `web/content/marketing/library/` — library guides (MDX)
+- `web/src/routes/_marketing/` — page copy in TSX string literals and JSX text
+- `web/src/lib/feature-pages.ts` — feature-page copy and FAQs
+- `web/src/components/` — shared marketing components (CTAs, headers)
+
+## Voice
+
+The reader is an indie founder or SEO freelancer. Write like a practitioner explaining a workflow, not a content marketer selling one. Name things; don't sell them. Specifics beat abstractions ("status codes, titles, meta descriptions" beats "page-level technical signals").
+
+Ben's own drafts are final copy, not a brief. Fill marked gaps and flag factual problems; do not rewrite his sentences into conversion copy.
+
+## Deslop pass
+
+The tells, in order of how often they appear:
+
+1. **Em dashes.** Replace with a comma, colon, semicolon, period, or parenthetical. Exception: verbatim quotes (interview blockquotes) keep their original punctuation. Sweep with:
+   `grep -rn "—" web/content web/src/routes/_marketing web/src/lib/feature-pages.ts web/src/components`
+2. **"X, not Y" contrasts.** The balanced noun-phrase pivot ("The unit of SEO isn't the keyword; it's the cluster") is the AI smell, and density is the giveaway — budget at most one deliberate contrast per page, placed where the contrast is the actual point. Fix by stating what the thing IS with a concrete consequence, or replacing the aphorism with the reason. Instruction-form contrasts ("Copy the words, not your summary of them") are natural speech; keep them.
+3. **Hype and stakes inflation.** "quietly fixes", "evil twin", "stark warning", "intent-matching machine", "the fix your rankings are waiting for". State the claim plainly.
+4. **Throat-clearing.** "Here's the thing:", "The practical consequence:", announce-before-quote sentences, "everyone does it wrong" strawman openers. Cut to the point; let quotes land without a setup sentence.
+5. **Filler adverbs and intensifiers.** actually, really, dramatically, exactly, "In other words".
+
+Not slop — leave alone: functional `→` arrows (`cluster → URL → status`), bold step labels in numbered how-tos, en dashes in number ranges (5–15), and accurate one-word claims like "Ungated" for a genuinely ungated PDF.
+
+## Directness pass (FAQs especially)
+
+- The first words answer the question. Yes/no questions open with "Yes", "No", "Not quite", or "Not unlimited" — never bury the verdict mid-sentence.
+- Banned hedges: "is designed to", "can be paired with", "adds context that can inform", "is useful for teams that", "keeps X organized so it can inform Y". If a sentence survives with the hedge deleted, the hedge was filler; if it doesn't, the sentence had no content.
+- No two FAQs on a page may share an answer. If two questions want the same answer, one of them gets the concrete version (the actual workflow or numbers) or gets cut.
+- Vague nouns get replaced by their referents: "technical signals" → the list of checks; "visibility metrics" → the metric names.
+
+## Product grounding pass
+
+Every capability claim gets verified against code, not memory. Canonical sources:
+
+- MCP claims → `src/server/mcp/tools/` (one file per tool; if there's no file, the tool doesn't exist)
+- Site audit checks and free limits → `src/shared/audit-limits.ts` (`FREE_MAX_AUDIT_PAGES`) and `src/server/features/audit/`
+- Keyword data fields → `src/server/features/keywords/services/research/research-data.ts`. Known gotcha: intent labels come from DataForSEO Labs only; the Google Ads fallback (used for non-Labs countries) returns intent "unknown", so never claim intent "on every keyword".
+- GSC capabilities → `src/server/features/gsc/` and `src/server/mcp/tools/search-console-tools.ts`
+- Feature inventory → `web/src/lib/feature-pages.ts` workflows sections (already reviewed copy; reuse its concrete lists)
+
+Attribution rule: the free discovery surfaces in the guides — autocomplete, People Also Ask, "related searches" — are **Google's**, and conversations and Search Console data are **the user's**. Say so explicitly ("Google's autocomplete", "your Search Console"). OpenSEO's role is the paid-data half: validating and expanding with volume, difficulty, and SERP data. Copy that lists those surfaces without attribution reads as OpenSEO features; that's a bug.
+
+## Pricing framing
+
+OpenSEO is not free and copy must never imply it is. The canonical framing:
+
+> Quality SEO data is difficult to get, which is why SaaS tools run $100/month and up. OpenSEO is the most affordable option, starting at $10/month, and you can start for free.
+
+Rules:
+
+- Use the full framing once per page (the main pricing-adjacent FAQ); shorter variants elsewhere ("you can start for free; paid plans start at $10/month") so the identical paragraph doesn't repeat across pages.
+- "Is X free?" questions get an honest verdict first: "Not unlimited", or "For smaller sites, yes" when a real free limit covers it (e.g. audits up to `FREE_MAX_AUDIT_PAGES` pages). "Open source" is true but is not an answer to "is it free".
+- Self-hosting is free software, not free data: self-hosters bring their own DataForSEO account.
+- Verify any number ($10/month, page limits, credit amounts) against code or the live pricing page before shipping it.
+
+## Review workflow
+
+1. Inventory the changed prose files (`git diff main... --stat`).
+2. Run the deslop greps and read every changed file in full — patterns cluster, so one hit means more nearby.
+3. For each finding, propose exact old → new replacements; verify each against the file before applying (subagent proposals included).
+4. Verify every product/pricing claim against the code paths above.
+5. Validate: `npm --prefix web run types:check`, and prettier on any touched TSX/TS (`npx prettier --write` in `web/`). Prettier failures in files you didn't touch are pre-existing; leave them.

--- a/.agents/skills/openseo-review-web-content/SKILL.md
+++ b/.agents/skills/openseo-review-web-content/SKILL.md
@@ -23,6 +23,8 @@ The reader is an indie founder or SEO freelancer. Write like a practitioner expl
 
 Ben's own drafts are final copy, not a brief. Fill marked gaps and flag factual problems; do not rewrite his sentences into conversion copy.
 
+Guides are tips first, product second. Mid-article product plugs get **deleted, not reworded** — the pitch belongs in the cost-question FAQ and the CTA, and the guide should read as useful without OpenSEO. Don't get into the weeds about OpenSEO inside a how-to.
+
 ## Deslop pass
 
 The tells, in order of how often they appear:
@@ -53,7 +55,11 @@ Every capability claim gets verified against code, not memory. Canonical sources
 - GSC capabilities → `src/server/features/gsc/` and `src/server/mcp/tools/search-console-tools.ts`
 - Feature inventory → `web/src/lib/feature-pages.ts` workflows sections (already reviewed copy; reuse its concrete lists)
 
-Attribution rule: the free discovery surfaces in the guides — autocomplete, People Also Ask, "related searches" — are **Google's**, and conversations and Search Console data are **the user's**. Say so explicitly ("Google's autocomplete", "your Search Console"). OpenSEO's role is the paid-data half: validating and expanding with volume, difficulty, and SERP data. Copy that lists those surfaces without attribution reads as OpenSEO features; that's a bug.
+Attribution rule: the free discovery surfaces in the guides — autocomplete, People Also Ask, "related searches" — are **Google's**, and conversations and Search Console data are **the user's**. Say so explicitly ("Google's autocomplete", "your Search Console"). OpenSEO's role is the paid-data half: validating and expanding with volume, difficulty, and SERP data. Copy that lists those surfaces without attribution reads as OpenSEO features; that's a bug. Known absences that have shipped as overclaims before: OpenSEO does **not** harvest autocomplete or People Also Ask (of those surfaces only Search Console is integrated), and never claim it "wraps" workflows it doesn't.
+
+UI-affordance rule: before copy instructs the reader to click, sort, or filter something ("sort by word count"), confirm that control exists in the client code. Known past miss: the keyword research table has no word-count column.
+
+Claims about named third parties (a customer, an interviewee's employer, a competitor) need a source or softening — "legally-mandated" about a specific company is a legal claim, not copy. And when a post is adapted from a source (podcast, talk), spot-check quotes against the source for quiet edits, like a competitor's name being scrubbed.
 
 ## Pricing framing
 
@@ -66,7 +72,23 @@ Rules:
 - Use the full framing once per page (the main pricing-adjacent FAQ); shorter variants elsewhere ("you can start for free; paid plans start at $10/month") so the identical paragraph doesn't repeat across pages.
 - "Is X free?" questions get an honest verdict first: "Not unlimited", or "For smaller sites, yes" when a real free limit covers it (e.g. audits up to `FREE_MAX_AUDIT_PAGES` pages). "Open source" is true but is not an answer to "is it free".
 - Self-hosting is free software, not free data: self-hosters bring their own DataForSEO account.
+- Free-tier facts (verify against `src/shared/billing.ts` and the pricing page before repeating): signup is card-free with a small trial-credit grant ($0.50 at time of writing); top-ups are paid-plan only; keyword research is credit-metered, so "the clustering pass is free" is only true for keywords already researched.
 - Verify any number ($10/month, page limits, credit amounts) against code or the live pricing page before shipping it.
+- FAQ answers on marketing pages also ship inside FAQPage JSON-LD — a false claim there is served to Google as structured data, which makes FAQ accuracy the highest-stakes copy on the page.
+
+## External contributions (consultants, guest authors)
+
+Extra checks when the content comes from outside the team:
+
+- **Outbound links are currency.** Every external link gets justified: who owns the domain, is there an undisclosed relationship, does the anchor deserve a dofollow editorial link from openseo.so? A link to a third-party SEO agency with no stated connection is a red flag. Attribution links should point at the specific article, not a homepage.
+- **Bylines must render.** If frontmatter carries an `author`, confirm the site actually displays it — a guest post publishing as first-party editorial while linking the author's own properties edges into Google's guest-post link-spam territory.
+- **Self-promotion in assets.** Check PDFs and images for the contributor's own branding; decide deliberately whether it stays.
+- **Binary assets get inspected**, not waved through: `strings` over PDFs for embedded links, screenshots checked against their captions.
+
+## Beyond the prose
+
+- **Sitemap:** `web/scripts/generate-sitemap.js` uses a hardcoded `STATIC_PATHS` list and only scans `content/blogs` and `content/docs` — new marketing/library pages must be added explicitly or they're invisible to crawlers. Verify by building and grepping the sitemap output.
+- **Screenshots:** must show real product output that reproduces the article's own example (capture via the app, seeded through the MCP if needed), the caption/alt text must match what's visible, and theme should be consistent across a page's image set.
 
 ## Review workflow
 

--- a/.agents/skills/openseo-review-web-content/SKILL.md
+++ b/.agents/skills/openseo-review-web-content/SKILL.md
@@ -1,92 +1,34 @@
 ---
 name: openseo-review-web-content
-description: Review or write copy for the OpenSEO marketing site (web/) — blog posts, library guides, feature pages, FAQs. Covers voice, deslop rules, directness, honest pricing framing, and verifying every product claim against the code. Use whenever adding or editing user-facing prose in web/content or web/src.
+description: Write and review content for the OpenSEO website (web/) — blog posts, guides, feature pages, FAQs. Distills the philosophy for on-brand, useful, accurate content. Use whenever adding or editing user-facing prose in web/content or web/src.
 ---
 
-# OpenSEO Web Content Review
+# OpenSEO Web Content
 
-## Goal
+Everything we publish must be traceable to what the product actually does and costs, and must read like a practitioner wrote it. The reader's interest comes first: teach something they can act on, and answer straight — including when the honest answer is "no" or "it costs money."
 
-Ship marketing copy that reads like a practitioner wrote it, answers questions directly, and never claims something the product doesn't do or a price it doesn't have.
+## Principles
 
-Run this before merging any PR that adds or edits prose in:
+1. **Traceable truth.** Every capability claim, price, and screenshot is verifiable against the code, the fact sheet (`src/server/features/onboarding/openseo-fact-sheet.md`), or the live product. If you can't point to where it's true, it doesn't ship.
+2. **Lead with the real answer.** "No," "not unlimited," and "it costs money" are complete answers. Hedging that lets a reader infer something more flattering than the truth is a way of misleading them.
+3. **Honest pricing, with its reasoning.** Quality SEO data is expensive everywhere — that's why the big suites run $100/month and up. OpenSEO is the affordable option: $10/month, free to start. Never simply "free."
+4. **Sound like a person.** Fix AI tells by restating the underlying claim plainly, not by polishing the flourish. The [deslop skill](../deslop/SKILL.md) is the reference for what to hunt and how to fix it.
+5. **Reader-first altitude.** Guides teach actionable SEO that stands on its own — not product documentation, not generic filler. Credit free resources to their real owners (Google's autocomplete, the reader's own Search Console).
+6. **One bar, whole surface.** When a standard improves, sweep everything to it — all the FAQs, all the pages — not just the instance that got noticed.
 
-- `web/content/blogs/` — blog posts
-- `web/content/marketing/library/` — library guides (MDX)
-- `web/src/routes/_marketing/` — page copy in TSX string literals and JSX text
-- `web/src/lib/feature-pages.ts` — feature-page copy and FAQs
-- `web/src/components/` — shared marketing components (CTAs, headers)
+## Questions to ask while reviewing
 
-## Voice
+- If a reader trusted every claim and screenshot, then opened OpenSEO right now, where would reality not match?
+- Does each answer open with the real answer, or quietly steer toward a more flattering inference?
+- Read the sharpest line aloud: would a person say it that way?
+- Is anything called free that actually costs credits?
+- Is this teaching the reader something useful on its own, or drifting into product docs or padding?
+- Does every link, image, and example on the page earn its place for the reader?
 
-The reader is an indie founder or SEO freelancer. Write like a practitioner explaining a workflow, not a content marketer selling one. Name things; don't sell them. Specifics beat abstractions ("status codes, titles, meta descriptions" beats "page-level technical signals").
+## Facts to verify, not remember
 
-Ben's own drafts are final copy, not a brief. Fill marked gaps and flag factual problems; do not rewrite his sentences into conversion copy.
+Check these against code before repeating any of them — they change: pricing and credits (`src/shared/billing.ts`, the pricing page), free-plan limits (`src/shared/audit-limits.ts`), MCP capabilities (`src/server/mcp/tools/` — one file per tool), and any UI affordance copy tells the reader to use (the column, sort, or filter must exist in the client code).
 
-Guides are tips first, product second. Mid-article product plugs get **deleted, not reworded** — the pitch belongs in the cost-question FAQ and the CTA, and the guide should read as useful without OpenSEO. Don't get into the weeds about OpenSEO inside a how-to.
+## Process
 
-## Deslop pass
-
-The tells, in order of how often they appear:
-
-1. **Em dashes.** Replace with a comma, colon, semicolon, period, or parenthetical. Exception: verbatim quotes (interview blockquotes) keep their original punctuation. Sweep with:
-   `grep -rn "—" web/content web/src/routes/_marketing web/src/lib/feature-pages.ts web/src/components`
-2. **"X, not Y" contrasts.** The balanced noun-phrase pivot ("The unit of SEO isn't the keyword; it's the cluster") is the AI smell, and density is the giveaway — budget at most one deliberate contrast per page, placed where the contrast is the actual point. Fix by stating what the thing IS with a concrete consequence, or replacing the aphorism with the reason. Instruction-form contrasts ("Copy the words, not your summary of them") are natural speech; keep them.
-3. **Hype and stakes inflation.** "quietly fixes", "evil twin", "stark warning", "intent-matching machine", "the fix your rankings are waiting for". State the claim plainly.
-4. **Throat-clearing.** "Here's the thing:", "The practical consequence:", announce-before-quote sentences, "everyone does it wrong" strawman openers. Cut to the point; let quotes land without a setup sentence.
-5. **Filler adverbs and intensifiers.** actually, really, dramatically, exactly, "In other words".
-
-Not slop — leave alone: functional `→` arrows (`cluster → URL → status`), bold step labels in numbered how-tos, en dashes in number ranges (5–15), and accurate one-word claims like "Ungated" for a genuinely ungated PDF.
-
-## Directness pass (FAQs especially)
-
-- The first words answer the question. Yes/no questions open with "Yes", "No", "Not quite", or "Not unlimited" — never bury the verdict mid-sentence.
-- Banned hedges: "is designed to", "can be paired with", "adds context that can inform", "is useful for teams that", "keeps X organized so it can inform Y". If a sentence survives with the hedge deleted, the hedge was filler; if it doesn't, the sentence had no content.
-- No two FAQs on a page may share an answer. If two questions want the same answer, one of them gets the concrete version (the actual workflow or numbers) or gets cut.
-- Vague nouns get replaced by their referents: "technical signals" → the list of checks; "visibility metrics" → the metric names.
-
-## Product grounding pass
-
-Every capability claim gets verified against code, not memory. Canonical sources:
-
-- MCP claims → `src/server/mcp/tools/` (one file per tool; if there's no file, the tool doesn't exist)
-- Site audit checks and free limits → `src/shared/audit-limits.ts` (`FREE_MAX_AUDIT_PAGES`) and `src/server/features/audit/`
-- Keyword data fields → `src/server/features/keywords/services/research/research-data.ts`. Known gotcha: intent labels come from DataForSEO Labs only; the Google Ads fallback (used for non-Labs countries) returns intent "unknown", so never claim intent "on every keyword".
-- GSC capabilities → `src/server/features/gsc/` and `src/server/mcp/tools/search-console-tools.ts`
-- Feature inventory → `web/src/lib/feature-pages.ts` workflows sections (already reviewed copy; reuse its concrete lists)
-
-Attribution rule: the free discovery surfaces in the guides — autocomplete, People Also Ask, "related searches" — are **Google's**, and conversations and Search Console data are **the user's**. Say so explicitly ("Google's autocomplete", "your Search Console"). OpenSEO's role is the paid-data half: validating and expanding with volume, difficulty, and SERP data. Copy that lists those surfaces without attribution reads as OpenSEO features; that's a bug. Known absences that have shipped as overclaims before: OpenSEO does **not** harvest autocomplete or People Also Ask (of those surfaces only Search Console is integrated), and never claim it "wraps" workflows it doesn't.
-
-UI-affordance rule: before copy instructs the reader to click, sort, or filter something ("sort by word count"), confirm that control exists in the client code. Known past miss: the keyword research table has no word-count column.
-
-Claims about named third parties (a customer, an interviewee's employer, a competitor) need a source or softening — "legally-mandated" about a specific company is a legal claim, not copy. When a post is adapted from a source (podcast, talk), check quotes against the source so they stay accurate.
-
-## Pricing framing
-
-OpenSEO is not free and copy must never imply it is. The canonical framing:
-
-> Quality SEO data is difficult to get, which is why SaaS tools run $100/month and up. OpenSEO is the most affordable option, starting at $10/month, and you can start for free.
-
-Rules:
-
-- Use the full framing once per page (the main pricing-adjacent FAQ); shorter variants elsewhere ("you can start for free; paid plans start at $10/month") so the identical paragraph doesn't repeat across pages.
-- "Is X free?" questions get an honest verdict first: "Not unlimited", or "For smaller sites, yes" when a real free limit covers it (e.g. audits up to `FREE_MAX_AUDIT_PAGES` pages). "Open source" is true but is not an answer to "is it free".
-- Self-hosting is free software, not free data: self-hosters bring their own DataForSEO account.
-- Free-tier facts (verify against `src/shared/billing.ts` and the pricing page before repeating): signup is card-free with a small trial-credit grant ($0.50 at time of writing); top-ups are paid-plan only; keyword research is credit-metered, so "the clustering pass is free" is only true for keywords already researched.
-- Verify any number ($10/month, page limits, credit amounts) against code or the live pricing page before shipping it.
-- FAQ answers on marketing pages also ship inside FAQPage JSON-LD — a false claim there is served to Google as structured data, which makes FAQ accuracy the highest-stakes copy on the page.
-
-## Beyond the prose
-
-- **Sitemap:** `web/scripts/generate-sitemap.js` uses a hardcoded `STATIC_PATHS` list and only scans `content/blogs` and `content/docs` — new marketing/library pages must be added explicitly or they're invisible to crawlers. Verify by building and grepping the sitemap output.
-- **Screenshots:** must show real product output that reproduces the article's own example (capture via the app, seeded through the MCP if needed), the caption/alt text must match what's visible, and theme should be consistent across a page's image set.
-- **Outbound links:** every external link earns its place — link the specific article rather than a homepage, and disclose any relationship to the linked site in the post.
-- **Bylines:** if a post's frontmatter names an `author`, confirm the site actually renders the byline so authorship is visible to readers.
-
-## Review workflow
-
-1. Inventory the changed prose files (`git diff main... --stat`).
-2. Run the deslop greps and read every changed file in full — patterns cluster, so one hit means more nearby.
-3. For each finding, propose exact old → new replacements; verify each against the file before applying (subagent proposals included).
-4. Verify every product/pricing claim against the code paths above.
-5. Validate: `npm --prefix web run types:check`, and prettier on any touched TSX/TS (`npx prettier --write` in `web/`). Prettier failures in files you didn't touch are pre-existing; leave them.
+Spawn subagents to run the review passes (voice/deslop, claims accuracy, directness) and have them return exact old → new proposals rather than editing directly. Do not accept their proposals blindly: verify each one against the actual file, and each factual claim against the code, before applying — subagent rewrites can introduce their own awkwardness or errors, and a proposal that mismatches the file means it reviewed stale text. After applying, sweep the changed surface yourself (patterns cluster — one em dash or hedge usually has neighbors), then run `npm --prefix web run types:check` and prettier on touched TS/TSX.

--- a/.agents/skills/openseo-review-web-content/SKILL.md
+++ b/.agents/skills/openseo-review-web-content/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: openseo-review-web-content
 description: Write and review content for the OpenSEO website (web/) — blog posts, guides, feature pages, FAQs. Distills the philosophy for on-brand, useful, accurate content. Use whenever adding or editing user-facing prose in web/content or web/src.
+metadata:
+  internal: true
 ---
 
 # OpenSEO Web Content

--- a/.agents/skills/openseo-review-web-content/SKILL.md
+++ b/.agents/skills/openseo-review-web-content/SKILL.md
@@ -59,7 +59,7 @@ Attribution rule: the free discovery surfaces in the guides — autocomplete, Pe
 
 UI-affordance rule: before copy instructs the reader to click, sort, or filter something ("sort by word count"), confirm that control exists in the client code. Known past miss: the keyword research table has no word-count column.
 
-Claims about named third parties (a customer, an interviewee's employer, a competitor) need a source or softening — "legally-mandated" about a specific company is a legal claim, not copy. And when a post is adapted from a source (podcast, talk), spot-check quotes against the source for quiet edits, like a competitor's name being scrubbed.
+Claims about named third parties (a customer, an interviewee's employer, a competitor) need a source or softening — "legally-mandated" about a specific company is a legal claim, not copy. When a post is adapted from a source (podcast, talk), check quotes against the source so they stay accurate.
 
 ## Pricing framing
 
@@ -76,19 +76,12 @@ Rules:
 - Verify any number ($10/month, page limits, credit amounts) against code or the live pricing page before shipping it.
 - FAQ answers on marketing pages also ship inside FAQPage JSON-LD — a false claim there is served to Google as structured data, which makes FAQ accuracy the highest-stakes copy on the page.
 
-## External contributions (consultants, guest authors)
-
-Extra checks when the content comes from outside the team:
-
-- **Outbound links are currency.** Every external link gets justified: who owns the domain, is there an undisclosed relationship, does the anchor deserve a dofollow editorial link from openseo.so? A link to a third-party SEO agency with no stated connection is a red flag. Attribution links should point at the specific article, not a homepage.
-- **Bylines must render.** If frontmatter carries an `author`, confirm the site actually displays it — a guest post publishing as first-party editorial while linking the author's own properties edges into Google's guest-post link-spam territory.
-- **Self-promotion in assets.** Check PDFs and images for the contributor's own branding; decide deliberately whether it stays.
-- **Binary assets get inspected**, not waved through: `strings` over PDFs for embedded links, screenshots checked against their captions.
-
 ## Beyond the prose
 
 - **Sitemap:** `web/scripts/generate-sitemap.js` uses a hardcoded `STATIC_PATHS` list and only scans `content/blogs` and `content/docs` — new marketing/library pages must be added explicitly or they're invisible to crawlers. Verify by building and grepping the sitemap output.
 - **Screenshots:** must show real product output that reproduces the article's own example (capture via the app, seeded through the MCP if needed), the caption/alt text must match what's visible, and theme should be consistent across a page's image set.
+- **Outbound links:** every external link earns its place — link the specific article rather than a homepage, and disclose any relationship to the linked site in the post.
+- **Bylines:** if a post's frontmatter names an `author`, confirm the site actually renders the byline so authorship is visible to readers.
 
 ## Review workflow
 

--- a/.agents/skills/papercuts/SKILL.md
+++ b/.agents/skills/papercuts/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: papercuts
-description: Log genuine, recurring repository friction to .agents/PAPERCUTS.md — confusing setup, a flaky repo command or script, a misleading in-repo error, stale generated files, or a non-obvious gotcha that will cost the next contributor time. Also use to review, deduplicate, and resolve existing entries. Gate hard before logging: only friction the repository itself can fix counts. Never log the agent's own sandbox/permission errors, shell-scripting mistakes, transient flakiness, or third-party tool quirks the repo can't change.
+description: "Log genuine, recurring repository friction to .agents/PAPERCUTS.md — confusing setup, a flaky repo command or script, a misleading in-repo error, stale generated files, or a non-obvious gotcha that will cost the next contributor time. Also use to review, deduplicate, and resolve existing entries. Gate hard before logging: only friction the repository itself can fix counts. Never log the agent's own sandbox/permission errors, shell-scripting mistakes, transient flakiness, or third-party tool quirks the repo can't change."
+metadata:
+  internal: true
 ---
 
 # Papercuts

--- a/.agents/skills/webapp-testing/SKILL.md
+++ b/.agents/skills/webapp-testing/SKILL.md
@@ -2,6 +2,8 @@
 name: webapp-testing
 description: Toolkit for interacting with and testing local web applications using Playwright. Supports verifying frontend functionality, debugging UI behavior, capturing browser screenshots, and viewing browser logs.
 license: Complete terms in LICENSE.txt
+metadata:
+  internal: true
 ---
 
 # Web Application Testing

--- a/.claude/skills/deslop/LICENSE
+++ b/.claude/skills/deslop/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Stephen D. Turner
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.claude/skills/deslop/SKILL.md
+++ b/.claude/skills/deslop/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: deslop
+description: Remove AI writing patterns from prose. Use this skill when writing, drafting, editing, reviewing, or revising any text to eliminate predictable AI tells, slop, and formulaic patterns. Trigger this skill whenever the user asks to "deslop", "de-AI", "make it sound human," "remove AI patterns," "remove AI tropes," "clean up AI writing," fix "slop," "deslop" text, or review prose for authenticity. Also use when the user asks you to write or draft anything and wants it to sound natural rather than AI-generated. Common use cases include scientific writing (manuscripts, abstracts, cover letters, grant narratives, discussion sections, peer review responses), blog posts, newsletters, memos, reports, and any other substantial prose.
+---
+
+# Deslop: Remove AI Writing Patterns from Prose
+
+Strip predictable AI patterns from writing. Make prose sound like a specific human wrote it, not like a language model generated it.
+
+## When to Apply
+
+- Any request to "make it sound human" or "deslop" writing
+- Any prose (articles, blog posts, essays, memos, newsletters, reports) or scientific writing (manuscripts, abstracts, cover letters, grant narratives, discussion sections, peer review responses) where the user wants it to sound natural rather than AI-generated
+- Editing or revising existing text where the user wants it to sound natural rather than AI-generated
+- Reviewing text for AI tells
+
+## Core Rules
+
+### 1. Cut filler phrases
+
+Remove throat-clearing openers ("Here's the thing:"), emphasis crutches ("Let that sink in."), business jargon ("navigate the landscape"), and meta-commentary ("In this section, we'll explore..."). See [references/phrases.md](references/phrases.md) for the full catalog.
+
+### 2. Break formulaic structures
+
+Avoid binary contrasts ("Not X. Y."), negative listings ("Not a X. Not a Y. A Z."), dramatic fragmentation ("Speed. That's it. That's the tradeoff."), self-posed rhetorical questions ("The result? Devastating."), and anaphora/tricolon abuse. See [references/structures.md](references/structures.md) for patterns and fixes.
+
+### 3. Eliminate AI tropes
+
+Watch for the full catalog of AI writing tells: "quietly" and other magic adverbs, "delve" and its cousins, the "serves as" dodge, false ranges ("from X to Y" where the range is meaningless), superficial participle analyses ("highlighting its importance"), invented concept labels ("the supervision paradox"), grandiose stakes inflation, patronizing analogies, and false vulnerability. See [references/tropes.md](references/tropes.md) for the complete list with examples.
+
+### 4. Use active voice with human subjects
+
+Prefer active constructions with named actors. "The complaint becomes a fix" is wrong. "The team fixed it" is right. If no specific person fits, use "we" in scientific prose or "you" in blog posts.
+
+### 5. Be specific
+
+No vague declaratives ("The reasons are structural"). Name the specific thing. No lazy extremes ("every," "always," "never") doing vague work. No vague attributions ("Experts argue..."). If you cannot name the expert, you do not have a source.
+
+In scientific writing, domain terminology is fine and expected. "Weighted interval score" is precise language, not jargon. The problem is business buzzwords ("leverage," "landscape," "ecosystem") and AI vocabulary tells ("delve," "tapestry," "nuanced") leaking into technical prose.
+
+### 6. Match register to context
+
+In blog posts and newsletters, put the reader in the room. "You" beats "People." Specifics beat abstractions. No narrator-from-a-distance voice.
+
+In scientific writing, maintain appropriate formality. Use "we" for your own work, cite specific authors instead of "researchers have shown," and avoid both the distant narrator ("It has long been recognized that...") and the overly casual blog voice. State claims and back them with citations.
+
+### 7. Vary rhythm
+
+Mix sentence lengths. Two items beat three. End paragraphs differently. No em dashes. Do not stack short punchy fragments for manufactured emphasis. Do not write listicles disguised as prose ("The first wall... The second wall...").
+
+### 8. Trust readers
+
+State facts directly. Skip softening, justification, hand-holding. No "Let's break this down." No "Think of it as..." No pedagogical voice unless the audience genuinely needs it. No fractal summaries (telling the reader what you are about to say, saying it, then summarizing what you said).
+
+### 9. Watch formatting tells
+
+No bold-first bullets (every list item starting with a bolded keyword). No unicode arrows. No em dashes. No signposted conclusions ("In conclusion..."). No "Despite these challenges..." formulas. These are strong AI signals.
+
+### 10. Do not dilute
+
+One point per section. Do not restate the same argument in ten different ways across thousands of words. Do not beat a single metaphor to death. Do not stack historical analogies for false authority ("Apple didn't build Uber. Facebook didn't build Spotify...").
+
+## Quick Checks
+
+Run these before delivering any prose:
+
+- Heavy use of adverbs or -ly words? Cut them.
+- Any passive voice? Find the actor, make them the subject. 
+- Inanimate thing doing a human verb? Name the person.
+- Any "here's what/this/that" throat-clearing? Cut to the point.
+- Any "not X, it's Y" contrasts? State Y directly.
+- Any self-posed rhetorical question answered immediately? Fold into a statement.
+- Three consecutive sentences match length? Break one.
+- Paragraph ends with a punchy one-liner? Vary it.
+- Em dash anywhere? Remove it. Use a comma or period or a parenthetical.
+- Vague declarative ("The implications are significant")? Name the specific implication.
+- Any sentence starting with What/When/Where/Which/Who/Why/How as a crutch? Restructure.
+- Meta-joiners ("The rest of this essay...")? Delete.
+- "It's worth noting" or similar filler transitions? Delete.
+- Same metaphor used more than twice? Replace or cut repeats.
+- "Despite these challenges..." formula? Rewrite.
+- Bold-first bullet pattern? Remove bold leads.
+- Tricolon (three-item list)? Use two items or one.
+
+## Scoring
+
+When reviewing text, rate 1-10 on each dimension:
+
+| Dimension | Question |
+|-----------|----------|
+| Directness | Statements or announcements? |
+| Rhythm | Varied or metronomic? |
+| Trust | Respects reader intelligence? |
+| Authenticity | Sounds like a specific human wrote it? |
+| Density | Anything cuttable? |
+
+Below 35/50: revise.
+
+## Reference Files
+
+Consult these for detailed catalogs when writing or editing:
+
+- [references/phrases.md](references/phrases.md): Phrases to remove or replace (throat-clearing, emphasis crutches, business jargon, adverbs, meta-commentary, vague declaratives)
+- [references/structures.md](references/structures.md): Structural patterns to avoid (binary contrasts, negative listings, dramatic fragmentation, rhetorical setups, false agency, passive voice, rhythm problems)
+- [references/tropes.md](references/tropes.md): Full catalog of AI writing tropes (word choice, sentence structure, paragraph structure, tone, formatting, composition)
+- [references/examples.md](references/examples.md): Before/after transformations showing how to fix common patterns
+
+## Examples
+
+See [references/examples.md](references/examples.md) for before/after transformations.
+
+**Quick inline example (scientific writing):**
+
+Before:
+> "It's worth noting that these findings have important implications for how we navigate the challenges of forecast ensembling moving forward. Despite these challenges, this work contributes meaningfully to the growing body of literature, highlighting the need for continued evaluation."
+
+After:
+> "If individual model rankings are unstable across geography and time, ensemble methods that weight models by past performance may not improve on equal-weight approaches."
+
+Changes: Replaced filler transition, vague declarative, "despite these challenges" formula, and superficial participle analysis with the specific implication.
+
+**Quick inline example (blog post):**
+
+Before:
+> "Here's the thing: most bioinformatics pipelines break in production. Not because the code is bad. Because the data is bad. Let that sink in."
+
+After:
+> "Most bioinformatics pipelines break in production. The code runs fine. The data doesn't match the assumptions baked into it."
+
+Changes: Removed opener, binary contrast, and emphasis crutch. Named the specific problem.

--- a/.claude/skills/deslop/SKILL.md
+++ b/.claude/skills/deslop/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: deslop
 description: Remove AI writing patterns from prose. Use this skill when writing, drafting, editing, reviewing, or revising any text to eliminate predictable AI tells, slop, and formulaic patterns. Trigger this skill whenever the user asks to "deslop", "de-AI", "make it sound human," "remove AI patterns," "remove AI tropes," "clean up AI writing," fix "slop," "deslop" text, or review prose for authenticity. Also use when the user asks you to write or draft anything and wants it to sound natural rather than AI-generated. Common use cases include scientific writing (manuscripts, abstracts, cover letters, grant narratives, discussion sections, peer review responses), blog posts, newsletters, memos, reports, and any other substantial prose.
+metadata:
+  internal: true
 ---
 
 # Deslop: Remove AI Writing Patterns from Prose

--- a/.claude/skills/deslop/references/examples.md
+++ b/.claude/skills/deslop/references/examples.md
@@ -1,0 +1,179 @@
+# Before/After Examples
+
+## Example 1: Throat-Clearing + Binary Contrast (Scientific)
+
+**Before:**
+> "Here's the thing: forecasting infectious disease is hard. Not because the models are complex. Because the data is complex. Let that sink in."
+
+**After:**
+> "Forecasting infectious disease is hard. The models are tractable. The data, collected under shifting surveillance definitions and reporting lags, is not."
+
+**Changes:** Removed opener, binary contrast structure, and emphasis crutch. Named the specific problem with the data.
+
+---
+
+## Example 2: Filler + "Despite These Challenges" (Cover Letter)
+
+**Before:**
+> "It's worth noting that these findings have important implications for how we navigate the challenges of forecast ensembling moving forward. Despite these challenges, this work contributes meaningfully to the growing body of literature, highlighting the need for continued evaluation and underscoring the importance of robust benchmarking."
+
+**After:**
+> "If individual model rankings are unstable across geography and time, ensemble methods that weight models by past performance may not improve on equal-weight approaches."
+
+**Changes:** Replaced filler transition, vague declarative, "despite these challenges" formula, and two superficial participle phrases with the specific implication of the findings.
+
+---
+
+## Example 3: Grandiose Stakes + Landscape (Scientific)
+
+**Before:**
+> "In today's rapidly evolving genomic landscape, single-cell RNA sequencing has fundamentally reshaped how we think about cellular heterogeneity. This paradigm shift has far-reaching implications for our understanding of disease."
+
+**After:**
+> "Single-cell RNA sequencing reveals cell-type-specific expression patterns that bulk methods average out. In tumor samples, this distinction matters: rare resistant subpopulations visible in single-cell data disappear in bulk profiles."
+
+**Changes:** Eliminated "landscape," "paradigm shift," "fundamentally," and the vague stakes claim. Replaced with a concrete example of why the method matters.
+
+---
+
+## Example 4: Passive Voice + False Agency (Discussion Section)
+
+**Before:**
+> "It was observed that model performance degraded at longer forecast horizons. The uncertainty naturally increased as the prediction window expanded. These results emerged from our analysis of 54 state-level forecasts."
+
+**After:**
+> "We observed that model performance degraded at longer forecast horizons. Each additional week of lead time added roughly 15% to the mean WIS. We saw this pattern across all 54 state-level forecasts."
+
+**Changes:** Named the actor ("we"). Replaced false agency ("uncertainty naturally increased," "results emerged") with specific claims and a number.
+
+---
+
+## Example 5: Self-Posed Rhetorical Question (Blog Post)
+
+**Before:**
+> "What if I told you that most bioinformatics pipelines break in production? The result? Wasted compute and silent errors. The worst part? Nobody checks the intermediate outputs. Here's why that matters:"
+
+**After:**
+> "Most bioinformatics pipelines break in production, and the failures are quiet. The FASTQ passes QC. The alignment runs. But the reference genome version changed between runs, and the variant calls shift without warning."
+
+**Changes:** Removed rhetorical setup and three self-posed questions. Replaced with a specific failure scenario the reader can picture.
+
+---
+
+## Example 6: "Serves As" + Superficial Participle Analysis (Abstract)
+
+**Before:**
+> "The FluSight initiative serves as a foundational framework for influenza forecasting in the United States, contributing to public health preparedness and underscoring the importance of collaborative forecasting efforts."
+
+**After:**
+> "The FluSight initiative coordinates influenza forecasting across dozens of modeling groups in the United States. Since 2013, it has standardized targets, submission formats, and evaluation metrics."
+
+**Changes:** Replaced "serves as a foundational framework" with what FluSight does. Replaced two participle phrases with a specific fact.
+
+---
+
+## Example 7: Narrator Distance + Vague Declarative (Blog Post)
+
+**Before:**
+> "Nobody designed the current state of genomic data sharing. The reasons are structural. This is genuinely hard, and the implications are significant."
+
+**After:**
+> "You inherit a genomic data sharing system that grew by accretion: dbGaP for controlled access, GEO for expression, SRA for raw reads, ClinVar for variants. Each solves one problem. None talks to the others without custom glue code."
+
+**Changes:** Replaced narrator distance ("Nobody designed...") with "you." Replaced two vague declaratives with the specific structural problem.
+
+---
+
+## Example 8: Listicle in a Trench Coat (Discussion Section)
+
+**Before:**
+> "The first limitation of our study is the relatively short evaluation window. The second limitation is the lack of a standardized baseline across all forecasters. The third limitation is the potential for overfitting to the specific characteristics of the 2021-22 and 2022-23 seasons."
+
+**After:**
+> "Our evaluation covers only two seasons, and both followed the unusual post-COVID influenza dynamics that may not generalize. We also lacked a standardized baseline: each forecaster chose their own training data and feature set, making apples-to-apples comparison difficult."
+
+**Changes:** Replaced the numbered listicle structure with woven prose. Combined related points and added specificity about why the limitations matter.
+
+---
+
+## Example 9: One-Point Dilution (Blog Post)
+
+**Before:**
+> "Reproducibility matters. In fact, reproducibility is the most underrated quality in computational biology. When you make your analysis reproducible, you reduce errors. Fewer errors mean more trust. More trust means faster adoption. The lesson? Make it reproducible. Irreproducible analyses are the enemy of science. The best papers are the reproducible ones."
+
+**After:**
+> "Reproducible analyses catch errors earlier. When Beaulieu-Jones and Greene re-ran 68 papers from the PharmacoGenomics Knowledge Base, only 40% reproduced. The ones that failed had no shared code or pinned dependency versions."
+
+**Changes:** Eight sentences restating one point became three sentences with a specific supporting example and a number.
+
+---
+
+## Example 10: Historical Analogy Stacking (General)
+
+**Before:**
+> "Apple didn't build Uber. Facebook didn't build Spotify. Stripe didn't build Shopify. AWS didn't build Airbnb. Every major technological shift follows the same pattern."
+
+**After:**
+> "AWS sold infrastructure. Airbnb built a business on top of it. That split between platform and product repeats across the industry."
+
+**Changes:** One concrete example examined in depth instead of four name-drops. Named the specific pattern.
+
+---
+
+## Example 11: Anaphora Abuse (Grant Narrative)
+
+**Before:**
+> "We will develop novel computational methods. We will apply these methods to large-scale genomic datasets. We will validate our findings using independent cohorts. We will disseminate our tools through open-source repositories. We will train the next generation of computational biologists."
+
+**After:**
+> "We will develop and validate statistical methods for multi-ancestry fine-mapping using UK Biobank and TOPMed cohorts, then release them as an R package with documentation and tutorials suitable for graduate training."
+
+**Changes:** Collapsed five anaphoric sentences into one that names specific methods, datasets, and deliverables.
+
+---
+
+## Example 12: Dramatic Fragmentation (General)
+
+**Before:**
+> "Speed. Quality. Cost. You can only pick two. That's it. That's the tradeoff."
+
+**After:**
+> "Speed, quality, cost: pick two."
+
+**Changes:** Single sentence. No performative emphasis.
+
+---
+
+## Example 13: False Vulnerability + Meta-Commentary (Blog Post)
+
+**Before:**
+> "And yes, since we're being honest: I've run plenty of analyses where the p-value was borderline and I squinted at it until it cooperated. I want to explore why that impulse is so common. In this post, I'll walk you through what I've learned."
+
+**After:**
+> "I've nudged a borderline p-value along by trying one more covariate. You probably have too. The question is what makes that feel acceptable in the moment, and the answer is usually that the rest of the analysis already 'looks right.'"
+
+**Changes:** Replaced false vulnerability with a specific, honest admission. Cut the meta-commentary ("In this post, I'll walk you through"). Stated the point instead of announcing it.
+
+---
+
+## Example 14: "It's Worth Noting" + Invented Concept Label (Scientific)
+
+**Before:**
+> "It's worth noting that this creates what might be called the 'calibration paradox': models that are well-calibrated at the national level may be poorly calibrated at the state level, reflecting broader trends in the tension between aggregation and granularity."
+
+**After:**
+> "National-level calibration does not guarantee state-level calibration. A model can produce well-calibrated 90% intervals for the US overall while consistently undercovering in states with smaller populations and noisier surveillance data."
+
+**Changes:** Cut the filler transition and the invented concept label. Replaced the superficial participle analysis with the specific mechanism (small states, noisy data).
+
+---
+
+## Example 15: "Imagine a World" + Patronizing Analogy (General)
+
+**Before:**
+> "Imagine a world where every meeting had a clear agenda. Think of it like a recipe: you wouldn't start cooking without knowing the ingredients. That's the promise of async-first communication. Let's unpack why this matters."
+
+**After:**
+> "Meetings without agendas waste time. A 15-person sync with no written agenda averages 47 minutes and produces no decisions (Atlassian, 2019). Writing the agenda forces the organizer to decide whether the meeting is necessary at all."
+
+**Changes:** Removed the "imagine" opener, the cooking analogy (which adds nothing), and the pedagogical "let's unpack." Replaced with a specific claim, a number, and the mechanism that makes agendas work.

--- a/.claude/skills/deslop/references/phrases.md
+++ b/.claude/skills/deslop/references/phrases.md
@@ -1,0 +1,215 @@
+# Phrases to Remove or Replace
+
+## Throat-Clearing Openers
+
+Remove these. State the content directly.
+
+- "Here's the thing:"
+- "Here's what [X]"
+- "Here's this [X]"
+- "Here's that [X]"
+- "Here's why [X]"
+- "Here's the kicker"
+- "Here's where it gets interesting"
+- "Here's what most people miss"
+- "Here's the deal"
+- "The uncomfortable truth is"
+- "It turns out"
+- "The real [X] is"
+- "Let me be clear"
+- "The truth is,"
+- "I'll say it again:"
+- "I'm going to be honest"
+- "Can we talk about"
+- "Here's what I find interesting"
+- "Here's the problem though"
+
+Any "here's what/this/that" construction is throat-clearing before the point. Cut it and state the point.
+
+## Emphasis Crutches
+
+These add no meaning. Delete them.
+
+- "Full stop." / "Period."
+- "Let that sink in."
+- "This matters because"
+- "Make no mistake"
+- "Here's why that matters"
+
+## Pedagogical Hand-Holding
+
+Phrases that assume the reader needs a teacher. Cut them.
+
+- "Let's break this down"
+- "Let's unpack this"
+- "Let's explore"
+- "Let's dive in"
+- "Let's delve into"
+- "Think of it as..."
+- "Think of it like..."
+- "Imagine a world where..."
+
+## Business Jargon
+
+Replace with plain language.
+
+| Avoid | Use instead |
+|-------|-------------|
+| Navigate (challenges) | Handle, address |
+| Unpack (analysis) | Explain, examine |
+| Lean into | Accept, embrace |
+| Landscape (context) | Situation, field |
+| Game-changer | Significant, important |
+| Double down | Commit, increase |
+| Deep dive | Analysis, examination |
+| Take a step back | Reconsider |
+| Moving forward | Next, from now |
+| Circle back | Return to, revisit |
+| On the same page | Aligned, agreed |
+| Leverage (verb) | Use |
+| Utilize | Use |
+| Robust | Strong, solid |
+| Streamline | Simplify |
+| Harness | Use, apply |
+| Paradigm | Model, approach |
+| Synergy | Cooperation, combined effect |
+| Ecosystem | System, field, community |
+| Framework | Structure, approach |
+
+## AI Vocabulary Tells
+
+Words that became dramatically overrepresented in AI-generated text. Avoid or replace.
+
+- "delve" (use: examine, look at, explore)
+- "tapestry" (use: mix, combination, range)
+- "certainly" (usually deletable)
+- "landscape" when meaning "field" or "situation"
+- "nuanced" (use: complex, subtle, specific)
+
+## The "Serves As" Dodge
+
+AI replaces simple "is" or "are" with pompous alternatives. Use the simple verb.
+
+| Avoid | Use instead |
+|-------|-------------|
+| serves as | is |
+| stands as | is |
+| marks (when meaning "is") | is |
+| represents (when meaning "is") | is |
+
+## Adverbs
+
+Kill all adverbs. No -ly words. No softeners, no intensifiers, no hedges.
+
+Specific offenders:
+
+- "really"
+- "just"
+- "literally"
+- "genuinely"
+- "honestly"
+- "simply"
+- "actually"
+- "deeply"
+- "truly"
+- "fundamentally"
+- "inherently"
+- "inevitably"
+- "interestingly"
+- "importantly"
+- "crucially"
+- "quietly" (AI's favorite for conveying subtle importance)
+- "remarkably"
+- "arguably"
+
+Also cut these filler phrases:
+
+- "At its core"
+- "In today's [X]"
+- "It's worth noting"
+- "It bears mentioning"
+- "Notably"
+- "At the end of the day"
+- "When it comes to"
+- "In a world where"
+- "The reality is"
+
+## Meta-Commentary
+
+Remove self-referential asides. The text should move, not announce its own structure.
+
+- "Hint:"
+- "Plot twist:" / "Spoiler:"
+- "You already know this, but"
+- "But that's another post"
+- "X is a feature, not a bug"
+- "Dressed up as"
+- "The rest of this essay explains..."
+- "Let me walk you through..."
+- "In this section, we'll..."
+- "As we'll see..."
+- "I want to explore..."
+- "In conclusion" / "To sum up" / "In summary"
+- "As we've seen in this section..."
+- "And so we return to where we began."
+
+## Performative Emphasis
+
+False intimacy or manufactured sincerity:
+
+- "creeps in"
+- "I promise"
+- "They exist, I promise"
+
+## False Vulnerability
+
+Simulated self-awareness that reads as performative:
+
+- "And yes, I'm openly..."
+- "And yes, since we're being honest..."
+- "This is not a rant; it's a diagnosis"
+
+## Telling Instead of Showing
+
+Announcing difficulty or significance rather than demonstrating it:
+
+- "This is genuinely hard"
+- "This is what leadership actually looks like"
+- "This is what X actually looks like"
+- "actually matters"
+
+## "The Truth Is Simple"
+
+Asserting clarity instead of demonstrating it:
+
+- "The reality is simpler"
+- "History is unambiguous on this point"
+- "History is clear, the metrics are clear, the examples are clear"
+- "but none of them is the real story. The real story is..."
+
+## Vague Declaratives
+
+Sentences that announce importance without naming the specific thing. Kill these or replace with the specific thing.
+
+- "The reasons are structural"
+- "The implications are significant"
+- "This is the deepest problem"
+- "The stakes are high"
+- "The consequences are real"
+
+## Vague Attributions
+
+Attributing claims to unnamed authorities. If you cannot name the source, you do not have one.
+
+- "Experts argue that..."
+- "Industry reports suggest that..."
+- "Observers have cited..."
+- "Several publications have noted..."
+
+## Grandiose Stakes Inflation
+
+Inflating every argument to world-historical significance. Scale claims to match the actual stakes.
+
+- "This will fundamentally reshape how we think about everything."
+- "will define the next era of computing"
+- "something entirely new"

--- a/.claude/skills/deslop/references/structures.md
+++ b/.claude/skills/deslop/references/structures.md
@@ -1,0 +1,257 @@
+# Structures to Avoid
+
+## Binary Contrasts (Negative Parallelism)
+
+The single most commonly identified AI writing tell. Creates false drama by framing everything as a surprising reframe. One in a piece can work; multiple instances per piece is a strong AI signal. Before LLMs, people did not write like this at scale.
+
+| Pattern | Problem |
+|---------|---------|
+| "Not because X. Because Y." / "Not because X, but because Y." | Telegraphed reversal |
+| "[X] isn't the problem. [Y] is." | Formulaic reframe |
+| "The answer isn't X. It's Y." | Predictable pivot |
+| "It feels like X. It's actually Y." | Setup/reveal cliche |
+| "The question isn't X. It's Y." | Rhetorical misdirection |
+| "Not X. But Y." / "not X, it's Y" / "isn't X, it's Y" | Mechanical contrast |
+| "It's not this. It's that." | Same formula, different words |
+| "stops being X and starts being Y" | False transformation arc |
+| "doesn't mean X, but actually Y" | Negation-then-assertion crutch |
+| "is about X but not Y" | False distinction |
+| "not just X but also Y" | Additive hedge |
+
+**Fix:** State Y directly. "The problem is Y." Drop the negation entirely.
+
+## Negative Listing
+
+Listing what something is *not* before revealing what it *is*. A dramatic countdown through negation.
+
+| Pattern | Problem |
+|---------|---------|
+| "Not a X... Not a Y... A Z." | Dramatic buildup through negation |
+| "It wasn't X. It wasn't Y. It was Z." | Same structure, past tense |
+| "Not ten. Not fifty. Five hundred." | Numerical countdown reveal |
+| "not recklessly, not completely, but enough" | Hedging disguised as precision |
+
+**Fix:** State Z. The reader does not need the runway.
+
+## Dramatic Fragmentation
+
+Sentence fragments for emphasis read as manufactured profundity. RLHF training has pushed models toward "writing for readability" aimed at the lowest common denominator: one thought per sentence, no mental state-keeping required. No human writes first drafts this way.
+
+| Pattern | Problem |
+|---------|---------|
+| "[Noun]. That's it. That's the [thing]." | Performative simplicity |
+| "X. And Y. And Z." | Staccato drama |
+| "This unlocks something. [Word]." | Artificial revelation |
+| "He published this. Openly. In a book." | Fragment stacking for emphasis |
+| "Platforms do." | Orphaned fragment as punchline |
+
+**Fix:** Complete sentences. Trust content over presentation.
+
+## Self-Posed Rhetorical Questions
+
+The model asks a question nobody was asking, then answers it for dramatic effect.
+
+| Pattern | Problem |
+|---------|---------|
+| "The result? Devastating." | Manufactured suspense |
+| "The worst part? Nobody saw it coming." | Same formula |
+| "What if [reframe]?" | Socratic posturing |
+| "Here's what I mean:" | Redundant preview |
+| "Think about it:" | Condescending prompt |
+| "And that's okay." | Unnecessary permission |
+
+**Fix:** Make the point. Let readers draw conclusions.
+
+## Anaphora Abuse
+
+Repeating the same sentence opening multiple times in quick succession.
+
+| Pattern | Problem |
+|---------|---------|
+| "They assume that... They assume that... They assume that..." | Mechanical repetition |
+| "They could expose... They could offer... They could provide..." | List disguised as prose |
+| "They have built X, but not Y. They have built A, but not B." | Parallel structure stacking |
+
+**Fix:** Vary sentence openings. Combine related points into single sentences.
+
+## Tricolon Abuse
+
+Overuse of the rule-of-three pattern. A single tricolon is fine; multiple back-to-back tricolons are an AI pattern.
+
+| Pattern | Problem |
+|---------|---------|
+| "Products impress; platforms empower. Products solve; platforms create." | Parallel tricolon stacking |
+| "identity, payments, compute, distribution" | Extended lists masquerading as analysis |
+| "workflows, decisions, and interactions" | Three-item groupings everywhere |
+
+**Fix:** Use two items or one. Break the three-item habit.
+
+## False Agency
+
+Giving inanimate things human verbs. AI loves this because it avoids naming the actor.
+
+| Pattern | Problem |
+|---------|---------|
+| "a complaint becomes a fix" | Someone fixed it. |
+| "a bet lives or dies in days" | Someone kills or ships the project. |
+| "the decision emerges" | Someone decides. |
+| "the culture shifts" | People change behavior. |
+| "the conversation moves toward" | Someone steers. |
+| "the data tells us" | Someone reads it and draws a conclusion. |
+| "the market rewards" | Buyers pay for things. |
+
+**Fix:** Name the human. "The team fixed it that week" beats "the complaint becomes a fix." If no specific person fits, use "you" to put the reader in the seat.
+
+## Narrator-from-a-Distance
+
+Floating above the scene instead of putting the reader in it.
+
+| Pattern | Problem |
+|---------|---------|
+| "Nobody designed this." | Disembodied observation |
+| "This happens because..." | Lecturer voice |
+| "This is why..." | Same |
+| "People tend to..." | Armchair sociologist |
+
+**Fix:** Put the reader in the room. "You don't sit down one day and decide to..." beats "Nobody designed this."
+
+## Passive Voice
+
+Every sentence needs a subject doing something. Passive voice hides the actor and drains energy.
+
+| Pattern | Fix |
+|---------|-----|
+| "X was created" | Name who created it |
+| "It is believed that" | Name who believes it |
+| "Mistakes were made" | Name who made them |
+| "The decision was reached" | Name who decided |
+
+**Fix:** Find the actor. Put them at the front of the sentence.
+
+## Listicle in a Trench Coat
+
+Numbered or labeled points dressed up as continuous prose. The model writes a listicle but wraps each point in a paragraph starting with "The first... The second... The third..." to disguise the format.
+
+| Pattern | Problem |
+|---------|---------|
+| "The first wall is... The second wall is... The third wall is..." | Numbered list pretending to be prose |
+| "The second takeaway is... The third takeaway is..." | Same |
+
+**Fix:** If the content is a list, present it as a list. If it should be prose, weave the points together without numbering.
+
+## Superficial Participle Analyses
+
+Tacking a present participle phrase onto the end of a sentence to inject shallow analysis.
+
+| Pattern | Problem |
+|---------|---------|
+| "contributing to the region's rich cultural heritage" | Hollow significance-signaling |
+| "highlighting its enduring legacy" | Same |
+| "underscoring its role as a dynamic hub" | Same |
+| "reflecting broader trends in..." | Same |
+
+**Fix:** Either make a specific analytical claim or delete the participle phrase.
+
+## False Ranges
+
+"From X to Y" constructions where X and Y are not on any real scale. In legitimate use, "from X to Y" implies a spectrum with a meaningful middle. AI uses it to list two loosely related things.
+
+| Pattern | Problem |
+|---------|---------|
+| "From innovation to implementation to cultural transformation." | No real spectrum |
+| "From the singularity of the Big Bang to the grand cosmic web." | Grandiose range with nothing in between |
+| "From problem-solving to scientific discovery to artistic expression." | Fancy list, not a range |
+
+**Fix:** If the items are a list, list them. If there is a real spectrum, describe it.
+
+## Historical Analogy Stacking
+
+Rapid-fire listing of historical companies or tech revolutions to build false authority. Common in technical writing.
+
+| Pattern | Problem |
+|---------|---------|
+| "Apple didn't build Uber. Facebook didn't build Spotify." | Shotgun historical references |
+| "Every major shift -- the web, mobile, social, cloud -- followed..." | Revolution-listing |
+| "Take Spotify... Or consider Uber... Airbnb followed... Shopify is another..." | Sequential name-dropping |
+
+**Fix:** Use one example, examine it in depth. One well-analyzed case beats five name-drops.
+
+## "Despite Its Challenges..."
+
+AI acknowledges problems only to immediately dismiss them. Always follows the same beat.
+
+| Pattern | Problem |
+|---------|---------|
+| "Despite these challenges, the initiative continues to thrive." | Formulaic optimism |
+| "Despite its prosperity, [X] faces challenges typical of..." | Structured dismiss-and-pivot |
+
+**Fix:** If challenges are worth mentioning, analyze them. If they are not, skip them.
+
+## Sentence Starters to Avoid
+
+| Pattern | Fix |
+|---------|-----|
+| Sentences starting with What, When, Where, Which, Who, Why, How | Restructure. Lead with the subject or the verb. |
+| Paragraphs starting with "So" | Start with content |
+| Sentences starting with "Look," | Remove |
+
+Wh- openers become a crutch. "What makes this hard is..." becomes "The constraint is..." or better, name the specific constraint.
+
+## Formulaic Constructions
+
+| Pattern | Problem |
+|---------|---------|
+| "By the time X, I was Y." | Narrative template |
+| "X that isn't Y" | Indirect. Say "X is broken" |
+
+## Rhythm Patterns
+
+| Pattern | Fix |
+|---------|-----|
+| Three-item lists | Use two items or one |
+| Questions answered immediately | Let questions breathe or cut them |
+| Every paragraph ends punchily | Vary endings |
+| Em dashes | Remove. Use commas or periods. |
+| Staccato fragmentation | Do not stack short punchy sentences |
+| "Not always. Not perfectly." | Hedging disguised as reassurance |
+
+## Formatting Tells
+
+| Pattern | Problem |
+|---------|---------|
+| Bold-first bullets | Every list item starting with a bolded keyword is an AI signal |
+| Unicode arrows (→) | Use -> or => or plain text instead |
+| Smart/curly quotes | Use straight quotes |
+| Signposted conclusions ("In conclusion...") | Let the writing conclude naturally |
+| Fractal summaries | Do not summarize what you are about to say, say it, then summarize what you said |
+
+## One-Point Dilution
+
+Making a single argument and restating it in ten different ways. The model pads a simple thesis to feel comprehensive by rephrasing the same idea with different metaphors, examples, and framings.
+
+**Fix:** State the point once, support it, move on. If the piece circles back to the same claim more than twice, cut the repetitions.
+
+## The Dead Metaphor
+
+Latching onto a single metaphor and using it in every paragraph. A human writer introduces a metaphor, uses it, and moves on. AI repeats the same metaphor 5-10 times.
+
+**Fix:** Use a metaphor once or twice. Then drop it.
+
+## Invented Concept Labels
+
+AI clusters invented compound labels that sound analytical without being grounded. It appends abstract problem-nouns (paradox, trap, creep, divide, vacuum, inversion) to domain words and uses them as if they are established terms.
+
+| Pattern | Problem |
+|---------|---------|
+| "the supervision paradox" | Invented term treated as established |
+| "the acceleration trap" | Same |
+| "workload creep" | Same |
+
+**Fix:** If the concept needs a name, define it. If it does not need a name, describe it in plain language.
+
+## Word Patterns
+
+| Pattern | Problem |
+|---------|---------|
+| Lazy extremes (every, always, never, everyone, everybody, nobody) | False authority. Use specifics instead of sweeping claims. |
+| All adverbs (-ly words, "really," "just," "literally," "genuinely," "honestly," "simply," "actually") | Empty emphasis. See phrases.md for full list. |

--- a/.claude/skills/deslop/references/tropes.md
+++ b/.claude/skills/deslop/references/tropes.md
@@ -1,0 +1,327 @@
+# AI Writing Tropes to Avoid
+
+Add this file to your AI assistant's system prompt or context to help it avoid
+common AI writing patterns. Source: [tropes.fyi](https://tropes.fyi) by [ossama.is](https://ossama.is)
+
+---
+
+## Word Choice
+
+### "Quietly" and Other Magic Adverbs
+
+Overuse of "quietly" and similar adverbs to convey subtle importance or understated power. AI reaches for these adverbs to make mundane descriptions feel significant. Also includes: "deeply", "fundamentally", "remarkably", "arguably".
+
+**Avoid patterns like:**
+- "quietly orchestrating workflows, decisions, and interactions"
+- "the one that quietly suffocates everything else"
+- "a quiet intelligence behind it"
+
+### "Delve" and Friends
+
+Used to be the most infamous AI tell. "Delve" went from an uncommon English word to appearing in a staggering percentage of AI-generated text. Part of a family of overused AI vocabulary including "certainly", "utilize", "leverage" (as a verb), "robust", "streamline", and "harness".
+
+**Avoid patterns like:**
+- "Let's delve into the details..."
+- "Delving deeper into this topic..."
+- "We certainly need to leverage these robust frameworks..."
+
+### "Tapestry" and "Landscape"
+
+Overuse of ornate or grandiose nouns where simpler words would do. "Tapestry" is used to describe anything interconnected. "Landscape" is used to describe any field or domain. Other offenders: "paradigm", "synergy", "ecosystem", "framework".
+
+**Avoid patterns like:**
+- "The rich tapestry of human experience..."
+- "Navigating the complex landscape of modern AI..."
+- "The ever-evolving landscape of technology..."
+
+### The "Serves As" Dodge
+
+Replacing simple "is" or "are" with pompous alternatives like "serves as", "stands as", "marks", or "represents". AI avoids basic copulas because its repetition penalty pushes it toward fancier constructions (I've studied this!).
+
+**Avoid patterns like:**
+- "The building serves as a reminder of the city's heritage."
+- "Gallery 825 serves as LAAA's exhibition space for contemporary art."
+- "The station marks a pivotal moment in the evolution of regional transit."
+
+---
+
+## Sentence Structure
+
+### Negative Parallelism
+
+The "It's not X -- it's Y" pattern, often with an em dash. The single most commonly identified AI writing tell. Man I f*cking hate it. AI uses this to create false profundity by framing everything as a surprising reframe. One in a piece can be effective; ten in a blog post is a genuine insult to the reader. Before LLMs, people simply did not write like this at scale. Includes the causal variant "not because X, but because Y" where every explanation is framed as a surprise reveal, the em-dash dismissal "X -- not Y", and the cross-sentence reframe where the same noun is negated then repositioned: "The question isn't X. The question is Y."
+
+**Avoid patterns like:**
+- "It's not bold. It's backwards."
+- "Feeding isn't nutrition. It's dialysis."
+- "Half the bugs you chase aren't in your code. They're in your head."
+
+### "Not X. Not Y. Just Z."
+
+The dramatic countdown pattern. AI builds tension by negating two or more things before revealing the actual point. Creates a false sense of narrowing down to the truth.
+
+**Avoid patterns like:**
+- "Not a bug. Not a feature. A fundamental design flaw."
+- "Not ten. Not fifty. Five hundred and twenty-three lint violations across 67 files."
+- "not recklessly, not completely, but enough"
+
+### "The X? A Y."
+
+Self-posed rhetorical questions answered immediately in the next sentence or clause. The model asks a question nobody was asking, then answers it for dramatic effect. Thinks this is the epitome of great writing.
+
+**Avoid patterns like:**
+- "The result? Devastating."
+- "The worst part? Nobody saw it coming."
+- "The scary part? This attack vector is perfect for developers."
+
+### Anaphora Abuse
+
+Repeating the same sentence opening multiple times in quick succession.
+
+**Avoid patterns like:**
+- "They assume that users will pay... They assume that developers will build... They assume that ecosystems will emerge... They assume that..."
+- "They could expose... They could offer... They could provide... They could create... They could let... They could unlock..."
+- "They have built engines, but not vehicles. They have built power, but not leverage. They have built walls, but not doors."
+
+### Tricolon Abuse
+
+Overuse of the rule-of-three pattern, often extended to four or five. A single tricolon is elegant; three back-to-back tricolons are a pattern recognition failure.
+
+**Avoid patterns like:**
+- "Products impress people; platforms empower them. Products solve problems; platforms create worlds. Products scale linearly; platforms scale exponentially."
+- "identity, payments, compute, distribution"
+- "workflows, decisions, and interactions"
+
+### "It's Worth Noting"
+
+Filler transitions that signal nothing. AI uses these phrases to introduce new points without actually connecting them to the previous argument. Also includes: "It bears mentioning", "Importantly", "Interestingly", "Notably".
+
+**Avoid patterns like:**
+- "It's worth noting that this approach has limitations."
+- "Importantly, we must consider the broader implications."
+- "Interestingly, this pattern repeats across industries."
+
+### Superficial Analyses
+
+Tacking a present participle ("-ing") phrase onto the end of a sentence to inject shallow analysis that says nothing. The model attaches significance, legacy, or broader meaning to mundane facts using phrases like "highlighting its importance", "reflecting broader trends", or "contributing to the development of...".
+
+**Avoid patterns like:**
+- "contributing to the region's rich cultural heritage"
+- "This etymology highlights the enduring legacy of the community's resistance and the transformative power of unity in shaping its identity."
+- "underscoring its role as a dynamic hub of activity and culture"
+
+### False Ranges
+
+Using "from X to Y" constructions where X and Y aren't on any real scale. In legitimate use, "from X to Y" implies a spectrum with a meaningful middle. AI uses it as a fancy way to list two loosely related things. "From innovation to cultural transformation" -- what's in between???? Nothing!
+
+**Avoid patterns like:**
+- "From innovation to implementation to cultural transformation."
+- "From the singularity of the Big Bang to the grand cosmic web."
+- "From problem-solving and tool-making to scientific discovery, artistic expression, and technological innovation."
+
+---
+
+## Paragraph Structure
+
+### Short Punchy Fragments
+
+Excessive use of very short sentences or sentence fragments as standalone paragraphs for manufactured emphasis. RLHF training has pushed models toward "writing for readability" aimed at the lowest common denominator: one thought per sentence, no mental state-keeping required. It's an inhuman style. No real person writes first drafts this way because it doesn't match how humans think or speak.
+
+**Avoid patterns like:**
+- "He published this. Openly. In a book. As a priest."
+- "These weren't just products. And the software side matched. Then it professionalised. But I adapted."
+- "Platforms do."
+
+### Listicle in a Trench Coat
+
+Numbered or labeled points dressed up as continuous prose. The model writes what is essentially a listicle but wraps each point in a paragraph that starts with "The first... The second... The third..." to disguise the format. Perhaps you told it to stop generating lists and it decided to do this instead... still very common.
+
+**Avoid patterns like:**
+- "The first wall is the absence of a free, scoped API... The second wall is the lack of delegated access... The third wall is the absence of scoped permissions..."
+- "The second takeaway is that... The third takeaway is that... The fourth takeaway is that..."
+
+---
+
+## Tone
+
+### "Here's the Kicker"
+
+False suspense transitions that promise a revelation but deliver a point that did NOT need the buildup. The model uses these phrases to manufacture drama before an otherwise unremarkable observation LOL. Also includes: "Here's the thing", "Here's where it gets interesting", "Here's what most people miss", "Here's the starting point", "Here's the deal".
+
+**Avoid patterns like:**
+- "Here's the kicker."
+- "Here's the thing about AI adoption."
+- "Here's where it gets interesting."
+
+### "Think of It As..."
+
+The patronizing analogy. AI constantly reaches for "Think of it as..." or "It's like a..." to simplify concepts. The model defaults to teacher mode and assumes the reader needs a metaphor to understand anything. Often produces analogies that are less clear than the original concept.
+
+**Avoid patterns like:**
+- "Think of it like a highway system for data."
+- "Think of it as a Swiss Army knife for your workflow."
+- "It's like asking someone to buy a car they're only allowed to sit in while it's parked."
+
+### "Imagine a World Where..."
+
+The classic AI invitation to futurism. To sell the argument usually begins with "Imagine" followed by a list of wonderful things that will happen if the reader agrees with the premise.
+
+**Avoid patterns like:**
+- "Imagine a world where every tool you use -- your calendar, your inbox, your documents, your CRM, your code editor -- has a quiet intelligence behind it..."
+- "In that world, workflows stop being collections of manual steps and start becoming orchestrations."
+
+### False Vulnerability
+
+Simulated self-awareness or honesty that reads as performative. The model pretends to break the fourth wall or admit a bias, creating a false sense of authenticity. Real vulnerability is specific and uncomfortable; AI vulnerability is polished and risk-free!!!!
+
+**Avoid patterns like:**
+- "And yes, I'm openly in love with the platform model"
+- "And yes, since we're being honest: I'm looking at you, OpenAI, Google, Anthropic, Meta"
+- "This is not a rant; it's a diagnosis"
+
+### "The Truth Is Simple"
+
+Asserting that something is obvious, clear or simple instead of actually proving it. If you have to tell the reader your point is clear, it very likely isn't. Also includes the dramatic reveal variant: "but none of them is the real story. The real story is..." -- claiming privileged insight while waving away everything before it.
+
+**Avoid patterns like:**
+- "The reality is simpler and less flattering"
+- "History is unambiguous on this point"
+- "History is clear, the metrics are clear, the examples are clear"
+
+### Grandiose Stakes Inflation
+
+Everything is the most important thing ever. AI inflates the stakes of every argument to world-historical significance. A blog post about API pricing becomes a meditation on the fate of civilization.
+
+**Avoid patterns like:**
+- "This will fundamentally reshape how we think about everything."
+- "will define the next era of computing"
+- "something entirely new"
+
+### "Let's Break This Down"
+
+The pedagogical voice that assumes the reader needs hand-holding. AI defaults to a teacher-student dynamic even when writing for expert audiences. Also includes: "Let's unpack this", "Let's explore", "Let's dive in".
+
+**Avoid patterns like:**
+- "Let's break this down step by step."
+- "Let's unpack what this really means."
+- "Let's explore this idea further."
+
+### Vague Attributions
+
+Attributing claims to unnamed authorities instead of being specific. AI loves to invoke "experts", "observers", "industry reports", and "several publications" without naming anyone. It also inflates the quantity of sources -- presenting what one person said as a widely held view, or writing "several publications have cited" when it means two. If you can't name the expert, you don't have a source.
+
+**Avoid patterns like:**
+- "Experts argue that this approach has significant drawbacks."
+- "Industry reports suggest that adoption is accelerating."
+- "Observers have cited the initiative as a turning point."
+
+### Invented Concept Labels
+
+AI clusters invented compound labels that sound analytical without being grounded. It appends abstract problem-nouns (paradox, trap, creep, divide, vacuum, inversion) to domain words — "supervision paradox", "acceleration trap", "workload creep" — and uses them as if they're established, rigorously defined terms. They function as rhetorical shorthand: name a thing, skip the argument. Multiple such labels in the same piece is a strong signal of AI slop.
+
+**Avoid patterns like:**
+- "the supervision paradox"
+- "the acceleration trap"
+- "workload creep"
+
+---
+
+## Formatting
+
+### Em-Dash Addiction
+
+Compulsive overuse of em dashes for dramatic pauses, parenthetical asides and pivot points. A human writer might use 2-3 per piece (and naturally); AI will use 20+.
+
+**Avoid patterns like:**
+- "The problem -- and this is the part nobody talks about -- is systemic."
+- "The tinkerer spirit didn't die of natural causes -- it was bought out."
+- "Not recklessly, not completely -- but enough -- enough to matter."
+
+### Bold-First Bullets
+
+Every bullet point or list item starts with a bolded phrase or sentence. Extremely common in Claude and ChatGPT markdown output. Almost nobody formats lists this way when writing by hand. It's a telltale sign of AI-generated documentation and blog posts AND README files (especially with emojis).
+
+**Avoid patterns like:**
+- "Every single bullet point begins with a bold keyword."
+- "**Security**: Environment-based configuration with..."
+- "**Performance**: Lazy loading of expensive resources..."
+
+### Unicode Decoration
+
+Use of unicode arrows (->), smart/curly quotes, and other special characters that can't be easily typed on a standard keyboard. Real writers typing in a text editor produce straight quotes and -> or =>. Claude in particular loves the -> arrow.
+
+**Avoid patterns like:**
+- "Input → Processing → Output"
+- "This leads to better outcomes → which means higher engagement"
+- "“Smart quotes” instead of straight "quotes" that you’d actually type"
+
+---
+
+## Composition
+
+### Fractal Summaries
+
+"What I'm going to tell you; what I'm telling you; what I just told you" -- applied at every level of the document. Every subsection gets a summary. Every section gets a summary. The document itself gets a summary.
+
+**Avoid patterns like:**
+- "In this section, we'll explore... [3000 words later] ...as we've seen in this section."
+- "A conclusion that restates every point already made in the previous 3000 words"
+- "And so we return to where we began."
+
+### The Dead Metaphor
+
+Latching onto a single metaphor and beating it into the ground across the entire thing. A human writer would introduce a metaphor, use it then move on. AI will repeat the same metaphor 5-10 times.
+
+**Avoid patterns like:**
+- "The ecosystem needs ecosystems to build ecosystem value."
+- "Walls and doors used 30+ times in the same article"
+- "Every paragraph finds a way to say "primitives" again"
+
+### Historical Analogy Stacking
+
+ESPECIALLY COMMON IN TECHNICAL WRITING: Rapid-fire listing of historical companies or tech revolutions to build false authority.
+
+**Avoid patterns like:**
+- "Apple didn't build Uber. Facebook didn't build Spotify. Stripe didn't build Shopify. AWS didn't build Airbnb."
+- "Every major technological shift -- the web, mobile, social, cloud -- followed the same pattern."
+- "Take Spotify... Or consider Uber... Airbnb followed a similar path... Shopify is another example... Even Discord..."
+
+### One-Point Dilution
+
+Making a single argument and restating it in 10 different ways across thousands of words. The model pads a simple thesis to feel "comprehensive" by rephrasing the same idea with different metaphors, examples, and framings. An 800-word argument becomes 4000 words of circular repetition.
+
+**Avoid patterns like:**
+- "The same point, restated eight ways across 4000 words."
+- "Each section rephrases the thesis with a different metaphor but adds nothing new"
+
+### Content Duplication
+
+Repeating entire sections or paragraphs verbatim within the same piece. This happens when the model loses track of what it has already written, especially in longer pieces. A dead giveaway of unedited AI output. Less common nowadays.
+
+**Avoid patterns like:**
+- "The same section appeared twice, word-for-word identical."
+- "Paragraph 3 and paragraph 17 are the same sentence reworded"
+
+### The Signposted Conclusion
+
+Explicitly announcing the conclusion with "In conclusion", "To sum up", or "In summary". Competent writing doesn't need to tell you it's concluding. The reader can feel it. AI signals its structural moves because it's following a template, not writing organically.
+
+**Avoid patterns like:**
+- "In conclusion, the future of AI depends on..."
+- "To sum up, we've explored three key themes..."
+- "In summary, the evidence suggests..."
+
+### "Despite Its Challenges..."
+
+The rigid formula where AI acknowledges problems only to immediately dismiss them. Always follows the same beat: "Despite its [positive words], [subject] faces challenges..." then ends with "Despite these challenges, [optimistic conclusion].".
+
+**Avoid patterns like:**
+- "Despite these challenges, the initiative continues to thrive."
+- "Despite its industrial and residential prosperity, Korattur faces challenges typical of urban areas."
+- "Despite their promising applications, pyroelectric materials face several challenges that must be addressed for broader adoption."
+
+---
+
+Remember: any of these patterns used once might be fine. The problem is when
+multiple tropes appear together or when a single trope is used repeatedly.
+Write like a human: varied, imperfect, specific.

--- a/.claude/skills/merge-ready/SKILL.md
+++ b/.claude/skills/merge-ready/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: merge-ready
 description: Take a branch from "code exists (or is about to)" to "ready for the maintainer's final review" — multi-axis subagent review with verified findings, fixes, ci:check, checkpoint commits, and an updated PR. Use whenever the user says a feature/fix/branch should be "merge ready", asks to get changes ready for review, or appends this to a build request ("build X and make it merge-ready").
+metadata:
+  internal: true
 ---
 
 # Merge ready

--- a/.claude/skills/merge-ready/SKILL.md
+++ b/.claude/skills/merge-ready/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: merge-ready
-description: Take a branch from "code exists (or is about to)" to "ready for Ben's final review" — multi-axis subagent review with verified findings, fixes, ci:check, checkpoint commits, and an updated PR. Use whenever the user says a feature/fix/branch should be "merge ready", asks to get changes ready for review, or appends this to a build request ("build X and make it merge-ready").
+description: Take a branch from "code exists (or is about to)" to "ready for the maintainer's final review" — multi-axis subagent review with verified findings, fixes, ci:check, checkpoint commits, and an updated PR. Use whenever the user says a feature/fix/branch should be "merge ready", asks to get changes ready for review, or appends this to a build request ("build X and make it merge-ready").
 ---
 
 # Merge ready
 
-Drive the current work to the point where the only remaining step is Ben's own review and merge. The deliverable is a pushed branch with a clean `pnpm ci:check`, checkpoint commits along the way, and an open PR with a high-level description plus review instructions.
+Drive the current work to the point where the only remaining step is the maintainer's own review and merge. The deliverable is a pushed branch with a clean `pnpm ci:check`, checkpoint commits along the way, and an open PR with a high-level description plus review instructions.
 
-**Never merge the PR. Ben always reviews last.**
+**Never merge the PR. The maintainer always reviews last.**
 
 ## 0. Figure out the starting point
 
@@ -23,12 +23,19 @@ This skill composes with feature work — it is not only a review pass:
 
 ## 2. Multi-axis subagent review
 
-Spawn independent review subagents **in parallel**, one per axis, each given the branch diff scope (`git diff origin/main...HEAD`) and repo access:
+Spawn independent review subagents **in parallel**, one per axis, each given repo access and the complete branch scope:
+
+- committed changes: `git diff origin/main...HEAD`
+- staged changes: `git diff --cached`
+- unstaged changes: `git diff`
+- untracked files: `git status --short`, followed by reading every in-scope untracked file
+
+Do not let an uncommitted or newly created file escape review merely because it is absent from `origin/main...HEAD`.
 
 1. **Unnecessary complexity** — thin wrappers, needless indirection, single-use abstractions, defensive guards for impossible states, dead config. This codebase deliberately stays simple.
 2. **Security** — authz on new endpoints (org/project scoping), SSRF, injection, secrets handling, anything user-input-shaped reaching D1/R2/external APIs.
 3. **Billing & metering** — ways a user could trigger DataForSEO/provider spend without being metered, charged-but-failed paths, retry/loop amplification, endpoints with unexpectedly high per-call user cost. Credits are billed via Autumn; uncounted spend is a revenue leak.
-4. **Library & project idioms** — TanStack (Router/Query/Start) used idiomatically; patterns match how the rest of the codebase already does it (Result-pattern error handling at provider seams, db/schema conventions, existing component patterns). Flag novel patterns where an established one exists.
+4. **Library & project idioms** — TanStack (Router/Query/Start) used idiomatically; patterns match how the rest of the codebase already does it (shared application/provider error boundaries, db/schema conventions, existing component patterns). Flag novel patterns where an established one exists.
 5. **Vibe-coded cruft** — leftover scaffolding, stale comments narrating the edit history, console.logs, TODO-without-owner, copy-pasted near-duplicates, files/exports nothing uses.
 
 Each reviewer returns findings with file:line, severity (`blocker` / `should-fix` / `nitpick`), and a one-line rationale. Tell reviewers explicitly: this is an early-stage product — do not chase theoretical edge cases; mark anything debatable as `nitpick`.
@@ -37,9 +44,17 @@ Each reviewer returns findings with file:line, severity (`blocker` / `should-fix
 
 For each `blocker` and `should-fix` finding, spawn verification subagents (in parallel) that adversarially check the finding against the actual code and verdict **APPLY / APPLY-MODIFIED / REJECT** with reasoning. Drop rejected findings. Nitpicks don't need verification — they're reported, not necessarily fixed.
 
+### Preserve review learnings
+
+After verification, route durable learnings without forcing every review to change policy:
+
+- If an **APPLY** or **APPLY-MODIFIED** finding reveals a recurring or high-risk repository invariant that existing `.greptile/` context and CI do not capture, use `maintain-greptile-rules` and apply its promotion bar.
+- Keep one-off bugs as code fixes and regression tests. Put deterministic mechanical checks in CI or lint instead of Greptile.
+- When a small tooling, documentation, or workflow frustration occurs, use `papercuts` to append it to `.agents/PAPERCUTS.md`; do not derail merge-ready work to fix it.
+
 ## 4. Fix, check, loop
 
-- Apply verified `blocker`/`should-fix` fixes. Apply nitpicks only when trivial and clearly right; otherwise list them in the PR for Ben to judge.
+- Apply verified `blocker`/`should-fix` fixes. Apply nitpicks only when trivial and clearly right; otherwise list them in the PR for the maintainer to judge.
 - **Checkpoint:** commit fixes in logical groups (e.g. one commit per axis or per concern) so the fix history is reviewable on its own.
 - Run `pnpm ci:check` (prettier, knip, tsc, oxlint). Fix failures and re-run until clean. If a fix was substantial (not formatting/lint), run a quick re-review of just that change.
 - Loop until ci:check passes and no verified findings remain unaddressed.
@@ -51,4 +66,4 @@ For each `blocker` and `should-fix` finding, spawn verification subagents (in pa
   - **High-level** — what changed and why, written for a human skimming. No file paths, no per-file changelog.
   - **How to review** — a short ordered guide: what to look at first, what the risky/judgment-call areas are, what was deliberately left out of scope.
   - **Review notes** — unfixed nitpicks and any REJECT verdicts worth a second opinion, clearly labeled as such.
-- Report back to Ben: PR link, one-paragraph summary, and anything that still needs his judgment. Do not merge.
+- Report back: PR link, one-paragraph summary, and anything that still needs the maintainer's judgment. Do not merge.

--- a/.claude/skills/openseo-release-notes/SKILL.md
+++ b/.claude/skills/openseo-release-notes/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: openseo-release-notes
 description: 'Cut an OpenSEO release — bump the version, draft user-facing release notes from commits since the last tag, run a review + subagent-verification pass, and open a "release: vX.X.X" PR. Use when the user asks to prepare a release, bump the version, or write release notes.'
+metadata:
+  internal: true
 ---
 
 # OpenSEO release notes

--- a/.claude/skills/openseo-review-web-content/SKILL.md
+++ b/.claude/skills/openseo-review-web-content/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: openseo-review-web-content
+description: Review or write copy for the OpenSEO marketing site (web/) — blog posts, library guides, feature pages, FAQs. Covers voice, deslop rules, directness, honest pricing framing, and verifying every product claim against the code. Use whenever adding or editing user-facing prose in web/content or web/src.
+---
+
+# OpenSEO Web Content Review
+
+## Goal
+
+Ship marketing copy that reads like a practitioner wrote it, answers questions directly, and never claims something the product doesn't do or a price it doesn't have.
+
+Run this before merging any PR that adds or edits prose in:
+
+- `web/content/blogs/` — blog posts
+- `web/content/marketing/library/` — library guides (MDX)
+- `web/src/routes/_marketing/` — page copy in TSX string literals and JSX text
+- `web/src/lib/feature-pages.ts` — feature-page copy and FAQs
+- `web/src/components/` — shared marketing components (CTAs, headers)
+
+## Voice
+
+The reader is an indie founder or SEO freelancer. Write like a practitioner explaining a workflow, not a content marketer selling one. Name things; don't sell them. Specifics beat abstractions ("status codes, titles, meta descriptions" beats "page-level technical signals").
+
+Ben's own drafts are final copy, not a brief. Fill marked gaps and flag factual problems; do not rewrite his sentences into conversion copy.
+
+## Deslop pass
+
+The tells, in order of how often they appear:
+
+1. **Em dashes.** Replace with a comma, colon, semicolon, period, or parenthetical. Exception: verbatim quotes (interview blockquotes) keep their original punctuation. Sweep with:
+   `grep -rn "—" web/content web/src/routes/_marketing web/src/lib/feature-pages.ts web/src/components`
+2. **"X, not Y" contrasts.** The balanced noun-phrase pivot ("The unit of SEO isn't the keyword; it's the cluster") is the AI smell, and density is the giveaway — budget at most one deliberate contrast per page, placed where the contrast is the actual point. Fix by stating what the thing IS with a concrete consequence, or replacing the aphorism with the reason. Instruction-form contrasts ("Copy the words, not your summary of them") are natural speech; keep them.
+3. **Hype and stakes inflation.** "quietly fixes", "evil twin", "stark warning", "intent-matching machine", "the fix your rankings are waiting for". State the claim plainly.
+4. **Throat-clearing.** "Here's the thing:", "The practical consequence:", announce-before-quote sentences, "everyone does it wrong" strawman openers. Cut to the point; let quotes land without a setup sentence.
+5. **Filler adverbs and intensifiers.** actually, really, dramatically, exactly, "In other words".
+
+Not slop — leave alone: functional `→` arrows (`cluster → URL → status`), bold step labels in numbered how-tos, en dashes in number ranges (5–15), and accurate one-word claims like "Ungated" for a genuinely ungated PDF.
+
+## Directness pass (FAQs especially)
+
+- The first words answer the question. Yes/no questions open with "Yes", "No", "Not quite", or "Not unlimited" — never bury the verdict mid-sentence.
+- Banned hedges: "is designed to", "can be paired with", "adds context that can inform", "is useful for teams that", "keeps X organized so it can inform Y". If a sentence survives with the hedge deleted, the hedge was filler; if it doesn't, the sentence had no content.
+- No two FAQs on a page may share an answer. If two questions want the same answer, one of them gets the concrete version (the actual workflow or numbers) or gets cut.
+- Vague nouns get replaced by their referents: "technical signals" → the list of checks; "visibility metrics" → the metric names.
+
+## Product grounding pass
+
+Every capability claim gets verified against code, not memory. Canonical sources:
+
+- MCP claims → `src/server/mcp/tools/` (one file per tool; if there's no file, the tool doesn't exist)
+- Site audit checks and free limits → `src/shared/audit-limits.ts` (`FREE_MAX_AUDIT_PAGES`) and `src/server/features/audit/`
+- Keyword data fields → `src/server/features/keywords/services/research/research-data.ts`. Known gotcha: intent labels come from DataForSEO Labs only; the Google Ads fallback (used for non-Labs countries) returns intent "unknown", so never claim intent "on every keyword".
+- GSC capabilities → `src/server/features/gsc/` and `src/server/mcp/tools/search-console-tools.ts`
+- Feature inventory → `web/src/lib/feature-pages.ts` workflows sections (already reviewed copy; reuse its concrete lists)
+
+Attribution rule: the free discovery surfaces in the guides — autocomplete, People Also Ask, "related searches" — are **Google's**, and conversations and Search Console data are **the user's**. Say so explicitly ("Google's autocomplete", "your Search Console"). OpenSEO's role is the paid-data half: validating and expanding with volume, difficulty, and SERP data. Copy that lists those surfaces without attribution reads as OpenSEO features; that's a bug.
+
+## Pricing framing
+
+OpenSEO is not free and copy must never imply it is. The canonical framing:
+
+> Quality SEO data is difficult to get, which is why SaaS tools run $100/month and up. OpenSEO is the most affordable option, starting at $10/month, and you can start for free.
+
+Rules:
+
+- Use the full framing once per page (the main pricing-adjacent FAQ); shorter variants elsewhere ("you can start for free; paid plans start at $10/month") so the identical paragraph doesn't repeat across pages.
+- "Is X free?" questions get an honest verdict first: "Not unlimited", or "For smaller sites, yes" when a real free limit covers it (e.g. audits up to `FREE_MAX_AUDIT_PAGES` pages). "Open source" is true but is not an answer to "is it free".
+- Self-hosting is free software, not free data: self-hosters bring their own DataForSEO account.
+- Verify any number ($10/month, page limits, credit amounts) against code or the live pricing page before shipping it.
+
+## Review workflow
+
+1. Inventory the changed prose files (`git diff main... --stat`).
+2. Run the deslop greps and read every changed file in full — patterns cluster, so one hit means more nearby.
+3. For each finding, propose exact old → new replacements; verify each against the file before applying (subagent proposals included).
+4. Verify every product/pricing claim against the code paths above.
+5. Validate: `npm --prefix web run types:check`, and prettier on any touched TSX/TS (`npx prettier --write` in `web/`). Prettier failures in files you didn't touch are pre-existing; leave them.

--- a/.claude/skills/openseo-review-web-content/SKILL.md
+++ b/.claude/skills/openseo-review-web-content/SKILL.md
@@ -23,6 +23,8 @@ The reader is an indie founder or SEO freelancer. Write like a practitioner expl
 
 Ben's own drafts are final copy, not a brief. Fill marked gaps and flag factual problems; do not rewrite his sentences into conversion copy.
 
+Guides are tips first, product second. Mid-article product plugs get **deleted, not reworded** — the pitch belongs in the cost-question FAQ and the CTA, and the guide should read as useful without OpenSEO. Don't get into the weeds about OpenSEO inside a how-to.
+
 ## Deslop pass
 
 The tells, in order of how often they appear:
@@ -53,7 +55,11 @@ Every capability claim gets verified against code, not memory. Canonical sources
 - GSC capabilities → `src/server/features/gsc/` and `src/server/mcp/tools/search-console-tools.ts`
 - Feature inventory → `web/src/lib/feature-pages.ts` workflows sections (already reviewed copy; reuse its concrete lists)
 
-Attribution rule: the free discovery surfaces in the guides — autocomplete, People Also Ask, "related searches" — are **Google's**, and conversations and Search Console data are **the user's**. Say so explicitly ("Google's autocomplete", "your Search Console"). OpenSEO's role is the paid-data half: validating and expanding with volume, difficulty, and SERP data. Copy that lists those surfaces without attribution reads as OpenSEO features; that's a bug.
+Attribution rule: the free discovery surfaces in the guides — autocomplete, People Also Ask, "related searches" — are **Google's**, and conversations and Search Console data are **the user's**. Say so explicitly ("Google's autocomplete", "your Search Console"). OpenSEO's role is the paid-data half: validating and expanding with volume, difficulty, and SERP data. Copy that lists those surfaces without attribution reads as OpenSEO features; that's a bug. Known absences that have shipped as overclaims before: OpenSEO does **not** harvest autocomplete or People Also Ask (of those surfaces only Search Console is integrated), and never claim it "wraps" workflows it doesn't.
+
+UI-affordance rule: before copy instructs the reader to click, sort, or filter something ("sort by word count"), confirm that control exists in the client code. Known past miss: the keyword research table has no word-count column.
+
+Claims about named third parties (a customer, an interviewee's employer, a competitor) need a source or softening — "legally-mandated" about a specific company is a legal claim, not copy. And when a post is adapted from a source (podcast, talk), spot-check quotes against the source for quiet edits, like a competitor's name being scrubbed.
 
 ## Pricing framing
 
@@ -66,7 +72,23 @@ Rules:
 - Use the full framing once per page (the main pricing-adjacent FAQ); shorter variants elsewhere ("you can start for free; paid plans start at $10/month") so the identical paragraph doesn't repeat across pages.
 - "Is X free?" questions get an honest verdict first: "Not unlimited", or "For smaller sites, yes" when a real free limit covers it (e.g. audits up to `FREE_MAX_AUDIT_PAGES` pages). "Open source" is true but is not an answer to "is it free".
 - Self-hosting is free software, not free data: self-hosters bring their own DataForSEO account.
+- Free-tier facts (verify against `src/shared/billing.ts` and the pricing page before repeating): signup is card-free with a small trial-credit grant ($0.50 at time of writing); top-ups are paid-plan only; keyword research is credit-metered, so "the clustering pass is free" is only true for keywords already researched.
 - Verify any number ($10/month, page limits, credit amounts) against code or the live pricing page before shipping it.
+- FAQ answers on marketing pages also ship inside FAQPage JSON-LD — a false claim there is served to Google as structured data, which makes FAQ accuracy the highest-stakes copy on the page.
+
+## External contributions (consultants, guest authors)
+
+Extra checks when the content comes from outside the team:
+
+- **Outbound links are currency.** Every external link gets justified: who owns the domain, is there an undisclosed relationship, does the anchor deserve a dofollow editorial link from openseo.so? A link to a third-party SEO agency with no stated connection is a red flag. Attribution links should point at the specific article, not a homepage.
+- **Bylines must render.** If frontmatter carries an `author`, confirm the site actually displays it — a guest post publishing as first-party editorial while linking the author's own properties edges into Google's guest-post link-spam territory.
+- **Self-promotion in assets.** Check PDFs and images for the contributor's own branding; decide deliberately whether it stays.
+- **Binary assets get inspected**, not waved through: `strings` over PDFs for embedded links, screenshots checked against their captions.
+
+## Beyond the prose
+
+- **Sitemap:** `web/scripts/generate-sitemap.js` uses a hardcoded `STATIC_PATHS` list and only scans `content/blogs` and `content/docs` — new marketing/library pages must be added explicitly or they're invisible to crawlers. Verify by building and grepping the sitemap output.
+- **Screenshots:** must show real product output that reproduces the article's own example (capture via the app, seeded through the MCP if needed), the caption/alt text must match what's visible, and theme should be consistent across a page's image set.
 
 ## Review workflow
 

--- a/.claude/skills/openseo-review-web-content/SKILL.md
+++ b/.claude/skills/openseo-review-web-content/SKILL.md
@@ -1,92 +1,34 @@
 ---
 name: openseo-review-web-content
-description: Review or write copy for the OpenSEO marketing site (web/) — blog posts, library guides, feature pages, FAQs. Covers voice, deslop rules, directness, honest pricing framing, and verifying every product claim against the code. Use whenever adding or editing user-facing prose in web/content or web/src.
+description: Write and review content for the OpenSEO website (web/) — blog posts, guides, feature pages, FAQs. Distills the philosophy for on-brand, useful, accurate content. Use whenever adding or editing user-facing prose in web/content or web/src.
 ---
 
-# OpenSEO Web Content Review
+# OpenSEO Web Content
 
-## Goal
+Everything we publish must be traceable to what the product actually does and costs, and must read like a practitioner wrote it. The reader's interest comes first: teach something they can act on, and answer straight — including when the honest answer is "no" or "it costs money."
 
-Ship marketing copy that reads like a practitioner wrote it, answers questions directly, and never claims something the product doesn't do or a price it doesn't have.
+## Principles
 
-Run this before merging any PR that adds or edits prose in:
+1. **Traceable truth.** Every capability claim, price, and screenshot is verifiable against the code, the fact sheet (`src/server/features/onboarding/openseo-fact-sheet.md`), or the live product. If you can't point to where it's true, it doesn't ship.
+2. **Lead with the real answer.** "No," "not unlimited," and "it costs money" are complete answers. Hedging that lets a reader infer something more flattering than the truth is a way of misleading them.
+3. **Honest pricing, with its reasoning.** Quality SEO data is expensive everywhere — that's why the big suites run $100/month and up. OpenSEO is the affordable option: $10/month, free to start. Never simply "free."
+4. **Sound like a person.** Fix AI tells by restating the underlying claim plainly, not by polishing the flourish. The [deslop skill](../deslop/SKILL.md) is the reference for what to hunt and how to fix it.
+5. **Reader-first altitude.** Guides teach actionable SEO that stands on its own — not product documentation, not generic filler. Credit free resources to their real owners (Google's autocomplete, the reader's own Search Console).
+6. **One bar, whole surface.** When a standard improves, sweep everything to it — all the FAQs, all the pages — not just the instance that got noticed.
 
-- `web/content/blogs/` — blog posts
-- `web/content/marketing/library/` — library guides (MDX)
-- `web/src/routes/_marketing/` — page copy in TSX string literals and JSX text
-- `web/src/lib/feature-pages.ts` — feature-page copy and FAQs
-- `web/src/components/` — shared marketing components (CTAs, headers)
+## Questions to ask while reviewing
 
-## Voice
+- If a reader trusted every claim and screenshot, then opened OpenSEO right now, where would reality not match?
+- Does each answer open with the real answer, or quietly steer toward a more flattering inference?
+- Read the sharpest line aloud: would a person say it that way?
+- Is anything called free that actually costs credits?
+- Is this teaching the reader something useful on its own, or drifting into product docs or padding?
+- Does every link, image, and example on the page earn its place for the reader?
 
-The reader is an indie founder or SEO freelancer. Write like a practitioner explaining a workflow, not a content marketer selling one. Name things; don't sell them. Specifics beat abstractions ("status codes, titles, meta descriptions" beats "page-level technical signals").
+## Facts to verify, not remember
 
-Ben's own drafts are final copy, not a brief. Fill marked gaps and flag factual problems; do not rewrite his sentences into conversion copy.
+Check these against code before repeating any of them — they change: pricing and credits (`src/shared/billing.ts`, the pricing page), free-plan limits (`src/shared/audit-limits.ts`), MCP capabilities (`src/server/mcp/tools/` — one file per tool), and any UI affordance copy tells the reader to use (the column, sort, or filter must exist in the client code).
 
-Guides are tips first, product second. Mid-article product plugs get **deleted, not reworded** — the pitch belongs in the cost-question FAQ and the CTA, and the guide should read as useful without OpenSEO. Don't get into the weeds about OpenSEO inside a how-to.
+## Process
 
-## Deslop pass
-
-The tells, in order of how often they appear:
-
-1. **Em dashes.** Replace with a comma, colon, semicolon, period, or parenthetical. Exception: verbatim quotes (interview blockquotes) keep their original punctuation. Sweep with:
-   `grep -rn "—" web/content web/src/routes/_marketing web/src/lib/feature-pages.ts web/src/components`
-2. **"X, not Y" contrasts.** The balanced noun-phrase pivot ("The unit of SEO isn't the keyword; it's the cluster") is the AI smell, and density is the giveaway — budget at most one deliberate contrast per page, placed where the contrast is the actual point. Fix by stating what the thing IS with a concrete consequence, or replacing the aphorism with the reason. Instruction-form contrasts ("Copy the words, not your summary of them") are natural speech; keep them.
-3. **Hype and stakes inflation.** "quietly fixes", "evil twin", "stark warning", "intent-matching machine", "the fix your rankings are waiting for". State the claim plainly.
-4. **Throat-clearing.** "Here's the thing:", "The practical consequence:", announce-before-quote sentences, "everyone does it wrong" strawman openers. Cut to the point; let quotes land without a setup sentence.
-5. **Filler adverbs and intensifiers.** actually, really, dramatically, exactly, "In other words".
-
-Not slop — leave alone: functional `→` arrows (`cluster → URL → status`), bold step labels in numbered how-tos, en dashes in number ranges (5–15), and accurate one-word claims like "Ungated" for a genuinely ungated PDF.
-
-## Directness pass (FAQs especially)
-
-- The first words answer the question. Yes/no questions open with "Yes", "No", "Not quite", or "Not unlimited" — never bury the verdict mid-sentence.
-- Banned hedges: "is designed to", "can be paired with", "adds context that can inform", "is useful for teams that", "keeps X organized so it can inform Y". If a sentence survives with the hedge deleted, the hedge was filler; if it doesn't, the sentence had no content.
-- No two FAQs on a page may share an answer. If two questions want the same answer, one of them gets the concrete version (the actual workflow or numbers) or gets cut.
-- Vague nouns get replaced by their referents: "technical signals" → the list of checks; "visibility metrics" → the metric names.
-
-## Product grounding pass
-
-Every capability claim gets verified against code, not memory. Canonical sources:
-
-- MCP claims → `src/server/mcp/tools/` (one file per tool; if there's no file, the tool doesn't exist)
-- Site audit checks and free limits → `src/shared/audit-limits.ts` (`FREE_MAX_AUDIT_PAGES`) and `src/server/features/audit/`
-- Keyword data fields → `src/server/features/keywords/services/research/research-data.ts`. Known gotcha: intent labels come from DataForSEO Labs only; the Google Ads fallback (used for non-Labs countries) returns intent "unknown", so never claim intent "on every keyword".
-- GSC capabilities → `src/server/features/gsc/` and `src/server/mcp/tools/search-console-tools.ts`
-- Feature inventory → `web/src/lib/feature-pages.ts` workflows sections (already reviewed copy; reuse its concrete lists)
-
-Attribution rule: the free discovery surfaces in the guides — autocomplete, People Also Ask, "related searches" — are **Google's**, and conversations and Search Console data are **the user's**. Say so explicitly ("Google's autocomplete", "your Search Console"). OpenSEO's role is the paid-data half: validating and expanding with volume, difficulty, and SERP data. Copy that lists those surfaces without attribution reads as OpenSEO features; that's a bug. Known absences that have shipped as overclaims before: OpenSEO does **not** harvest autocomplete or People Also Ask (of those surfaces only Search Console is integrated), and never claim it "wraps" workflows it doesn't.
-
-UI-affordance rule: before copy instructs the reader to click, sort, or filter something ("sort by word count"), confirm that control exists in the client code. Known past miss: the keyword research table has no word-count column.
-
-Claims about named third parties (a customer, an interviewee's employer, a competitor) need a source or softening — "legally-mandated" about a specific company is a legal claim, not copy. When a post is adapted from a source (podcast, talk), check quotes against the source so they stay accurate.
-
-## Pricing framing
-
-OpenSEO is not free and copy must never imply it is. The canonical framing:
-
-> Quality SEO data is difficult to get, which is why SaaS tools run $100/month and up. OpenSEO is the most affordable option, starting at $10/month, and you can start for free.
-
-Rules:
-
-- Use the full framing once per page (the main pricing-adjacent FAQ); shorter variants elsewhere ("you can start for free; paid plans start at $10/month") so the identical paragraph doesn't repeat across pages.
-- "Is X free?" questions get an honest verdict first: "Not unlimited", or "For smaller sites, yes" when a real free limit covers it (e.g. audits up to `FREE_MAX_AUDIT_PAGES` pages). "Open source" is true but is not an answer to "is it free".
-- Self-hosting is free software, not free data: self-hosters bring their own DataForSEO account.
-- Free-tier facts (verify against `src/shared/billing.ts` and the pricing page before repeating): signup is card-free with a small trial-credit grant ($0.50 at time of writing); top-ups are paid-plan only; keyword research is credit-metered, so "the clustering pass is free" is only true for keywords already researched.
-- Verify any number ($10/month, page limits, credit amounts) against code or the live pricing page before shipping it.
-- FAQ answers on marketing pages also ship inside FAQPage JSON-LD — a false claim there is served to Google as structured data, which makes FAQ accuracy the highest-stakes copy on the page.
-
-## Beyond the prose
-
-- **Sitemap:** `web/scripts/generate-sitemap.js` uses a hardcoded `STATIC_PATHS` list and only scans `content/blogs` and `content/docs` — new marketing/library pages must be added explicitly or they're invisible to crawlers. Verify by building and grepping the sitemap output.
-- **Screenshots:** must show real product output that reproduces the article's own example (capture via the app, seeded through the MCP if needed), the caption/alt text must match what's visible, and theme should be consistent across a page's image set.
-- **Outbound links:** every external link earns its place — link the specific article rather than a homepage, and disclose any relationship to the linked site in the post.
-- **Bylines:** if a post's frontmatter names an `author`, confirm the site actually renders the byline so authorship is visible to readers.
-
-## Review workflow
-
-1. Inventory the changed prose files (`git diff main... --stat`).
-2. Run the deslop greps and read every changed file in full — patterns cluster, so one hit means more nearby.
-3. For each finding, propose exact old → new replacements; verify each against the file before applying (subagent proposals included).
-4. Verify every product/pricing claim against the code paths above.
-5. Validate: `npm --prefix web run types:check`, and prettier on any touched TSX/TS (`npx prettier --write` in `web/`). Prettier failures in files you didn't touch are pre-existing; leave them.
+Spawn subagents to run the review passes (voice/deslop, claims accuracy, directness) and have them return exact old → new proposals rather than editing directly. Do not accept their proposals blindly: verify each one against the actual file, and each factual claim against the code, before applying — subagent rewrites can introduce their own awkwardness or errors, and a proposal that mismatches the file means it reviewed stale text. After applying, sweep the changed surface yourself (patterns cluster — one em dash or hedge usually has neighbors), then run `npm --prefix web run types:check` and prettier on touched TS/TSX.

--- a/.claude/skills/openseo-review-web-content/SKILL.md
+++ b/.claude/skills/openseo-review-web-content/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: openseo-review-web-content
 description: Write and review content for the OpenSEO website (web/) — blog posts, guides, feature pages, FAQs. Distills the philosophy for on-brand, useful, accurate content. Use whenever adding or editing user-facing prose in web/content or web/src.
+metadata:
+  internal: true
 ---
 
 # OpenSEO Web Content

--- a/.claude/skills/openseo-review-web-content/SKILL.md
+++ b/.claude/skills/openseo-review-web-content/SKILL.md
@@ -59,7 +59,7 @@ Attribution rule: the free discovery surfaces in the guides — autocomplete, Pe
 
 UI-affordance rule: before copy instructs the reader to click, sort, or filter something ("sort by word count"), confirm that control exists in the client code. Known past miss: the keyword research table has no word-count column.
 
-Claims about named third parties (a customer, an interviewee's employer, a competitor) need a source or softening — "legally-mandated" about a specific company is a legal claim, not copy. And when a post is adapted from a source (podcast, talk), spot-check quotes against the source for quiet edits, like a competitor's name being scrubbed.
+Claims about named third parties (a customer, an interviewee's employer, a competitor) need a source or softening — "legally-mandated" about a specific company is a legal claim, not copy. When a post is adapted from a source (podcast, talk), check quotes against the source so they stay accurate.
 
 ## Pricing framing
 
@@ -76,19 +76,12 @@ Rules:
 - Verify any number ($10/month, page limits, credit amounts) against code or the live pricing page before shipping it.
 - FAQ answers on marketing pages also ship inside FAQPage JSON-LD — a false claim there is served to Google as structured data, which makes FAQ accuracy the highest-stakes copy on the page.
 
-## External contributions (consultants, guest authors)
-
-Extra checks when the content comes from outside the team:
-
-- **Outbound links are currency.** Every external link gets justified: who owns the domain, is there an undisclosed relationship, does the anchor deserve a dofollow editorial link from openseo.so? A link to a third-party SEO agency with no stated connection is a red flag. Attribution links should point at the specific article, not a homepage.
-- **Bylines must render.** If frontmatter carries an `author`, confirm the site actually displays it — a guest post publishing as first-party editorial while linking the author's own properties edges into Google's guest-post link-spam territory.
-- **Self-promotion in assets.** Check PDFs and images for the contributor's own branding; decide deliberately whether it stays.
-- **Binary assets get inspected**, not waved through: `strings` over PDFs for embedded links, screenshots checked against their captions.
-
 ## Beyond the prose
 
 - **Sitemap:** `web/scripts/generate-sitemap.js` uses a hardcoded `STATIC_PATHS` list and only scans `content/blogs` and `content/docs` — new marketing/library pages must be added explicitly or they're invisible to crawlers. Verify by building and grepping the sitemap output.
 - **Screenshots:** must show real product output that reproduces the article's own example (capture via the app, seeded through the MCP if needed), the caption/alt text must match what's visible, and theme should be consistent across a page's image set.
+- **Outbound links:** every external link earns its place — link the specific article rather than a homepage, and disclose any relationship to the linked site in the post.
+- **Bylines:** if a post's frontmatter names an `author`, confirm the site actually renders the byline so authorship is visible to readers.
 
 ## Review workflow
 

--- a/.claude/skills/papercuts/SKILL.md
+++ b/.claude/skills/papercuts/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: papercuts
-description: Log genuine, recurring repository friction to .agents/PAPERCUTS.md — confusing setup, a flaky repo command or script, a misleading in-repo error, stale generated files, or a non-obvious gotcha that will cost the next contributor time. Also use to review, deduplicate, and resolve existing entries. Gate hard before logging: only friction the repository itself can fix counts. Never log the agent's own sandbox/permission errors, shell-scripting mistakes, transient flakiness, or third-party tool quirks the repo can't change.
+description: "Log genuine, recurring repository friction to .agents/PAPERCUTS.md — confusing setup, a flaky repo command or script, a misleading in-repo error, stale generated files, or a non-obvious gotcha that will cost the next contributor time. Also use to review, deduplicate, and resolve existing entries. Gate hard before logging: only friction the repository itself can fix counts. Never log the agent's own sandbox/permission errors, shell-scripting mistakes, transient flakiness, or third-party tool quirks the repo can't change."
+metadata:
+  internal: true
 ---
 
 # Papercuts

--- a/web/content/marketing/library/cluster-topical-hubs.mdx
+++ b/web/content/marketing/library/cluster-topical-hubs.mdx
@@ -42,7 +42,7 @@ For SERP-overlap clustering at scale, paid tools exist, but for most sites, Open
 
 ### Is there a free keyword clustering tool?
 
-This workflow is the closest thing: the clustering pass runs through the MCP on keywords you've already researched, so there's no separate clustering tool to buy. OpenSEO itself is open source.
+Not an unlimited one. The grouping step itself is free (the MCP prompt above does it), but it runs on researched keywords, and quality keyword data is the part that costs money everywhere. OpenSEO includes the clustering pass with research, so there's no separate clustering tool to buy; you can start for free, and paid plans start at $10/month.
 
 ### What is a keyword mapping template?
 

--- a/web/content/marketing/library/long-tail-question-mining.mdx
+++ b/web/content/marketing/library/long-tail-question-mining.mdx
@@ -45,4 +45,4 @@ One intent per page. Make the long-tail query the H2 (or H1) verbatim where natu
 
 ### Is there a free long-tail keyword generator?
 
-Google gives you two: autocomplete and People Also Ask. Your Search Console is the third and best; it's your site's actual tail. OpenSEO connects your Search Console and expands what you find into full keyword lists: open source and free to try.
+Google gives you two: autocomplete and People Also Ask. Your Search Console is the third and best; it's your site's actual tail. OpenSEO connects your Search Console and expands what you find into full keyword lists. You can start for free; paid plans start at $10/month.

--- a/web/content/marketing/library/search-intent-mapping.mdx
+++ b/web/content/marketing/library/search-intent-mapping.mdx
@@ -44,4 +44,4 @@ Queries that signal purchase readiness: "pricing", "vs", "alternative", "best X 
 
 ### How do I check the search intent of a keyword?
 
-Search it. The current top 10 is Google's answer: if it's all listicles, the intent is commercial comparison; all docs and definitions, informational. OpenSEO also auto-labels intent on every [researched keyword](/features/keyword-research).
+Search it. The current top 10 is Google's answer: if it's all listicles, the intent is commercial comparison; all docs and definitions, informational. OpenSEO also auto-labels intent on [researched keywords](/features/keyword-research) in most countries.

--- a/web/content/marketing/library/seed-from-conversation.mdx
+++ b/web/content/marketing/library/seed-from-conversation.mdx
@@ -33,7 +33,7 @@ and tell me which have measured demand vs. which go on the watch list.
 
 ### How do I do keyword research for free?
 
-Conversations for seeds (this page), Google autocomplete + People Also Ask for expansion, Search Console for validation. OpenSEO validates and expands what those surface: open source, no card required.
+Conversations for seeds (this page), Google autocomplete + People Also Ask for expansion, Search Console for validation. OpenSEO validates and expands what those surface; you can start for free, and paid plans start at $10/month.
 
 ### How do I find LSI keywords?
 

--- a/web/src/components/feature-page.tsx
+++ b/web/src/components/feature-page.tsx
@@ -190,94 +190,41 @@ function GuidesSection({
 }) {
   return (
     <section className="mt-12">
-      <div className="rounded-[20px] bg-neutral-950 p-7 text-white md:p-12">
-        <p className="text-sm font-medium text-[#c9c4bd]">{guides.eyebrow}</p>
-        <h2 className="mt-3 text-2xl font-semibold tracking-tight text-white">
-          {guides.title}
-        </h2>
-        <p className="mt-3 max-w-2xl text-sm leading-6 text-[#c9c4bd]">
-          {guides.description}
-        </p>
-        <div className="mt-8 grid gap-3 md:grid-cols-2">
-          {guides.items.map((item) => {
-            const body = (
-              <>
-                <div className="flex items-start justify-between gap-2 text-[15px] font-semibold text-white">
-                  <span>{item.label}</span>
-                  {item.href ? (
-                    <span
-                      aria-hidden="true"
-                      className="text-[var(--color-brand-accent)]"
-                    >
-                      &rarr;
-                    </span>
-                  ) : (
-                    <span className="shrink-0 rounded-full border border-[#2e2e2e] px-2 py-0.5 font-mono text-[9px] uppercase tracking-wider text-[#8f8a83]">
-                      Next up
-                    </span>
-                  )}
-                </div>
-                <p className="mt-1.5 font-mono text-[11px] text-[#8f8a83]">
-                  {item.by}
-                </p>
-              </>
-            );
-            return item.href ? (
-              <a
-                key={item.label}
-                href={item.href}
-                className="block rounded-[10px] border border-[#2e2e2e] bg-[#1c1c1c] px-[18px] py-3.5 transition-colors hover:border-[var(--color-brand-accent)] hover:bg-[#212121]"
+      <h2 className="text-2xl font-semibold tracking-tight text-neutral-950">
+        {guides.title}
+      </h2>
+      <p className="mt-2 max-w-2xl text-sm leading-6 text-[var(--color-brand-muted)]">
+        {guides.description}
+      </p>
+      <div className="mt-5 grid gap-4 md:grid-cols-2">
+        {guides.items.map((item) => (
+          <a
+            key={item.href}
+            href={item.href}
+            className="rounded-lg border border-[var(--color-border-subtle)] bg-white p-5 transition-colors hover:border-neutral-900"
+          >
+            <h3 className="text-base font-semibold text-neutral-950">
+              {item.label}
+              <span
+                aria-hidden="true"
+                className="ml-1 text-[var(--color-brand-accent)]"
               >
-                {body}
-              </a>
-            ) : (
-              <div
-                key={item.label}
-                className="rounded-[10px] border border-[#2e2e2e] bg-[#1c1c1c] px-[18px] py-3.5"
-              >
-                {body}
-              </div>
-            );
-          })}
-        </div>
+                &rarr;
+              </span>
+            </h3>
+            <p className="mt-2 text-sm leading-6 text-[var(--color-brand-muted)]">
+              {item.description}
+            </p>
+          </a>
+        ))}
+      </div>
+      <div className="mt-4">
         <a
           href={guides.cta.href}
-          className="mt-8 inline-flex h-11 items-center rounded-lg border border-[#444] px-5 text-sm font-medium text-white transition-colors hover:border-[var(--color-brand-accent)]"
+          className="text-sm font-medium text-neutral-950 underline decoration-[var(--color-brand-accent)] underline-offset-4"
         >
           {guides.cta.label}
-          <span aria-hidden="true" className="ml-2">
-            &rarr;
-          </span>
-        </a>
-      </div>
-
-      <div className="mt-4 flex flex-wrap items-center gap-8 rounded-xl border border-[var(--color-border-subtle)] bg-white p-7">
-        <div
-          aria-hidden="true"
-          className="relative h-[90px] w-[72px] shrink-0 rounded-md border border-[var(--color-border-subtle)] bg-gradient-to-br from-white to-[#f5f1ec]"
-        >
-          <span className="absolute left-[9px] right-[9px] top-[9px] h-[3px] bg-[var(--color-brand-accent)] shadow-[0_7px_0_#e7e0d7,0_14px_0_#e7e0d7,0_21px_0_#e7e0d7]" />
-          <span className="absolute bottom-[7px] left-[7px] rounded-[3px] bg-[var(--color-brand-accent)] px-[5px] py-[2px] font-mono text-[9px] text-white">
-            PDF
-          </span>
-        </div>
-        <div className="min-w-[240px] flex-1">
-          <p className="text-sm font-medium text-[var(--color-brand-accent)]">
-            {guides.download.eyebrow}
-          </p>
-          <h3 className="mt-2 text-[19px] font-semibold text-neutral-950">
-            {guides.download.title}
-          </h3>
-          <p className="mt-1.5 text-sm leading-6 text-[var(--color-brand-muted)]">
-            {guides.download.description}
-          </p>
-        </div>
-        <a
-          href={guides.download.href}
-          className="inline-flex h-11 items-center rounded-lg bg-neutral-950 px-5 text-sm font-medium text-white transition-colors hover:bg-neutral-800"
-        >
-          {guides.download.label}
-          <span aria-hidden="true" className="ml-2">
+          <span aria-hidden="true" className="ml-1">
             &rarr;
           </span>
         </a>

--- a/web/src/lib/feature-pages.ts
+++ b/web/src/lib/feature-pages.ts
@@ -112,7 +112,7 @@ export const featurePages = {
       {
         question: "Can I use OpenSEO as a free keyword research tool?",
         answer:
-          "OpenSEO is open source and can be self-hosted. The managed app also keeps keyword research tied to transparent usage instead of a large fixed subscription to a closed SEO suite.",
+          "Not unlimited: quality keyword data costs money everywhere, which is why the big SEO suites run $100/month and up. OpenSEO is the most affordable option; you can start for free, and paid plans start at $10/month with usage credits included. It's also open source, so you can self-host with your own DataForSEO account.",
       },
       {
         question: "Does OpenSEO show live search results?",
@@ -220,7 +220,7 @@ export const featurePages = {
       {
         question: "Is OpenSEO a free SEO audit tool?",
         answer:
-          "OpenSEO is open source and can be self-hosted. Managed usage depends on the crawl and data costs behind each workflow.",
+          "For smaller sites, yes: the free plan includes site audits up to 50 pages per crawl. Larger crawls need a paid plan, starting at $10/month. OpenSEO is also open source and self-hostable.",
       },
       {
         question: "Who should use OpenSEO Site Audit?",

--- a/web/src/lib/feature-pages.ts
+++ b/web/src/lib/feature-pages.ts
@@ -30,22 +30,14 @@ export type FeaturePage = {
     answer: string;
   }>;
   guides?: {
-    eyebrow: string;
     title: string;
     description: string;
     items: Array<{
       label: string;
-      by: string;
-      href?: string;
+      description: string;
+      href: string;
     }>;
     cta: {
-      label: string;
-      href: string;
-    };
-    download: {
-      eyebrow: string;
-      title: string;
-      description: string;
       label: string;
       href: string;
     };
@@ -129,59 +121,38 @@ export const featurePages = {
       },
     ],
     guides: {
-      eyebrow: "The practitioner playbook",
       title: "The Keyword Research Strategy Library",
       description:
-        "Eight field-tested plays for finding demand that converts, each drawn from a working SEO on the Unscripted podcast, with the workflow and who endorses it. Free, and built to be run inside OpenSEO.",
+        "Practitioner plays that treat keyword research as demand discovery, not a volume spreadsheet. Each guide is a full walkthrough with the copy-paste MCP prompt that runs it.",
       items: [
         {
           label: "Seed from conversation, not a volume report",
-          by: "Slaymaker · Bajayo · Digneo",
+          description:
+            "Harvest seed keywords from sales calls and support tickets.",
           href: "/library/keyword-research/seed-from-conversation",
         },
         {
-          label: "Long-tail & question mining (PAA, query fan-out)",
-          by: "Baterina · Moser · Barnard",
+          label: "What are long-tail keywords, and how to mine them",
+          description:
+            "PAA fan-out, autocomplete harvesting, and your own GSC queries.",
           href: "/library/keyword-research/long-tail-question-mining",
         },
         {
           label: "Search-intent mapping (hot / warm / cold)",
-          by: "Merrilees · Ashford",
+          description:
+            "Label every keyword by buying temperature before you write.",
           href: "/library/keyword-research/search-intent-mapping",
         },
         {
-          label: "Opportunity sizing & forecasting",
-          by: "Rivera · Berkowitz · Baterina",
-        },
-        {
-          label: "Programmatic & data-driven discovery (GSC)",
-          by: "Rivera · Simmons",
-        },
-        {
           label: "Cluster keywords into topical hubs",
-          by: "Simmons · Homer",
+          description:
+            "One page per intent, plus the keyword cannibalization fix.",
           href: "/library/keyword-research/cluster-topical-hubs",
-        },
-        {
-          label: "Intent beyond Google (Pinterest, AI, LinkedIn)",
-          by: "Bocchese · Alfon · Popp",
-        },
-        {
-          label: "Make positioning map to real demand",
-          by: "Little · Popp · Homer",
         },
       ],
       cta: {
-        label: "Open the full library",
+        label: "Browse the full Strategy Library",
         href: "/library/keyword-research",
-      },
-      download: {
-        eyebrow: "Free download",
-        title: "The Keyword Research Playbook",
-        description:
-          "All 8 plays in one designed PDF: workflows, the practitioner quotes behind them, and a seed-to-brief checklist.",
-        label: "Download the PDF",
-        href: "/library/keyword-research/keyword-research-playbook.pdf",
       },
     },
   },

--- a/web/src/lib/feature-pages.ts
+++ b/web/src/lib/feature-pages.ts
@@ -215,7 +215,7 @@ export const featurePages = {
       {
         question: "What does the OpenSEO site audit tool check?",
         answer:
-          "OpenSEO crawls pages, shows page-level technical signals, and can attach Lighthouse issue details when Lighthouse is enabled.",
+          "Status codes, titles, meta descriptions, headings, indexability signals, image alt coverage, links, and response time for every crawled page. Enable Lighthouse and each page also gets performance, SEO, accessibility, and best-practice issues.",
       },
       {
         question: "Is OpenSEO a free SEO audit tool?",
@@ -296,12 +296,12 @@ export const featurePages = {
       {
         question: "Can I check competitor backlinks in OpenSEO?",
         answer:
-          "Yes. OpenSEO's backlink workflow is designed for researching your own domain as well as competitor domains.",
+          "Yes. Enter any domain, yours or a competitor's, and pull its backlinks, referring domains, and top linked pages.",
       },
       {
         question: "How does backlink research connect to SEO planning?",
         answer:
-          "Backlinks add link-profile context that can inform link-building, digital PR, and competitor research alongside your keyword work.",
+          "Backlinks tell you whether a page ranks on content or on authority. Check them before targeting a keyword to judge whether you can realistically outrank the incumbents, and check a competitor's profile to find sites that might link to you too.",
       },
     ],
   },
@@ -377,12 +377,12 @@ export const featurePages = {
       {
         question: "Can OpenSEO help with competitor keyword analysis?",
         answer:
-          "Yes. Domain Overview is designed to reveal the keywords and topics a competitor is already visible for.",
+          "Yes. Enter a competitor's domain and you get the keywords it ranks for and its top organic pages: the raw material for finding topics worth building or defending.",
       },
       {
         question: "Is Domain Overview the same as a traffic checker?",
         answer:
-          "It includes traffic-oriented visibility metrics, but the bigger value is connecting that traffic estimate to ranking keywords and top pages.",
+          "Not quite. It includes an estimated-traffic metric, but the value is seeing which keywords and pages produce that traffic, which a plain traffic checker doesn't show.",
       },
     ],
   },
@@ -453,7 +453,7 @@ export const featurePages = {
       {
         question: "Does OpenSEO track mobile and desktop rankings?",
         answer:
-          "OpenSEO rank tracking can be configured for mobile, desktop, or both, so teams can compare devices when both are enabled.",
+          "Yes: mobile, desktop, or both. Each tracked domain is configured with the devices you want, and enabling both lets you compare them side by side.",
       },
       {
         question: "How should I choose keywords to track?",
@@ -530,7 +530,7 @@ export const featurePages = {
       {
         question: "How do saved keywords fit into SEO planning?",
         answer:
-          "Saved Keywords keeps promising ideas organized so they can inform content planning, rank tracking decisions, and future research.",
+          "Research fills the list, tags group it into pages and campaigns, and the shortlist feeds rank tracking. Saved keywords are the bridge between finding an opportunity and acting on it.",
       },
     ],
   },
@@ -669,7 +669,7 @@ export const featurePages = {
       {
         question: "Why does prompt research matter for SEO?",
         answer:
-          "Prompts reveal comparison, problem, and buying questions that can inform pages, guides, and the pages or domains that appear in returned citations.",
+          "Prompts are the new queries: they show the comparison, problem, and buying questions your customers now ask AI tools. The cited sources show which pages and domains those answers are built on, so you can see where your coverage is missing.",
       },
       {
         question: "Can this help with answer engine optimization?",

--- a/web/src/routes/_marketing/library/keyword-research/index.tsx
+++ b/web/src/routes/_marketing/library/keyword-research/index.tsx
@@ -59,7 +59,7 @@ const faqs = [
   {
     question: "How do you do keyword research for free?",
     answer:
-      "The entire workflow runs on free surfaces: conversations, autocomplete, People Also Ask, Search Console. OpenSEO itself is open source and free to try.",
+      "The discovery half runs on free surfaces: conversations, autocomplete, People Also Ask, Search Console. Quality SEO data (volume, difficulty, live SERPs) is difficult to get, which is why SaaS tools run $100/month and up. OpenSEO is the most affordable option, starting at $10/month, and you can start for free.",
   },
   {
     question: "Can you do keyword research without Google Keyword Planner?",
@@ -210,15 +210,17 @@ function KeywordResearchLibraryPage() {
           >
             OpenSEO's keyword research
           </a>
-          , connected to your live Search Console. Open source, free to try,
-          self-hostable, and scriptable through the{" "}
+          , connected to your live Search Console. Open source, self-hostable,
+          and scriptable through the{" "}
           <a
             href="/docs/mcp"
             className="font-medium text-neutral-950 underline decoration-[var(--color-brand-accent)] underline-offset-4"
           >
             MCP
           </a>{" "}
-          so your AI assistant can run the whole workflow. No trial clocks.
+          so your AI assistant can run the whole workflow. Quality SEO data is
+          why the big suites run $100/month and up; OpenSEO starts at $10/month,
+          and you can start for free.
         </p>
       </section>
 

--- a/web/src/routes/_marketing/library/keyword-research/index.tsx
+++ b/web/src/routes/_marketing/library/keyword-research/index.tsx
@@ -59,7 +59,7 @@ const faqs = [
   {
     question: "How do you do keyword research for free?",
     answer:
-      "The discovery half runs on free surfaces: conversations, autocomplete, People Also Ask, Search Console. Quality SEO data (volume, difficulty, live SERPs) is difficult to get, which is why SaaS tools run $100/month and up. OpenSEO is the most affordable option, starting at $10/month, and you can start for free.",
+      "The discovery half runs on sources you already have: customer conversations, Google's autocomplete and People Also Ask, and your Search Console. Quality SEO data (volume, difficulty, live SERPs) is difficult to get, which is why SaaS tools run $100/month and up. OpenSEO is the most affordable option, starting at $10/month, and you can start for free.",
   },
   {
     question: "Can you do keyword research without Google Keyword Planner?",
@@ -202,8 +202,8 @@ function KeywordResearchLibraryPage() {
           Free keyword research tools for every play
         </h2>
         <p className="mt-2 max-w-2xl text-sm leading-6 text-[var(--color-brand-muted)]">
-          The free surfaces (autocomplete, People Also Ask, your Search Console)
-          do the discovery. Every play then runs in{" "}
+          Google's free surfaces (autocomplete, People Also Ask) plus your own
+          Search Console do the discovery. Every play then runs in{" "}
           <a
             href="/features/keyword-research"
             className="font-medium text-neutral-950 underline decoration-[var(--color-brand-accent)] underline-offset-4"


### PR DESCRIPTION
Follow-up to #128, which merged and deployed with a few issues. This PR:

## Revert
- Reverts the unfinished feature-page Strategy Library redesign (practitioner-credits box + download card) back to the shipped guides section. The original work is preserved on the #128 head for re-landing when finished.

## Copy fixes
- Rephrases every place that implied OpenSEO is free, using the canonical framing: quality SEO data is why SaaS suites run $100/month+; OpenSEO starts at $10/month and you can start for free.
- Attributes free discovery surfaces to their real owners (Google's autocomplete and People Also Ask, your own Search Console) instead of implying they're OpenSEO features.
- Answers "is there a free X tool?" FAQs honestly ("Not an unlimited one", "For smaller sites, yes: 50 pages per crawl" — verified against `FREE_MAX_AUDIT_PAGES`).
- Rewrites hedgy feature-page FAQ answers to lead with the answer and name concrete things instead of "signals" and "context".
- Softens the intent auto-label claim (Google Ads fallback countries have no intent data).

## Skills
- New `openseo-review-web-content` skill: a short, judgment-first philosophy for writing on-brand, useful, accurate website content, distilled from the #128 review sessions.
- Vendors the MIT-licensed `deslop` skill so contributors get the AI-tell reference with a clone.
- De-personalizes `merge-ready` for external contributors and syncs its stale `.claude/` copy.
- Marks repo-development skills `metadata.internal: true` so `npx skills add every-app/open-seo` offers only the SEO skills; fixes the papercuts frontmatter YAML that broke the installer.

## Review notes
- Web typecheck passes; prettier clean on all touched files (4 pre-existing prettier failures in untouched files remain).
- Known open items from the #128 review deliberately NOT in this PR: library pages missing from the sitemap, the rightthing.agency outbound link, the unrendered guest byline, and the Finder "legally-mandated" claim.