### PR TITLE
feat(mcp): add/remove rank tracking keywords

### DIFF
--- a/src/server/mcp/server.ts
+++ b/src/server/mcp/server.ts
@@ -4,7 +4,9 @@ import { getBacklinksOverviewTool } from "@/server/mcp/tools/get-backlinks-overv
 import { getBacklinksProfileTool } from "@/server/mcp/tools/get-backlinks-profile";
 import { getDomainKeywordSuggestionsTool } from "@/server/mcp/tools/get-domain-keyword-suggestions";
 import { getDomainOverviewTool } from "@/server/mcp/tools/get-domain-overview";
+import { addRankTrackingKeywordsTool } from "@/server/mcp/tools/add-rank-tracking-keywords";
 import { getRankTrackerTool } from "@/server/mcp/tools/get-rank-tracker";
+import { removeRankTrackingKeywordsTool } from "@/server/mcp/tools/remove-rank-tracking-keywords";
 import { getSerpResultsTool } from "@/server/mcp/tools/get-serp-results";
 import { createProjectTool } from "@/server/mcp/tools/create-project";
 import { listProjectsTool } from "@/server/mcp/tools/list-projects";
@@ -143,6 +145,24 @@ export function registerOpenSeoMcpTools(server: McpServer) {
       getRankTrackerTool.name,
       getRankTrackerTool.config.outputSchema,
       getRankTrackerTool.handler,
+    ),
+  );
+  server.registerTool(
+    addRankTrackingKeywordsTool.name,
+    addRankTrackingKeywordsTool.config,
+    instrumentMcpToolHandler(
+      addRankTrackingKeywordsTool.name,
+      addRankTrackingKeywordsTool.config.outputSchema,
+      addRankTrackingKeywordsTool.handler,
+    ),
+  );
+  server.registerTool(
+    removeRankTrackingKeywordsTool.name,
+    removeRankTrackingKeywordsTool.config,
+    instrumentMcpToolHandler(
+      removeRankTrackingKeywordsTool.name,
+      removeRankTrackingKeywordsTool.config.outputSchema,
+      removeRankTrackingKeywordsTool.handler,
     ),
   );
   server.registerTool(

--- a/src/server/mcp/tools/add-rank-tracking-keywords.ts
+++ b/src/server/mcp/tools/add-rank-tracking-keywords.ts
@@ -1,0 +1,102 @@
+import { z } from "zod";
+import { RankTrackingRepository } from "@/server/features/rank-tracking/repositories/RankTrackingRepository";
+import { RankTrackingService } from "@/server/features/rank-tracking/services/RankTrackingService";
+import { mcpResponse } from "@/server/mcp/formatters";
+import { buildProjectMeta } from "@/server/mcp/context";
+import { optionalMetaOutputSchema } from "@/server/mcp/output-schemas";
+import { withMcpProjectAuth } from "@/server/mcp/project-auth";
+import { projectIdSchema } from "@/server/mcp/schemas";
+import {
+  estimateRankCheckCredits,
+  MAX_TRACKED_KEYWORD_LENGTH,
+} from "@/shared/rank-tracking";
+
+const inputSchema = {
+  projectId: projectIdSchema,
+  trackerId: z
+    .string()
+    .min(1)
+    .describe(
+      "Rank tracker config ID from get_rank_tracker (the `id` on each config).",
+    ),
+  keywords: z
+    .array(z.string().min(1).max(MAX_TRACKED_KEYWORD_LENGTH))
+    .min(1)
+    .max(2000)
+    .describe("Keywords to start tracking (1-2000). Duplicates are skipped."),
+} as const;
+
+type Args = z.infer<z.ZodObject<typeof inputSchema>>;
+
+export const addRankTrackingKeywordsTool = {
+  name: "add_rank_tracking_keywords",
+  config: {
+    title: "Add rank tracking keywords",
+    description:
+      "Add keywords to an existing rank tracker. Uses no credits on this call — keywords are stored only. Each later scheduled or manual check spends DataForSEO credits for every tracked keyword × device. Response includes a projected per-check cost for the tracker after the add (queued pricing when the tracker is scheduled; live pricing when schedule is manual). Does not start a check — use the dashboard Check Now for that. Get `trackerId` from get_rank_tracker.",
+    inputSchema,
+    outputSchema: {
+      projectId: z.string(),
+      trackerId: z.string(),
+      added: z.number(),
+      addedIds: z.array(z.string()),
+      keywordCount: z.number(),
+      costUsd: z.number(),
+      costCredits: z.number(),
+      costMethod: z.enum(["live", "queued"]),
+      scheduleInterval: z.string(),
+      ...optionalMetaOutputSchema,
+    },
+    annotations: {
+      readOnlyHint: false,
+      openWorldHint: false,
+      destructiveHint: false,
+    },
+  },
+  handler: withMcpProjectAuth(async (args: Args, context) => {
+    const { added, addedIds } = await RankTrackingService.addKeywords(
+      args.trackerId,
+      args.projectId,
+      args.keywords,
+    );
+    const config = await RankTrackingRepository.getConfigById({
+      configId: args.trackerId,
+      projectId: args.projectId,
+    });
+    if (!config) {
+      throw new Error(
+        `Rank tracker ${args.trackerId} not found in project ${args.projectId}.`,
+      );
+    }
+    const keywordCount = await RankTrackingRepository.getKeywordCountForConfig(
+      args.trackerId,
+    );
+    const costMethod = config.scheduleInterval === "manual" ? "live" : "queued";
+    const { costUsd, costCredits } = estimateRankCheckCredits(
+      keywordCount,
+      config.devices,
+      config.serpDepth,
+      costMethod,
+    );
+
+    return mcpResponse({
+      text: `Added ${added} keyword${added === 1 ? "" : "s"} to tracker ${args.trackerId} (${config.domain}). Now tracking ${keywordCount}. Projected ${costMethod} check: ~$${costUsd.toFixed(4)} (${costCredits} credits). No check was started.`,
+      meta: buildProjectMeta(
+        context,
+        args.projectId,
+        `/p/${args.projectId}/rank-tracking/${args.trackerId}`,
+      ),
+      structuredContent: {
+        projectId: args.projectId,
+        trackerId: args.trackerId,
+        added,
+        addedIds,
+        keywordCount,
+        costUsd,
+        costCredits,
+        costMethod,
+        scheduleInterval: config.scheduleInterval,
+      },
+    });
+  }),
+};

--- a/src/server/mcp/tools/get-rank-tracker.ts
+++ b/src/server/mcp/tools/get-rank-tracker.ts
@@ -46,7 +46,7 @@ export const getRankTrackerTool = {
   config: {
     title: "Get rank tracker",
     description:
-      "Read-only access to rank tracker configs and their latest results. With `trackerId`, returns config + latest snapshot per keyword. Without it, lists all trackers in the project. Uses no credits — reads from OpenSEO state, no DataForSEO call. To trigger a new check, use the dashboard.",
+      "Read-only access to rank tracker configs and their latest results. With `trackerId`, returns config + latest snapshot per keyword (including `trackingKeywordId` for remove_rank_tracking_keywords). Without it, lists all trackers in the project. Uses no credits — reads from OpenSEO state, no DataForSEO call. To add/remove keywords use add_rank_tracking_keywords / remove_rank_tracking_keywords. To trigger a new check, use the dashboard.",
     inputSchema,
     outputSchema: z
       .object({

--- a/src/server/mcp/tools/rank-tracking-write-tools.test.ts
+++ b/src/server/mcp/tools/rank-tracking-write-tools.test.ts
@@ -1,0 +1,177 @@
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import type { ToolExtra } from "@/server/mcp/context";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MCP_AUTH_CONTEXT_PROP } from "@/server/mcp/context";
+
+const mocks = vi.hoisted(() => ({
+  getProjectForOrganization: vi.fn(),
+  addKeywords: vi.fn(),
+  removeKeywords: vi.fn(),
+  getConfigById: vi.fn(),
+  getKeywordCountForConfig: vi.fn(),
+}));
+
+vi.mock("@/server/features/projects/services/ProjectService", () => ({
+  ProjectService: {
+    getProjectForOrganization: mocks.getProjectForOrganization,
+  },
+}));
+
+vi.mock("@/server/features/rank-tracking/services/RankTrackingService", () => ({
+  RankTrackingService: {
+    addKeywords: mocks.addKeywords,
+    removeKeywords: mocks.removeKeywords,
+  },
+}));
+
+vi.mock(
+  "@/server/features/rank-tracking/repositories/RankTrackingRepository",
+  () => ({
+    RankTrackingRepository: {
+      getConfigById: mocks.getConfigById,
+      getKeywordCountForConfig: mocks.getKeywordCountForConfig,
+    },
+  }),
+);
+
+const authContext = {
+  userId: "user_123",
+  userEmail: "alice@example.com",
+  organizationId: "org_123",
+  clientId: "client_123",
+  scopes: ["mcp"],
+  audience: "https://open-seo.test/mcp",
+  subject: "user_123",
+  baseUrl: "https://open-seo.test",
+};
+
+const toolExtra: ToolExtra = {
+  signal: new AbortController().signal,
+  requestId: 1,
+  sendNotification: vi.fn(),
+  sendRequest: vi.fn(),
+  authInfo: {
+    token: "token",
+    clientId: "client_123",
+    scopes: ["mcp"],
+    resource: new URL("https://open-seo.test/mcp"),
+    extra: { [MCP_AUTH_CONTEXT_PROP]: authContext },
+  } satisfies AuthInfo,
+};
+
+describe("rank tracking write MCP tools", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.getProjectForOrganization.mockReset();
+    mocks.getProjectForOrganization.mockResolvedValue({
+      id: "project_1",
+      locationCode: 2840,
+      languageCode: "en",
+    });
+    mocks.addKeywords.mockReset();
+    mocks.removeKeywords.mockReset();
+    mocks.getConfigById.mockReset();
+    mocks.getKeywordCountForConfig.mockReset();
+  });
+
+  it("adds keywords and returns a schedule-aware queued cost estimate", async () => {
+    mocks.addKeywords.mockResolvedValue({
+      added: 2,
+      addedIds: ["kw_1", "kw_2"],
+    });
+    mocks.getConfigById.mockResolvedValue({
+      id: "tracker_1",
+      domain: "acme.com",
+      devices: "both",
+      serpDepth: 10,
+      scheduleInterval: "weekly",
+    });
+    mocks.getKeywordCountForConfig.mockResolvedValue(12);
+    const { addRankTrackingKeywordsTool } =
+      await import("./add-rank-tracking-keywords");
+
+    const result = await addRankTrackingKeywordsTool.handler(
+      {
+        projectId: "project_1",
+        trackerId: "tracker_1",
+        keywords: ["seo audit", "technical seo"],
+      },
+      toolExtra,
+    );
+
+    expect(mocks.addKeywords).toHaveBeenCalledWith("tracker_1", "project_1", [
+      "seo audit",
+      "technical seo",
+    ]);
+    expect(mocks.removeKeywords).not.toHaveBeenCalled();
+    expect(result.structuredContent).toMatchObject({
+      added: 2,
+      addedIds: ["kw_1", "kw_2"],
+      keywordCount: 12,
+      costMethod: "queued",
+      scheduleInterval: "weekly",
+    });
+    expect(result.structuredContent).toHaveProperty("costUsd");
+    expect(result.structuredContent).toHaveProperty("costCredits");
+  });
+
+  it("uses live cost method when the tracker schedule is manual", async () => {
+    mocks.addKeywords.mockResolvedValue({ added: 1, addedIds: ["kw_1"] });
+    mocks.getConfigById.mockResolvedValue({
+      id: "tracker_1",
+      domain: "acme.com",
+      devices: "desktop",
+      serpDepth: 10,
+      scheduleInterval: "manual",
+    });
+    mocks.getKeywordCountForConfig.mockResolvedValue(1);
+    const { addRankTrackingKeywordsTool } =
+      await import("./add-rank-tracking-keywords");
+
+    const result = await addRankTrackingKeywordsTool.handler(
+      {
+        projectId: "project_1",
+        trackerId: "tracker_1",
+        keywords: ["seo"],
+      },
+      toolExtra,
+    );
+
+    expect(result.structuredContent).toMatchObject({
+      costMethod: "live",
+      scheduleInterval: "manual",
+    });
+  });
+
+  it("removes keywords by id without triggering a check", async () => {
+    mocks.removeKeywords.mockResolvedValue(undefined);
+    const { removeRankTrackingKeywordsTool } =
+      await import("./remove-rank-tracking-keywords");
+
+    const result = await removeRankTrackingKeywordsTool.handler(
+      {
+        projectId: "project_1",
+        trackerId: "tracker_1",
+        keywordIds: [
+          "11111111-1111-1111-1111-111111111111",
+          "22222222-2222-2222-2222-222222222222",
+        ],
+      },
+      toolExtra,
+    );
+
+    expect(mocks.removeKeywords).toHaveBeenCalledWith(
+      "tracker_1",
+      "project_1",
+      [
+        "11111111-1111-1111-1111-111111111111",
+        "22222222-2222-2222-2222-222222222222",
+      ],
+    );
+    expect(mocks.addKeywords).not.toHaveBeenCalled();
+    expect(result.structuredContent).toMatchObject({
+      removed: 2,
+      trackerId: "tracker_1",
+    });
+  });
+});

--- a/src/server/mcp/tools/remove-rank-tracking-keywords.ts
+++ b/src/server/mcp/tools/remove-rank-tracking-keywords.ts
@@ -1,0 +1,67 @@
+import { z } from "zod";
+import { RankTrackingService } from "@/server/features/rank-tracking/services/RankTrackingService";
+import { mcpResponse } from "@/server/mcp/formatters";
+import { buildProjectMeta } from "@/server/mcp/context";
+import { optionalMetaOutputSchema } from "@/server/mcp/output-schemas";
+import { withMcpProjectAuth } from "@/server/mcp/project-auth";
+import { projectIdSchema } from "@/server/mcp/schemas";
+
+const inputSchema = {
+  projectId: projectIdSchema,
+  trackerId: z
+    .string()
+    .min(1)
+    .describe(
+      "Rank tracker config ID from get_rank_tracker (the `id` on each config).",
+    ),
+  keywordIds: z
+    .array(z.string().uuid())
+    .min(1)
+    .max(2000)
+    .describe(
+      "Tracking keyword IDs to remove. Get `trackingKeywordId` values from get_rank_tracker structured results.",
+    ),
+} as const;
+
+type Args = z.infer<z.ZodObject<typeof inputSchema>>;
+
+export const removeRankTrackingKeywordsTool = {
+  name: "remove_rank_tracking_keywords",
+  config: {
+    title: "Remove rank tracking keywords",
+    description:
+      "Remove tracked keywords from a rank tracker by ID. Uses no credits. Pass `trackingKeywordId` values from get_rank_tracker (structured results.rows). Does not delete historical snapshots.",
+    inputSchema,
+    outputSchema: {
+      projectId: z.string(),
+      trackerId: z.string(),
+      removed: z.number(),
+      ...optionalMetaOutputSchema,
+    },
+    annotations: {
+      readOnlyHint: false,
+      openWorldHint: false,
+      destructiveHint: true,
+    },
+  },
+  handler: withMcpProjectAuth(async (args: Args, context) => {
+    await RankTrackingService.removeKeywords(
+      args.trackerId,
+      args.projectId,
+      args.keywordIds,
+    );
+    return mcpResponse({
+      text: `Removed ${args.keywordIds.length} keyword${args.keywordIds.length === 1 ? "" : "s"} from tracker ${args.trackerId}.`,
+      meta: buildProjectMeta(
+        context,
+        args.projectId,
+        `/p/${args.projectId}/rank-tracking/${args.trackerId}`,
+      ),
+      structuredContent: {
+        projectId: args.projectId,
+        trackerId: args.trackerId,
+        removed: args.keywordIds.length,
+      },
+    });
+  }),
+};


### PR DESCRIPTION
Related to #125

## Problem
Agents can read rank trackers via `get_rank_tracker`, but cannot add or remove tracked keywords without leaving MCP for the dashboard.

## Fix
- `add_rank_tracking_keywords` → `RankTrackingService.addKeywords`, with a schedule-aware projected check cost (queued vs live) after the add
- `remove_rank_tracking_keywords` → `RankTrackingService.removeKeywords` by `trackingKeywordId`
- No auto `triggerCheck` / metrics refresh (avoids silent credit spend)
- Out of scope: create/update config, `triggerCheck`

## Verification
- `pnpm exec prettier --write` on touched MCP files
- `pnpm exec vitest run src/server/mcp/tools/rank-tracking-write-tools.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm exec oxlint` on touched files (`--type-aware`)

Made with [Cursor](https://cursor.com)