### PR TITLE
feat(mcp): add AI Search visibility and cited-sources tools

### DIFF
--- a/src/server/features/ai-search/services/brandLookup.ts
+++ b/src/server/features/ai-search/services/brandLookup.ts
@@ -1,5 +1,8 @@
 import { waitUntil } from "cloudflare:workers";
-import type { BillingCustomerContext } from "@/server/billing/subscription";
+import {
+  customerHasPaidPlan,
+  type BillingCustomerContext,
+} from "@/server/billing/subscription";
 import { createDataforseoClient } from "@/server/lib/dataforseo";
 import {
   buildLlmTarget,
@@ -9,6 +12,7 @@ import {
 } from "@/server/lib/dataforseo";
 import type { LlmCrossAggregatedItem } from "@/server/lib/dataforseoLlmSchemas";
 import { AppError } from "@/server/lib/errors";
+import { isHostedServerAuthMode } from "@/server/lib/runtime-env";
 import { buildCacheKey, getCached, setCached } from "@/server/lib/r2-cache";
 import {
   resolveCompetitorGroups,
@@ -48,6 +52,8 @@ export async function getBrandLookup(
   input: BrandLookupInput,
   billingCustomer: BillingCustomerContext,
 ): Promise<BrandLookupResult> {
+  await assertAiSearchPaidPlan(billingCustomer.organizationId);
+
   const detected = detectTarget(input.query);
   const competitorGroups = resolveCompetitorGroups(
     detected.value,
@@ -149,6 +155,18 @@ export async function getBrandLookup(
   }
 
   return result;
+}
+
+// Gated here, not only in the server function, so every caller — the UI's
+// server function and MCP tools alike — inherits the paid-plan check before
+// any DataForSEO spend. Mirrors AuditService's resolveAuditLimitTier.
+async function assertAiSearchPaidPlan(organizationId: string): Promise<void> {
+  if (!(await isHostedServerAuthMode())) return;
+  if (await customerHasPaidPlan(organizationId)) return;
+  throw new AppError(
+    "PAYMENT_REQUIRED",
+    "Upgrade to the paid plan to use AI Visibility",
+  );
 }
 
 async function settle<T>(

--- a/src/server/features/ai-search/services/promptExplorer.ts
+++ b/src/server/features/ai-search/services/promptExplorer.ts
@@ -1,8 +1,12 @@
 import { waitUntil } from "cloudflare:workers";
-import type { BillingCustomerContext } from "@/server/billing/subscription";
+import {
+  customerHasPaidPlan,
+  type BillingCustomerContext,
+} from "@/server/billing/subscription";
 import { createDataforseoClient } from "@/server/lib/dataforseo";
 import type { LlmResponseResult } from "@/server/lib/dataforseoLlmSchemas";
 import { AppError } from "@/server/lib/errors";
+import { isHostedServerAuthMode } from "@/server/lib/runtime-env";
 import { buildCacheKey, getCached, setCached } from "@/server/lib/r2-cache";
 import { safeHostname, safeHttpUrl } from "@/server/features/ai-search/safeUrl";
 import {
@@ -42,6 +46,8 @@ export async function explorePrompt(
   input: PromptExplorerInput,
   billingCustomer: BillingCustomerContext,
 ): Promise<PromptExplorerResult> {
+  await assertAiSearchPaidPlan(billingCustomer.organizationId);
+
   const dataforseo = createDataforseoClient(billingCustomer);
   const highlightBrand = input.highlightBrand?.trim() || null;
 
@@ -75,6 +81,19 @@ export async function explorePrompt(
     fetchedAt: new Date().toISOString(),
     results,
   };
+}
+
+// Gated here, not only in the server function, so every caller — the UI's
+// server function and MCP tools alike — inherits the paid-plan check before
+// any DataForSEO spend. Mirrors brandLookup.ts's assertAiSearchPaidPlan and
+// AuditService's resolveAuditLimitTier.
+async function assertAiSearchPaidPlan(organizationId: string): Promise<void> {
+  if (!(await isHostedServerAuthMode())) return;
+  if (await customerHasPaidPlan(organizationId)) return;
+  throw new AppError(
+    "PAYMENT_REQUIRED",
+    "Upgrade to the paid plan to use AI Visibility",
+  );
 }
 
 type RunModelArgs = {

--- a/src/server/mcp/server.ts
+++ b/src/server/mcp/server.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { instrumentMcpToolHandler } from "@/server/mcp/instrumentation";
 import {
   getAiSearchCitedSourcesTool,
+  getAiSearchPromptResultsTool,
   getAiSearchVisibilityTool,
 } from "@/server/mcp/tools/ai-search-tools";
 import { getBacklinksOverviewTool } from "@/server/mcp/tools/get-backlinks-overview";
@@ -273,6 +274,15 @@ export function registerOpenSeoMcpTools(server: McpServer) {
       getAiSearchCitedSourcesTool.name,
       getAiSearchCitedSourcesTool.config.outputSchema,
       getAiSearchCitedSourcesTool.handler,
+    ),
+  );
+  server.registerTool(
+    getAiSearchPromptResultsTool.name,
+    getAiSearchPromptResultsTool.config,
+    instrumentMcpToolHandler(
+      getAiSearchPromptResultsTool.name,
+      getAiSearchPromptResultsTool.config.outputSchema,
+      getAiSearchPromptResultsTool.handler,
     ),
   );
 }

--- a/src/server/mcp/server.ts
+++ b/src/server/mcp/server.ts
@@ -1,5 +1,9 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { instrumentMcpToolHandler } from "@/server/mcp/instrumentation";
+import {
+  getAiSearchCitedSourcesTool,
+  getAiSearchVisibilityTool,
+} from "@/server/mcp/tools/ai-search-tools";
 import { getBacklinksOverviewTool } from "@/server/mcp/tools/get-backlinks-overview";
 import { getBacklinksProfileTool } from "@/server/mcp/tools/get-backlinks-profile";
 import { getDomainKeywordSuggestionsTool } from "@/server/mcp/tools/get-domain-keyword-suggestions";
@@ -251,6 +255,24 @@ export function registerOpenSeoMcpTools(server: McpServer) {
       getAuditPagesTool.name,
       getAuditPagesTool.config.outputSchema,
       getAuditPagesTool.handler,
+    ),
+  );
+  server.registerTool(
+    getAiSearchVisibilityTool.name,
+    getAiSearchVisibilityTool.config,
+    instrumentMcpToolHandler(
+      getAiSearchVisibilityTool.name,
+      getAiSearchVisibilityTool.config.outputSchema,
+      getAiSearchVisibilityTool.handler,
+    ),
+  );
+  server.registerTool(
+    getAiSearchCitedSourcesTool.name,
+    getAiSearchCitedSourcesTool.config,
+    instrumentMcpToolHandler(
+      getAiSearchCitedSourcesTool.name,
+      getAiSearchCitedSourcesTool.config.outputSchema,
+      getAiSearchCitedSourcesTool.handler,
     ),
   );
 }

--- a/src/server/mcp/tools/ai-search-tools.test.ts
+++ b/src/server/mcp/tools/ai-search-tools.test.ts
@@ -2,11 +2,15 @@ import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ToolExtra } from "@/server/mcp/context";
 import { MCP_AUTH_CONTEXT_PROP } from "@/server/mcp/context";
-import type { BrandLookupResult } from "@/types/schemas/ai-search";
+import type {
+  BrandLookupResult,
+  PromptExplorerResult,
+} from "@/types/schemas/ai-search";
 
 const mocks = vi.hoisted(() => ({
   getProjectForOrganization: vi.fn(),
   getBrandLookup: vi.fn(),
+  explorePrompt: vi.fn(),
 }));
 
 vi.mock("cloudflare:workers", () => ({ env: {} }));
@@ -17,6 +21,9 @@ vi.mock("@/server/features/projects/services/ProjectService", () => ({
 }));
 vi.mock("@/server/features/ai-search/services/brandLookup", () => ({
   getBrandLookup: mocks.getBrandLookup,
+}));
+vi.mock("@/server/features/ai-search/services/promptExplorer", () => ({
+  explorePrompt: mocks.explorePrompt,
 }));
 
 const authContext = {
@@ -99,6 +106,38 @@ const baseResult: BrandLookupResult = {
   monthlyVolume: [{ year: 2026, month: 7, volume: 1200 }],
 };
 
+const basePromptResult: PromptExplorerResult = {
+  prompt: "what is acme",
+  highlightBrand: "acme",
+  fetchedAt: "2026-07-25T00:00:00.000Z",
+  results: [
+    {
+      status: "success",
+      model: "chat_gpt",
+      modelName: "gpt-5",
+      text: "Acme is a widget company.",
+      citations: [
+        {
+          url: "https://acme.com",
+          domain: "acme.com",
+          title: "Acme",
+          matchedBrand: true,
+        },
+      ],
+      fanOutQueries: ["what does acme sell"],
+      brandMentioned: true,
+      outputTokens: 128,
+      webSearch: true,
+    },
+    {
+      status: "error",
+      model: "claude",
+      errorCode: "UPSTREAM_ERROR",
+      message: "This model is temporarily unavailable. Please try again.",
+    },
+  ],
+};
+
 describe("AI Search MCP tools", () => {
   beforeEach(() => {
     mocks.getProjectForOrganization.mockReset();
@@ -108,6 +147,7 @@ describe("AI Search MCP tools", () => {
       languageCode: "en",
     });
     mocks.getBrandLookup.mockReset();
+    mocks.explorePrompt.mockReset();
   });
 
   it("get_ai_search_visibility returns mentions, share of voice, and no citation fields", async () => {
@@ -218,5 +258,99 @@ describe("AI Search MCP tools", () => {
       "No cited pages found.",
     );
     expect(text?.type === "text" && text.text).toContain("No prompts found.");
+  });
+
+  it("get_ai_search_prompt_results defaults to chat_gpt and renders per-model text and errors", async () => {
+    mocks.explorePrompt.mockResolvedValue(basePromptResult);
+    const { getAiSearchPromptResultsTool } = await import("./ai-search-tools");
+
+    const result = await getAiSearchPromptResultsTool.handler(
+      { projectId: "project_1", prompt: "what is acme" },
+      toolExtra,
+    );
+
+    expect(mocks.explorePrompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "project_1",
+        prompt: "what is acme",
+        models: ["chat_gpt"],
+      }),
+      expect.objectContaining({ organizationId: "org_123" }),
+    );
+    expect(result.structuredContent).toMatchObject({
+      prompt: "what is acme",
+      results: [
+        expect.objectContaining({ model: "chat_gpt", status: "success" }),
+        expect.objectContaining({ model: "claude", status: "error" }),
+      ],
+    });
+    const text = result.content?.[0];
+    expect(text?.type === "text" && text.text).toContain(
+      "Acme is a widget company.",
+    );
+    expect(text?.type === "text" && text.text).toContain(
+      "Citations: https://acme.com (acme.com)",
+    );
+    expect(text?.type === "text" && text.text).toContain(
+      "Error: This model is temporarily unavailable. Please try again.",
+    );
+    expect(text?.type === "text" && text.text).toContain(
+      "chat_gpt | success | yes | 1 | 128",
+    );
+  });
+
+  it("get_ai_search_prompt_results forwards explicit models and options", async () => {
+    mocks.explorePrompt.mockResolvedValue(basePromptResult);
+    const { getAiSearchPromptResultsTool } = await import("./ai-search-tools");
+
+    await getAiSearchPromptResultsTool.handler(
+      {
+        projectId: "project_1",
+        prompt: "what is acme",
+        models: ["claude", "gemini"],
+        highlightBrand: "acme",
+        webSearch: false,
+        webSearchCountryCode: "GB",
+      },
+      toolExtra,
+    );
+
+    expect(mocks.explorePrompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        models: ["claude", "gemini"],
+        highlightBrand: "acme",
+        webSearch: false,
+        webSearchCountryCode: "GB",
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("get_ai_search_prompt_results reports an empty response as such", async () => {
+    mocks.explorePrompt.mockResolvedValue({
+      ...basePromptResult,
+      results: [
+        {
+          status: "success",
+          model: "chat_gpt",
+          modelName: "gpt-5",
+          text: "",
+          citations: [],
+          fanOutQueries: [],
+          brandMentioned: null,
+          outputTokens: null,
+          webSearch: true,
+        },
+      ],
+    });
+    const { getAiSearchPromptResultsTool } = await import("./ai-search-tools");
+
+    const result = await getAiSearchPromptResultsTool.handler(
+      { projectId: "project_1", prompt: "what is acme" },
+      toolExtra,
+    );
+
+    const text = result.content?.[0];
+    expect(text?.type === "text" && text.text).toContain("(empty response)");
   });
 });

--- a/src/server/mcp/tools/ai-search-tools.test.ts
+++ b/src/server/mcp/tools/ai-search-tools.test.ts
@@ -1,0 +1,222 @@
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ToolExtra } from "@/server/mcp/context";
+import { MCP_AUTH_CONTEXT_PROP } from "@/server/mcp/context";
+import type { BrandLookupResult } from "@/types/schemas/ai-search";
+
+const mocks = vi.hoisted(() => ({
+  getProjectForOrganization: vi.fn(),
+  getBrandLookup: vi.fn(),
+}));
+
+vi.mock("cloudflare:workers", () => ({ env: {} }));
+vi.mock("@/server/features/projects/services/ProjectService", () => ({
+  ProjectService: {
+    getProjectForOrganization: mocks.getProjectForOrganization,
+  },
+}));
+vi.mock("@/server/features/ai-search/services/brandLookup", () => ({
+  getBrandLookup: mocks.getBrandLookup,
+}));
+
+const authContext = {
+  userId: "user_123",
+  userEmail: "alice@example.com",
+  organizationId: "org_123",
+  clientId: "client_123",
+  scopes: ["mcp"],
+  audience: "https://open-seo.test/mcp",
+  subject: "user_123",
+  baseUrl: "https://open-seo.test",
+};
+
+const toolExtra: ToolExtra = {
+  signal: new AbortController().signal,
+  requestId: 1,
+  sendNotification: vi.fn(),
+  sendRequest: vi.fn(),
+  authInfo: {
+    token: "token",
+    clientId: "client_123",
+    scopes: ["mcp"],
+    resource: new URL("https://open-seo.test/mcp"),
+    extra: { [MCP_AUTH_CONTEXT_PROP]: authContext },
+  } satisfies AuthInfo,
+};
+
+const baseResult: BrandLookupResult = {
+  query: "acme",
+  detectedTargetType: "keyword",
+  resolvedTarget: "acme",
+  fetchedAt: "2026-07-24T00:00:00.000Z",
+  hasData: true,
+  totalMentions: 42,
+  totalAiSearchVolume: 1200,
+  perPlatform: [
+    {
+      platform: "chat_gpt",
+      status: "success",
+      mentions: 30,
+      aiSearchVolume: 800,
+    },
+    {
+      platform: "google",
+      status: "success",
+      mentions: 12,
+      aiSearchVolume: 400,
+    },
+  ],
+  shareOfVoice: {
+    platforms: ["chat_gpt", "google"],
+    entries: [
+      { label: "acme", isTarget: true, mentions: 42, sharePct: 60 },
+      { label: "widgetco", isTarget: false, mentions: 28, sharePct: 40 },
+    ],
+  },
+  topPages: [
+    {
+      url: "https://acme.com/pricing",
+      domain: "acme.com",
+      platform: "chat_gpt",
+      mentions: 10,
+      capturedVolume: 300,
+      keywords: [{ question: "how much is acme", aiSearchVolume: 50 }],
+    },
+  ],
+  topQueries: [
+    {
+      question: "what is acme",
+      platform: "chat_gpt",
+      aiSearchVolume: 100,
+      firstSeenAt: "2026-06-01T00:00:00.000Z",
+      lastSeenAt: "2026-07-01T00:00:00.000Z",
+      citedSources: [
+        { url: "https://acme.com", domain: "acme.com", title: "Acme" },
+      ],
+      brandsMentioned: ["acme", "widgetco"],
+    },
+  ],
+  monthlyVolume: [{ year: 2026, month: 7, volume: 1200 }],
+};
+
+describe("AI Search MCP tools", () => {
+  beforeEach(() => {
+    mocks.getProjectForOrganization.mockReset();
+    mocks.getProjectForOrganization.mockResolvedValue({
+      id: "project_1",
+      locationCode: 2840,
+      languageCode: "en",
+    });
+    mocks.getBrandLookup.mockReset();
+  });
+
+  it("get_ai_search_visibility returns mentions, share of voice, and no citation fields", async () => {
+    mocks.getBrandLookup.mockResolvedValue(baseResult);
+    const { getAiSearchVisibilityTool } = await import("./ai-search-tools");
+
+    const result = await getAiSearchVisibilityTool.handler(
+      { projectId: "project_1", query: "acme", competitors: ["widgetco"] },
+      toolExtra,
+    );
+
+    expect(mocks.getBrandLookup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "project_1",
+        query: "acme",
+        competitors: ["widgetco"],
+        locationCode: 2840,
+        languageCode: "en",
+      }),
+      expect.objectContaining({ organizationId: "org_123" }),
+    );
+    expect(result.structuredContent).toMatchObject({
+      totalMentions: 42,
+      totalAiSearchVolume: 1200,
+      shareOfVoice: { platforms: ["chat_gpt", "google"] },
+    });
+    expect(result.structuredContent).not.toHaveProperty("topPages");
+    expect(result.structuredContent).not.toHaveProperty("topQueries");
+    const text = result.content?.[0];
+    expect(text?.type === "text" && text.text).toContain("Total mentions: 42");
+    expect(text?.type === "text" && text.text).toContain("Share of Voice");
+    expect(text?.type === "text" && text.text).toContain(
+      "acme (target) | 42 | 60",
+    );
+  });
+
+  it("get_ai_search_visibility notes when Share of Voice failed despite requested competitors", async () => {
+    mocks.getBrandLookup.mockResolvedValue({
+      ...baseResult,
+      shareOfVoice: null,
+    });
+    const { getAiSearchVisibilityTool } = await import("./ai-search-tools");
+
+    const result = await getAiSearchVisibilityTool.handler(
+      { projectId: "project_1", query: "acme", competitors: ["widgetco"] },
+      toolExtra,
+    );
+
+    const text = result.content?.[0];
+    expect(text?.type === "text" && text.text).toContain(
+      "Share of Voice unavailable",
+    );
+  });
+
+  it("get_ai_search_visibility defaults competitors to an empty list when omitted", async () => {
+    mocks.getBrandLookup.mockResolvedValue(baseResult);
+    const { getAiSearchVisibilityTool } = await import("./ai-search-tools");
+
+    await getAiSearchVisibilityTool.handler(
+      { projectId: "project_1", query: "acme" },
+      toolExtra,
+    );
+
+    expect(mocks.getBrandLookup).toHaveBeenCalledWith(
+      expect.objectContaining({ competitors: [] }),
+      expect.anything(),
+    );
+  });
+
+  it("get_ai_search_cited_sources returns cited pages and prompts, and no mention totals", async () => {
+    mocks.getBrandLookup.mockResolvedValue(baseResult);
+    const { getAiSearchCitedSourcesTool } = await import("./ai-search-tools");
+
+    const result = await getAiSearchCitedSourcesTool.handler(
+      { projectId: "project_1", query: "acme" },
+      toolExtra,
+    );
+
+    expect(result.structuredContent).toMatchObject({
+      topPages: [expect.objectContaining({ url: "https://acme.com/pricing" })],
+      topQueries: [expect.objectContaining({ question: "what is acme" })],
+    });
+    expect(result.structuredContent).not.toHaveProperty("totalMentions");
+    expect(result.structuredContent).not.toHaveProperty("shareOfVoice");
+    const text = result.content?.[0];
+    expect(text?.type === "text" && text.text).toContain(
+      "https://acme.com/pricing",
+    );
+    expect(text?.type === "text" && text.text).toContain("what is acme");
+  });
+
+  it("get_ai_search_cited_sources reports no cited pages/prompts found", async () => {
+    mocks.getBrandLookup.mockResolvedValue({
+      ...baseResult,
+      hasData: false,
+      topPages: [],
+      topQueries: [],
+    });
+    const { getAiSearchCitedSourcesTool } = await import("./ai-search-tools");
+
+    const result = await getAiSearchCitedSourcesTool.handler(
+      { projectId: "project_1", query: "acme" },
+      toolExtra,
+    );
+
+    const text = result.content?.[0];
+    expect(text?.type === "text" && text.text).toContain(
+      "No cited pages found.",
+    );
+    expect(text?.type === "text" && text.text).toContain("No prompts found.");
+  });
+});

--- a/src/server/mcp/tools/ai-search-tools.ts
+++ b/src/server/mcp/tools/ai-search-tools.ts
@@ -1,0 +1,227 @@
+import { z } from "zod";
+import type { BillingCustomerContext } from "@/server/billing/subscription";
+import { getBrandLookup } from "@/server/features/ai-search/services/brandLookup";
+import {
+  BRAND_LOOKUP_MAX_INPUT_LENGTH,
+  brandLookupInputSchema,
+  brandLookupResultSchema,
+} from "@/types/schemas/ai-search";
+import { mcpResponse } from "@/server/mcp/formatters";
+import { buildProjectMeta } from "@/server/mcp/context";
+import { optionalMetaOutputSchema } from "@/server/mcp/output-schemas";
+import { withMcpProjectAuth } from "@/server/mcp/project-auth";
+import { formatMcpTable, type McpTableColumn } from "@/server/mcp/table";
+import { projectIdSchema } from "@/server/mcp/schemas";
+
+// Brand Lookup only ever queries US/en (2840/"en") today — that's what the
+// dashboard's Brand Lookup page hardcodes, and DataForSEO's ChatGPT mentions
+// data is US/en-only regardless of what's requested. Keeping the same fixed
+// market here avoids exposing an MCP surface the product doesn't otherwise
+// support or test.
+const BRAND_LOOKUP_LOCATION_CODE = 2840;
+const BRAND_LOOKUP_LANGUAGE_CODE = "en";
+
+const inputSchema = {
+  projectId: projectIdSchema,
+  query: z
+    .string()
+    .trim()
+    .min(1)
+    .max(BRAND_LOOKUP_MAX_INPUT_LENGTH)
+    .describe(
+      "Brand name, keyword, or domain to look up (e.g. 'Semrush' or 'semrush.com').",
+    ),
+  competitors: z
+    .array(z.string().trim().min(1).max(BRAND_LOOKUP_MAX_INPUT_LENGTH))
+    .max(5)
+    .optional()
+    .describe(
+      "Up to 5 competitor brands/domains to compare Share of Voice against. Omit for mention counts only, with no comparison.",
+    ),
+} as const;
+
+type Args = z.infer<z.ZodObject<typeof inputSchema>>;
+
+/**
+ * Both tools below read the same underlying Brand Lookup result (shared
+ * ChatGPT + Google AI Overview mentions fetch, R2-cached for 24h per
+ * project/target/competitor set) and each project a different slice of it —
+ * mirroring the split the dashboard doesn't need but two focused MCP tools
+ * do, so an agent asking only "who's winning share of voice" doesn't also
+ * have to receive every cited URL.
+ */
+async function fetchBrandLookup(args: Args, billing: BillingCustomerContext) {
+  const input = brandLookupInputSchema.parse({
+    projectId: args.projectId,
+    query: args.query,
+    competitors: args.competitors,
+    locationCode: BRAND_LOOKUP_LOCATION_CODE,
+    languageCode: BRAND_LOOKUP_LANGUAGE_CODE,
+  });
+  return getBrandLookup(input, billing);
+}
+
+const PLATFORM_COLUMNS: McpTableColumn<{
+  platform: string;
+  status: string;
+  mentions: number | null;
+  aiSearchVolume: number | null;
+}>[] = [
+  { header: "platform", value: (row) => row.platform },
+  { header: "status", value: (row) => row.status },
+  { header: "mentions", value: (row) => row.mentions },
+  { header: "AI search volume", value: (row) => row.aiSearchVolume },
+];
+
+export const getAiSearchVisibilityTool = {
+  name: "get_ai_search_visibility",
+  config: {
+    title: "Get AI Search visibility",
+    description:
+      "Brand mention counts and AI search volume for a brand, keyword, or domain across ChatGPT and Google AI Overview, plus Share of Voice against up to 5 named competitors. Fixed to the US/en market, matching the dashboard's Brand Lookup page. Calls DataForSEO's LLM Mentions API — charges credits on a cache miss, then cached 24h per project/query/competitor set. For the URLs cited as sources, use get_ai_search_cited_sources instead.",
+    inputSchema,
+    outputSchema: brandLookupResultSchema
+      .omit({ topPages: true, topQueries: true })
+      .extend(optionalMetaOutputSchema)
+      .passthrough(),
+    annotations: {
+      readOnlyHint: false,
+      openWorldHint: false,
+      destructiveHint: false,
+    },
+  },
+  handler: withMcpProjectAuth(async (args: Args, context) => {
+    const result = await fetchBrandLookup(args, context.billing);
+    const lines = [
+      `Query: ${result.query} (detected ${result.detectedTargetType}: ${result.resolvedTarget})`,
+      result.hasData
+        ? `Total mentions: ${result.totalMentions ?? "?"}, AI search volume: ${result.totalAiSearchVolume ?? "?"}`
+        : "No AI Search data found for this target.",
+      "",
+      "By platform:",
+      formatMcpTable(result.perPlatform, PLATFORM_COLUMNS),
+    ];
+    if (result.shareOfVoice) {
+      lines.push(
+        "",
+        `Share of Voice (${result.shareOfVoice.platforms.join(", ")}):`,
+        formatMcpTable(result.shareOfVoice.entries, [
+          {
+            header: "label",
+            value: (row) =>
+              row.isTarget ? `${row.label} (target)` : row.label,
+          },
+          { header: "mentions", value: (row) => row.mentions },
+          { header: "share %", value: (row) => row.sharePct },
+        ]),
+      );
+    } else if (args.competitors?.length) {
+      lines.push(
+        "",
+        "Share of Voice unavailable (both platform calls failed for the competitor comparison).",
+      );
+    }
+    return mcpResponse({
+      text: lines.join("\n"),
+      meta: buildProjectMeta(
+        context,
+        args.projectId,
+        `/p/${args.projectId}/brand-lookup`,
+        { q: args.query, c: args.competitors?.join(",") },
+      ),
+      structuredContent: {
+        query: result.query,
+        detectedTargetType: result.detectedTargetType,
+        resolvedTarget: result.resolvedTarget,
+        fetchedAt: result.fetchedAt,
+        hasData: result.hasData,
+        totalMentions: result.totalMentions,
+        totalAiSearchVolume: result.totalAiSearchVolume,
+        perPlatform: result.perPlatform,
+        shareOfVoice: result.shareOfVoice,
+        monthlyVolume: result.monthlyVolume,
+      },
+    });
+  }),
+};
+
+const CITED_PAGE_COLUMNS: McpTableColumn<{
+  url: string;
+  platform: string;
+  mentions: number | null;
+  capturedVolume: number | null;
+}>[] = [
+  { header: "url", value: (row) => row.url },
+  { header: "platform", value: (row) => row.platform },
+  { header: "mentions", value: (row) => row.mentions },
+  { header: "AI search volume", value: (row) => row.capturedVolume },
+];
+
+export const getAiSearchCitedSourcesTool = {
+  name: "get_ai_search_cited_sources",
+  config: {
+    title: "Get AI Search cited sources",
+    description:
+      "Which URLs get cited as sources in ChatGPT and Google AI Overview answers about a brand, keyword, or domain, plus the underlying prompts/questions and the other brands mentioned alongside each one. Fixed to the US/en market, matching the dashboard's Brand Lookup page. Calls DataForSEO's LLM Mentions API — charges credits on a cache miss, then cached 24h per project/query/competitor set. For mention counts and Share of Voice, use get_ai_search_visibility instead.",
+    inputSchema,
+    outputSchema: brandLookupResultSchema
+      .pick({
+        query: true,
+        detectedTargetType: true,
+        resolvedTarget: true,
+        fetchedAt: true,
+        hasData: true,
+        topPages: true,
+        topQueries: true,
+      })
+      .extend(optionalMetaOutputSchema)
+      .passthrough(),
+    annotations: {
+      readOnlyHint: false,
+      openWorldHint: false,
+      destructiveHint: false,
+    },
+  },
+  handler: withMcpProjectAuth(async (args: Args, context) => {
+    const result = await fetchBrandLookup(args, context.billing);
+    const lines = [
+      `Query: ${result.query} (detected ${result.detectedTargetType}: ${result.resolvedTarget})`,
+      "",
+      `Cited pages (${result.topPages.length}):`,
+      result.topPages.length === 0
+        ? "No cited pages found."
+        : formatMcpTable(result.topPages, CITED_PAGE_COLUMNS),
+      "",
+      `Prompts sampled (${result.topQueries.length}):`,
+      result.topQueries.length === 0
+        ? "No prompts found."
+        : formatMcpTable(result.topQueries, [
+            { header: "question", value: (row) => row.question },
+            { header: "platform", value: (row) => row.platform },
+            {
+              header: "cited domains",
+              value: (row) =>
+                row.citedSources.map((s) => s.domain ?? s.url).join(", "),
+            },
+          ]),
+    ];
+    return mcpResponse({
+      text: lines.join("\n"),
+      meta: buildProjectMeta(
+        context,
+        args.projectId,
+        `/p/${args.projectId}/brand-lookup`,
+        { q: args.query, c: args.competitors?.join(",") },
+      ),
+      structuredContent: {
+        query: result.query,
+        detectedTargetType: result.detectedTargetType,
+        resolvedTarget: result.resolvedTarget,
+        fetchedAt: result.fetchedAt,
+        hasData: result.hasData,
+        topPages: result.topPages,
+        topQueries: result.topQueries,
+      },
+    });
+  }),
+};

--- a/src/server/mcp/tools/ai-search-tools.ts
+++ b/src/server/mcp/tools/ai-search-tools.ts
@@ -21,7 +21,7 @@ import { projectIdSchema } from "@/server/mcp/schemas";
 const BRAND_LOOKUP_LOCATION_CODE = 2840;
 const BRAND_LOOKUP_LANGUAGE_CODE = "en";
 
-const inputSchema = {
+const baseInputSchema = {
   projectId: projectIdSchema,
   query: z
     .string()
@@ -31,16 +31,22 @@ const inputSchema = {
     .describe(
       "Brand name, keyword, or domain to look up (e.g. 'Semrush' or 'semrush.com').",
     ),
+} as const;
+
+type BaseArgs = z.infer<z.ZodObject<typeof baseInputSchema>>;
+
+const visibilityInputSchema = {
+  ...baseInputSchema,
   competitors: z
     .array(z.string().trim().min(1).max(BRAND_LOOKUP_MAX_INPUT_LENGTH))
     .max(5)
     .optional()
     .describe(
-      "Up to 5 competitor brands/domains to compare Share of Voice against. Omit for mention counts only, with no comparison.",
+      "Up to 5 competitor brands/domains to compare Share of Voice against. Omit for mention counts only, with no comparison. Each named competitor runs an extra paid cross-aggregated lookup per platform.",
     ),
 } as const;
 
-type Args = z.infer<z.ZodObject<typeof inputSchema>>;
+type VisibilityArgs = z.infer<z.ZodObject<typeof visibilityInputSchema>>;
 
 /**
  * Both tools below read the same underlying Brand Lookup result (shared
@@ -49,8 +55,16 @@ type Args = z.infer<z.ZodObject<typeof inputSchema>>;
  * mirroring the split the dashboard doesn't need but two focused MCP tools
  * do, so an agent asking only "who's winning share of voice" doesn't also
  * have to receive every cited URL.
+ *
+ * `competitors` is only accepted by get_ai_search_visibility: passing it adds
+ * a paid cross-aggregated Share-of-Voice call per platform, and
+ * get_ai_search_cited_sources has nowhere to surface that data — accepting it
+ * there would silently spend credits on a result the caller never sees.
  */
-async function fetchBrandLookup(args: Args, billing: BillingCustomerContext) {
+async function fetchBrandLookup(
+  args: BaseArgs & { competitors?: string[] },
+  billing: BillingCustomerContext,
+) {
   const input = brandLookupInputSchema.parse({
     projectId: args.projectId,
     query: args.query,
@@ -79,7 +93,7 @@ export const getAiSearchVisibilityTool = {
     title: "Get AI Search visibility",
     description:
       "Brand mention counts and AI search volume for a brand, keyword, or domain across ChatGPT and Google AI Overview, plus Share of Voice against up to 5 named competitors. Fixed to the US/en market, matching the dashboard's Brand Lookup page. Calls DataForSEO's LLM Mentions API — charges credits on a cache miss, then cached 24h per project/query/competitor set. For the URLs cited as sources, use get_ai_search_cited_sources instead.",
-    inputSchema,
+    inputSchema: visibilityInputSchema,
     outputSchema: brandLookupResultSchema
       .omit({ topPages: true, topQueries: true })
       .extend(optionalMetaOutputSchema)
@@ -90,7 +104,7 @@ export const getAiSearchVisibilityTool = {
       destructiveHint: false,
     },
   },
-  handler: withMcpProjectAuth(async (args: Args, context) => {
+  handler: withMcpProjectAuth(async (args: VisibilityArgs, context) => {
     const result = await fetchBrandLookup(args, context.billing);
     const lines = [
       `Query: ${result.query} (detected ${result.detectedTargetType}: ${result.resolvedTarget})`,
@@ -162,8 +176,8 @@ export const getAiSearchCitedSourcesTool = {
   config: {
     title: "Get AI Search cited sources",
     description:
-      "Which URLs get cited as sources in ChatGPT and Google AI Overview answers about a brand, keyword, or domain, plus the underlying prompts/questions and the other brands mentioned alongside each one. Fixed to the US/en market, matching the dashboard's Brand Lookup page. Calls DataForSEO's LLM Mentions API — charges credits on a cache miss, then cached 24h per project/query/competitor set. For mention counts and Share of Voice, use get_ai_search_visibility instead.",
-    inputSchema,
+      "Which URLs get cited as sources in ChatGPT and Google AI Overview answers about a brand, keyword, or domain, plus the underlying prompts/questions and the other brands mentioned alongside each one. Fixed to the US/en market, matching the dashboard's Brand Lookup page. Takes no competitors — it doesn't report Share of Voice, so it never runs the paid competitor comparison; use get_ai_search_visibility for that. Calls DataForSEO's LLM Mentions API — charges credits on a cache miss, then cached 24h per project/query.",
+    inputSchema: baseInputSchema,
     outputSchema: brandLookupResultSchema
       .pick({
         query: true,
@@ -182,7 +196,7 @@ export const getAiSearchCitedSourcesTool = {
       destructiveHint: false,
     },
   },
-  handler: withMcpProjectAuth(async (args: Args, context) => {
+  handler: withMcpProjectAuth(async (args: BaseArgs, context) => {
     const result = await fetchBrandLookup(args, context.billing);
     const lines = [
       `Query: ${result.query} (detected ${result.detectedTargetType}: ${result.resolvedTarget})`,
@@ -211,7 +225,7 @@ export const getAiSearchCitedSourcesTool = {
         context,
         args.projectId,
         `/p/${args.projectId}/brand-lookup`,
-        { q: args.query, c: args.competitors?.join(",") },
+        { q: args.query },
       ),
       structuredContent: {
         query: result.query,

--- a/src/server/mcp/tools/ai-search-tools.ts
+++ b/src/server/mcp/tools/ai-search-tools.ts
@@ -1,10 +1,17 @@
 import { z } from "zod";
 import type { BillingCustomerContext } from "@/server/billing/subscription";
 import { getBrandLookup } from "@/server/features/ai-search/services/brandLookup";
+import { explorePrompt } from "@/server/features/ai-search/services/promptExplorer";
 import {
   BRAND_LOOKUP_MAX_INPUT_LENGTH,
   brandLookupInputSchema,
   brandLookupResultSchema,
+  promptExplorerInputSchema,
+  promptExplorerModelSchema,
+  promptExplorerResultSchema,
+  PROMPT_EXPLORER_MAX_PROMPT_LENGTH,
+  webSearchCountryCodeSchema,
+  type PromptExplorerModel,
 } from "@/types/schemas/ai-search";
 import { mcpResponse } from "@/server/mcp/formatters";
 import { buildProjectMeta } from "@/server/mcp/context";
@@ -236,6 +243,147 @@ export const getAiSearchCitedSourcesTool = {
         topPages: result.topPages,
         topQueries: result.topQueries,
       },
+    });
+  }),
+};
+
+const promptResultsInputSchema = {
+  projectId: projectIdSchema,
+  prompt: z
+    .string()
+    .trim()
+    .min(1)
+    .max(PROMPT_EXPLORER_MAX_PROMPT_LENGTH)
+    .describe("The prompt/question to ask each model, verbatim."),
+  models: z
+    .array(promptExplorerModelSchema)
+    .min(1)
+    .max(4)
+    .optional()
+    .describe(
+      "Which LLMs to ask: 'chat_gpt', 'claude', 'gemini', 'perplexity' (1-4, deduped). Each model is a separate paid call. Defaults to just 'chat_gpt' to keep an unspecified call cheap.",
+    ),
+  highlightBrand: z
+    .string()
+    .trim()
+    .min(1)
+    .max(BRAND_LOOKUP_MAX_INPUT_LENGTH)
+    .optional()
+    .describe(
+      "Brand to check for in each answer and its citations. Sets brandMentioned per model result; omit to leave it null.",
+    ),
+  webSearch: z
+    .boolean()
+    .optional()
+    .describe("Allow each model to use web search. Defaults to true."),
+  webSearchCountryCode: webSearchCountryCodeSchema
+    .optional()
+    .describe(
+      "ISO-2 country code for the web-search component of the answer (e.g. 'US', 'GB'). Affects results when webSearch is true.",
+    ),
+} as const;
+
+type PromptResultsArgs = z.infer<z.ZodObject<typeof promptResultsInputSchema>>;
+
+const DEFAULT_PROMPT_EXPLORER_MODELS: PromptExplorerModel[] = ["chat_gpt"];
+
+async function fetchPromptResults(
+  args: PromptResultsArgs,
+  billing: BillingCustomerContext,
+) {
+  const input = promptExplorerInputSchema.parse({
+    projectId: args.projectId,
+    prompt: args.prompt,
+    models: args.models ?? DEFAULT_PROMPT_EXPLORER_MODELS,
+    highlightBrand: args.highlightBrand,
+    webSearch: args.webSearch,
+    webSearchCountryCode: args.webSearchCountryCode,
+  });
+  return explorePrompt(input, billing);
+}
+
+type ModelSummaryRow = {
+  model: string;
+  status: string;
+  brandMentioned: string;
+  citations: number | string;
+  outputTokens: number | string | null;
+};
+
+const MODEL_SUMMARY_COLUMNS: McpTableColumn<ModelSummaryRow>[] = [
+  { header: "model", value: (row) => row.model },
+  { header: "status", value: (row) => row.status },
+  { header: "brand mentioned", value: (row) => row.brandMentioned },
+  { header: "citations", value: (row) => row.citations },
+  { header: "output tokens", value: (row) => row.outputTokens },
+];
+
+export const getAiSearchPromptResultsTool = {
+  name: "get_ai_search_prompt_results",
+  config: {
+    title: "Get AI Search prompt results",
+    description:
+      "Ask one prompt across up to 4 LLMs (ChatGPT, Claude, Gemini, Perplexity) and return each model's raw answer, citations, and follow-up fan-out queries — for inspecting exactly what an AI assistant says in response to a specific question, rather than aggregate visibility. For brand mention counts and Share of Voice, use get_ai_search_visibility instead. Each requested model is a separate paid DataForSEO call, cached 7 days per (model, prompt, web search settings) tuple; defaults to just 'chat_gpt' when models is omitted to keep an unspecified call cheap.",
+    inputSchema: promptResultsInputSchema,
+    outputSchema: promptExplorerResultSchema
+      .extend(optionalMetaOutputSchema)
+      .passthrough(),
+    annotations: {
+      readOnlyHint: false,
+      openWorldHint: false,
+      destructiveHint: false,
+    },
+  },
+  handler: withMcpProjectAuth(async (args: PromptResultsArgs, context) => {
+    const result = await fetchPromptResults(args, context.billing);
+    const summaryRows: ModelSummaryRow[] = result.results.map((r) =>
+      r.status === "success"
+        ? {
+            model: r.model,
+            status: "success",
+            brandMentioned:
+              r.brandMentioned == null ? "—" : r.brandMentioned ? "yes" : "no",
+            citations: r.citations.length,
+            outputTokens: r.outputTokens,
+          }
+        : {
+            model: r.model,
+            status: "error",
+            brandMentioned: "—",
+            citations: "—",
+            outputTokens: "—",
+          },
+    );
+    const lines = [
+      `Prompt: ${result.prompt}`,
+      `Highlight brand: ${result.highlightBrand ?? "none"}`,
+      "",
+      formatMcpTable(summaryRows, MODEL_SUMMARY_COLUMNS),
+    ];
+    for (const modelResult of result.results) {
+      lines.push("", `--- ${modelResult.model} ---`);
+      if (modelResult.status === "error") {
+        lines.push(`Error: ${modelResult.message}`);
+        continue;
+      }
+      lines.push(modelResult.text || "(empty response)");
+      if (modelResult.citations.length > 0) {
+        lines.push(
+          "Citations: " +
+            modelResult.citations
+              .map((c) => `${c.url} (${c.domain ?? "?"})`)
+              .join(", "),
+        );
+      }
+    }
+    return mcpResponse({
+      text: lines.join("\n"),
+      meta: buildProjectMeta(
+        context,
+        args.projectId,
+        `/p/${args.projectId}/prompt-explorer`,
+      ),
+      structuredContent: result,
     });
   }),
 };

--- a/src/serverFunctions/ai-search.ts
+++ b/src/serverFunctions/ai-search.ts
@@ -28,7 +28,8 @@ export const lookupBrand = createServerFn({ method: "POST" })
   .middleware(requireProjectContext)
   .validator(brandLookupInputSchema)
   .handler(async ({ data, context }) => {
-    await assertPaidPlan(context.organizationId);
+    // getBrandLookup self-gates on the paid plan so MCP callers inherit the
+    // same check; no need to duplicate it here.
     return getBrandLookup({ ...data, projectId: context.projectId }, context);
   });
 

--- a/src/serverFunctions/ai-search.ts
+++ b/src/serverFunctions/ai-search.ts
@@ -1,28 +1,11 @@
 import { createServerFn } from "@tanstack/react-start";
 import { getBrandLookup } from "@/server/features/ai-search/services/brandLookup";
 import { explorePrompt as runExplorePrompt } from "@/server/features/ai-search/services/promptExplorer";
-import { customerHasPaidPlan } from "@/server/billing/subscription";
-import { AppError } from "@/server/lib/errors";
-import { isHostedServerAuthMode } from "@/server/lib/runtime-env";
 import { requireProjectContext } from "@/serverFunctions/middleware";
 import {
   brandLookupInputSchema,
   promptExplorerInputSchema,
 } from "@/types/schemas/ai-search";
-
-/**
- * AI Visibility endpoints are gated behind the paid plan in hosted mode
- * because each call fans out to several paid DataForSEO requests. Self-hosted
- * deployments pay DataForSEO directly and aren't gated.
- */
-async function assertPaidPlan(organizationId: string) {
-  if (!(await isHostedServerAuthMode())) return;
-  if (await customerHasPaidPlan(organizationId)) return;
-  throw new AppError(
-    "PAYMENT_REQUIRED",
-    "Upgrade to the paid plan to use AI Visibility",
-  );
-}
 
 export const lookupBrand = createServerFn({ method: "POST" })
   .middleware(requireProjectContext)
@@ -37,6 +20,7 @@ export const explorePrompt = createServerFn({ method: "POST" })
   .middleware(requireProjectContext)
   .validator(promptExplorerInputSchema)
   .handler(async ({ data, context }) => {
-    await assertPaidPlan(context.organizationId);
+    // runExplorePrompt self-gates on the paid plan so MCP callers inherit the
+    // same check; no need to duplicate it here.
     return runExplorePrompt({ ...data, projectId: context.projectId }, context);
   });

--- a/web/content/docs/mcp.md
+++ b/web/content/docs/mcp.md
@@ -87,6 +87,8 @@ OpenSEO MCP exposes tools for SEO research workflows:
 - Check backlink and referring-domain overview data.
 - Read first-party Google Search Console performance (clicks, impressions, CTR, position).
 - Inspect index status, crawl, and canonical for specific URLs (up to 10 per call).
+- Read AI Search visibility: brand mention counts and Share of Voice vs. named competitors across ChatGPT and Google AI Overview.
+- Read AI Search cited sources: which URLs get cited as sources in AI answers, and the prompts that cited them.
 
 ## What to do after setup
 

--- a/web/content/docs/mcp.md
+++ b/web/content/docs/mcp.md
@@ -89,6 +89,7 @@ OpenSEO MCP exposes tools for SEO research workflows:
 - Inspect index status, crawl, and canonical for specific URLs (up to 10 per call).
 - Read AI Search visibility: brand mention counts and Share of Voice vs. named competitors across ChatGPT and Google AI Overview.
 - Read AI Search cited sources: which URLs get cited as sources in AI answers, and the prompts that cited them.
+- Ask one prompt across up to 4 LLMs (ChatGPT, Claude, Gemini, Perplexity) and read each model's raw answer and citations.
 
 ## What to do after setup
 


### PR DESCRIPTION
## What changed

Adds three read-only MCP tools that thinly wrap the existing `ai-search` feature, closing the gap called out in #126: the MCP server had 20+ classic-SEO tools but nothing for AI-Search/AEO visibility.

- `get_ai_search_visibility` — brand mention counts and AI search volume per platform (ChatGPT, Google AI Overview), plus Share of Voice vs. up to 5 named competitors.
- `get_ai_search_cited_sources` — which URLs get cited as sources in AI answers, plus the sampled prompts and other brands mentioned alongside each.
- `get_ai_search_prompt_results` — ask one prompt across up to 4 LLMs (ChatGPT, Claude, Gemini, Perplexity) and return each model's raw answer, citations, and fan-out queries. Defaults to a single `chat_gpt` call when `models` is omitted, since each requested model is a separate paid call.

All three call existing services (no new DataForSEO integration), are project-scoped via `withMcpProjectAuth`, and follow the `get-domain-overview.ts` pattern (Zod input/output schemas, credit-cost note in the description, registered individually in `server.ts`).

### A note on `citedSources.ts`

`citedSources.ts` isn't a standalone queryable service — it's a shaping helper (`deriveCitedSources`) consumed internally by `brandLookup.ts` to build the `topPages`/`topQueries` fields on `BrandLookupResult`. So `get_ai_search_cited_sources` calls `getBrandLookup` with the same input as `get_ai_search_visibility` and projects just the citation-relevant fields, rather than calling a separate service.

### Paid-plan gate fix

`lookupBrand`/`explorePrompt` (the server functions backing the dashboard) gate AI Search behind the hosted paid plan via `assertPaidPlan` in `serverFunctions/ai-search.ts`, but the underlying services didn't enforce this themselves — so new MCP tools calling them directly would have bypassed the gate for hosted free-tier orgs. Moved the check into `getBrandLookup` and `explorePrompt` (mirroring `AuditService.resolveAuditLimitTier`'s self-gating pattern) so every caller, dashboard and MCP alike, inherits it, and removed the now-redundant checks from both server functions.

### Market scope

`get_ai_search_visibility` and `get_ai_search_cited_sources` are fixed to US/en (2840/`en`), matching what the dashboard's Brand Lookup page already hardcodes — not exposed as a caller-configurable input, since DataForSEO's ChatGPT mentions data is US/en-only regardless and the product doesn't test other markets for this feature today. `get_ai_search_prompt_results` exposes `webSearchCountryCode` since Prompt Explorer's own UI does.

### `competitors` scoping (addressed a review comment)

`get_ai_search_cited_sources` initially shared its input schema with `get_ai_search_visibility`, including `competitors`. Codex correctly flagged that forwarding `competitors` there would trigger paid cross-aggregated Share-of-Voice calls per platform with no way for that tool to return the result. Fixed by giving `get_ai_search_cited_sources` its own smaller input schema with no `competitors` field.

## Testing

- `src/server/mcp/tools/ai-search-tools.test.ts` — 8 tests: structured content shape per tool (each excludes the other tools' fields), Share-of-Voice table/unavailable-message rendering, cited-pages/prompts table rendering and empty states, default-competitors-to-`[]` behavior, prompt-results default model, explicit model/option forwarding, and per-model success/error/empty-response text rendering.
- Full existing `ai-search` + `mcp` suites still pass (148 tests) after the plan-gate move.
- `pnpm exec tsc --noEmit`, `pnpm exec oxlint . --type-aware`, `pnpm exec prettier --check`, `pnpm exec knip` all clean.

Fixes #126