### PR TITLE
fix(rank-tracking): add Check Now button to empty state

### DIFF
--- a/src/client/features/rank-tracking/RankTrackingDomainDetail.tsx
+++ b/src/client/features/rank-tracking/RankTrackingDomainDetail.tsx
@@ -186,6 +186,16 @@ export function RankTrackingDomainDetail({
   // Fall back to the table if history disappears (e.g. device switch).
   const effectiveViewMode = historyAvailable ? viewMode : "table";
 
+  const handleCheckNow = () => {
+    const count = costEstimate?.keywordCount ?? rows?.length ?? 0;
+    if (count > 0) {
+      requestCheck(count);
+      return;
+    }
+    setShowAddKeywords(true);
+    toast.info("Add keywords first, then check rankings");
+  };
+
   return (
     <div className="space-y-3">
       <button
@@ -287,10 +297,7 @@ export function RankTrackingDomainDetail({
             );
             toast.success("Keywords copied to clipboard");
           }}
-          onCheckNow={() => {
-            const count = costEstimate?.keywordCount ?? rows?.length ?? 0;
-            if (count > 0) requestCheck(count);
-          }}
+          onCheckNow={handleCheckNow}
           onRefreshMetrics={refreshMetrics}
           metricsRefreshing={metricsRefreshing}
           checkBusy={isBusy}
@@ -334,6 +341,9 @@ export function RankTrackingDomainDetail({
               locationCode={config.locationCode}
               locationName={config.locationName}
               serpDepth={config.serpDepth}
+              onCheckNow={handleCheckNow}
+              checkBusy={isBusy}
+              checkDisabled={isFreePlan}
             />
           )}
         </div>

--- a/src/client/features/rank-tracking/RankTrackingTable.tsx
+++ b/src/client/features/rank-tracking/RankTrackingTable.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useRef, useState } from "react";
 import { toast } from "sonner";
-import { FileDown, Loader2, Sheet, Trash2 } from "lucide-react";
+import { FileDown, Loader2, Play, Sheet, Trash2 } from "lucide-react";
 import { Modal } from "@/client/components/Modal";
 import {
   AppDataTable,
@@ -40,6 +40,9 @@ export function RankTrackingTable({
   locationCode,
   locationName,
   serpDepth,
+  onCheckNow,
+  checkBusy = false,
+  checkDisabled = false,
 }: {
   totalCount: number;
   rows: RankTrackingRow[];
@@ -53,6 +56,9 @@ export function RankTrackingTable({
   locationCode: number;
   locationName?: string | null;
   serpDepth: number;
+  onCheckNow?: () => void;
+  checkBusy?: boolean;
+  checkDisabled?: boolean;
 }) {
   const queryClient = useQueryClient();
   const [showConfirm, setShowConfirm] = useState(false);
@@ -157,10 +163,32 @@ export function RankTrackingTable({
 
   if (rows.length === 0) {
     return (
-      <div className="rounded-xl border border-dashed border-base-300 p-10 text-center text-sm text-base-content/55">
-        {totalCount === 0
-          ? 'No rank data yet. Click "Check Now" to run your first check.'
-          : "No keywords match your search."}
+      <div className="rounded-xl border border-dashed border-base-300 p-10 text-center text-sm text-base-content/55 space-y-4">
+        {totalCount === 0 ? (
+          <>
+            <p>
+              No rank data yet. Click &quot;Check Now&quot; to run your first
+              check.
+            </p>
+            {onCheckNow && !checkDisabled && (
+              <button
+                type="button"
+                className="btn btn-primary btn-sm gap-1.5"
+                onClick={onCheckNow}
+                disabled={checkBusy}
+              >
+                {checkBusy ? (
+                  <Loader2 className="size-3.5 animate-spin" />
+                ) : (
+                  <Play className="size-3.5" />
+                )}
+                {checkBusy ? "Running..." : "Check Now"}
+              </button>
+            )}
+          </>
+        ) : (
+          <p>No keywords match your search.</p>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
Related to #50

## Problem
When a rank tracker has no keywords yet, the table empty state says to click "Check Now", but that action only lives in the overflow menu next to Export — so the empty state points at a control that isn't visible.

## Fix
- Add a primary Check Now button on that empty state (same handler as the More menu).
- If there are still no keywords, open Add keywords and toast instead of starting an empty check.

## Verification
- `pnpm exec prettier --write` on the two touched files
- `pnpm exec tsc --noEmit`

Made with [Cursor](https://cursor.com)