### PR TITLE
fix(dev): set AUTH_MODE=local_noauth in local dev scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "type": "module",
   "packageManager": "pnpm@10.30.1",
   "scripts": {
-    "dev": "vite dev",
+    "dev": "AUTH_MODE=local_noauth vite dev",
     "dev:clear-chat": "rm -rf .wrangler/state/v3/do/open-seo-OnboardingChatAgent",
-    "dev:agents": "mkdir -p .logs && portless run vite dev 2>&1 | tee .logs/dev-server.log",
-    "dev:agents:force": "mkdir -p .logs && portless --force run vite dev 2>&1 | tee .logs/dev-server.log",
+    "dev:agents": "mkdir -p .logs && AUTH_MODE=local_noauth portless run vite dev 2>&1 | tee .logs/dev-server.log",
+    "dev:agents:force": "mkdir -p .logs && AUTH_MODE=local_noauth portless --force run vite dev 2>&1 | tee .logs/dev-server.log",
     "build": "vite build && tsc --noEmit",
     "lint": "oxlint . --type-aware",
     "lint:fix": "oxlint . --type-aware --fix",


### PR DESCRIPTION
## Problem

A fresh `pnpm dev` renders **"Authentication setup required"** instead of the app. The `dev`, `dev:agents`, and `dev:agents:force` scripts run `vite dev` without `AUTH_MODE`, so it defaults to `cloudflare_access` (`getAuthMode` in `src/lib/auth-mode.ts`) — which needs `TEAM_DOMAIN`/`POLICY_AUD` a local env lacks.

This contradicts `docs/LOCAL_DEVELOPMENT.md`, which already claims these scripts set `AUTH_MODE=local_noauth` automatically.

Fixes #146

## Change

Set `AUTH_MODE=local_noauth` inline in the three local dev scripts, using the same inline-env pattern already used by `alchemy` and `sourcemaps:upload`. No new dependency; makes the existing docs true.

```diff
-    "dev": "vite dev",
+    "dev": "AUTH_MODE=local_noauth vite dev",
```
(same for `dev:agents` and `dev:agents:force`)

## Verification

- With `AUTH_MODE` unset in `.env.local`, plain `pnpm run dev` now lands in the app as `admin@localhost` — no auth wall (verified via headless browser against http://localhost:3001).
- `pnpm ci:check` passes (prettier, knip, tsc ×2, oxlint).
- Explicit override still works: `AUTH_MODE=cloudflare_access pnpm dev` for testing Access locally.
