### PR TITLE
fix(audit): stop applying the cumulative capacity cap to self-hosted deploys

### DIFF
--- a/src/server/features/audit/services/AuditService.limitTier.test.ts
+++ b/src/server/features/audit/services/AuditService.limitTier.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { isHostedMock, hasManagedAccessMock, hasPaidPlanMock } = vi.hoisted(
+  () => ({
+    isHostedMock: vi.fn(),
+    hasManagedAccessMock: vi.fn(),
+    hasPaidPlanMock: vi.fn(),
+  }),
+);
+
+vi.mock("cloudflare:workers", () => ({ env: {} }));
+
+vi.mock("@/server/lib/runtime-env", () => ({
+  isHostedServerAuthMode: isHostedMock,
+}));
+
+vi.mock("@/server/billing/subscription", () => ({
+  customerHasManagedAccess: hasManagedAccessMock,
+  customerHasPaidPlan: hasPaidPlanMock,
+}));
+
+// Pulled in transitively by AuditService; stubbed so the tier resolver can be
+// exercised without a database or a KV binding.
+vi.mock("@/server/features/audit/repositories/AuditRepository", () => ({
+  AuditRepository: {},
+}));
+
+vi.mock("@/server/lib/audit/progress-kv", () => ({
+  AuditProgressKV: {},
+}));
+
+import { AuditService } from "@/server/features/audit/services/AuditService";
+import { AppError } from "@/server/lib/errors";
+
+describe("resolveAuditLimitTier", () => {
+  beforeEach(() => {
+    hasManagedAccessMock.mockResolvedValue(true);
+    hasPaidPlanMock.mockResolvedValue(true);
+  });
+
+  it("resolves self-hosted deploys to the self_hosted tier", async () => {
+    isHostedMock.mockResolvedValue(false);
+
+    await expect(AuditService.resolveAuditLimitTier("org_1")).resolves.toBe(
+      "self_hosted",
+    );
+    // Self-hosted has no Autumn balance, so billing must not be consulted.
+    expect(hasManagedAccessMock).not.toHaveBeenCalled();
+    expect(hasPaidPlanMock).not.toHaveBeenCalled();
+  });
+
+  it("resolves a hosted subscriber to the paid tier", async () => {
+    isHostedMock.mockResolvedValue(true);
+
+    await expect(AuditService.resolveAuditLimitTier("org_1")).resolves.toBe(
+      "paid",
+    );
+  });
+
+  it("resolves a hosted account without a paid plan to the free tier", async () => {
+    isHostedMock.mockResolvedValue(true);
+    hasPaidPlanMock.mockResolvedValue(false);
+
+    await expect(AuditService.resolveAuditLimitTier("org_1")).resolves.toBe(
+      "free",
+    );
+  });
+
+  it("rejects a hosted account with no managed access", async () => {
+    isHostedMock.mockResolvedValue(true);
+    hasManagedAccessMock.mockResolvedValue(false);
+
+    const rejection = AuditService.resolveAuditLimitTier("org_1");
+    await expect(rejection).rejects.toBeInstanceOf(AppError);
+    await expect(rejection).rejects.toHaveProperty("code", "PAYMENT_REQUIRED");
+  });
+});

--- a/src/server/features/audit/services/AuditService.ts
+++ b/src/server/features/audit/services/AuditService.ts
@@ -27,7 +27,7 @@ import { isHostedServerAuthMode } from "@/server/lib/runtime-env";
 async function resolveAuditLimitTier(
   organizationId: string,
 ): Promise<AuditLimitTier> {
-  if (!(await isHostedServerAuthMode())) return "paid";
+  if (!(await isHostedServerAuthMode())) return "self_hosted";
   const [hasManagedAccess, hasPaidPlan] = await Promise.all([
     customerHasManagedAccess(organizationId),
     customerHasPaidPlan(organizationId),

--- a/src/server/features/audit/services/audit-capacity.test.ts
+++ b/src/server/features/audit/services/audit-capacity.test.ts
@@ -47,4 +47,23 @@ describe("audit capacity helpers", () => {
     expect(freeAudit.pagesTotal).toBe(AUDIT_LIMITS.free.maxPagesPerAudit);
     expect(freeAudit.total).toBeLessThan(AUDIT_LIMITS.free.maxCapacityUnits);
   });
+
+  it("caps cumulative capacity on hosted tiers but not on self-hosted", () => {
+    // maxCapacityUnits is summed over every audit the user has ever started,
+    // so a finite bound is a lifetime budget. That's intended for the hosted
+    // tiers and wrong for a self-hosted operator's own compute.
+    expect(Number.isFinite(AUDIT_LIMITS.free.maxCapacityUnits)).toBe(true);
+    expect(Number.isFinite(AUDIT_LIMITS.paid.maxCapacityUnits)).toBe(true);
+    expect(AUDIT_LIMITS.self_hosted.maxCapacityUnits).toBe(
+      Number.POSITIVE_INFINITY,
+    );
+  });
+
+  it("keeps the per-audit page ceiling identical for paid and self-hosted", () => {
+    // Unlike the capacity budget, this one is a technical ceiling (Workflow
+    // step budget, D1 row writes) and must not be lifted for self-hosted.
+    expect(AUDIT_LIMITS.self_hosted.maxPagesPerAudit).toBe(
+      AUDIT_LIMITS.paid.maxPagesPerAudit,
+    );
+  });
 });

--- a/src/server/features/audit/services/audit-capacity.ts
+++ b/src/server/features/audit/services/audit-capacity.ts
@@ -6,13 +6,24 @@ import {
   PAID_MAX_AUDIT_PAGES,
 } from "@/shared/audit-limits";
 
-export type AuditLimitTier = "free" | "paid";
+export type AuditLimitTier = "free" | "paid" | "self_hosted";
 
 // The crawler runs on our Workers compute and isn't credit-metered, so these
 // per-tier bounds are the abuse control: free accounts cost nothing to create,
 // so they get one small audit at a time and a modest total budget. Paid gets
 // bounds sized for real sites rather than abuse (a payment method on file is
-// the deterrent). Self-hosted deployments resolve to the paid tier.
+// the deterrent).
+//
+// `maxCapacityUnits` is cumulative, not concurrent: getAuditUsageForUser sums
+// pagesTotal + lighthouseTotal over every audit row the user has ever started,
+// with no status filter and no time window. That's the intended shape for a
+// hosted abuse bound, but on a self-hosted deploy it's a lifetime budget on the
+// operator's own compute — ~10 full-size audits before AUDIT_CAPACITY_REACHED,
+// with deleting old audits as the only reset. Self-hosted therefore gets its
+// own tier with the bound lifted, matching how every other hosted-only gate
+// (credits, plan checks, DataForSEO metering) already skips self-hosted.
+// maxPagesPerAudit stays at the paid value: that one is a real technical
+// ceiling (Workflow step budget, D1 row writes), not a plan limit.
 export const AUDIT_LIMITS: Record<
   AuditLimitTier,
   {
@@ -29,6 +40,11 @@ export const AUDIT_LIMITS: Record<
   paid: {
     maxPagesPerAudit: PAID_MAX_AUDIT_PAGES,
     maxCapacityUnits: 100_000,
+    maxRunningAudits: Number.POSITIVE_INFINITY,
+  },
+  self_hosted: {
+    maxPagesPerAudit: PAID_MAX_AUDIT_PAGES,
+    maxCapacityUnits: Number.POSITIVE_INFINITY,
     maxRunningAudits: Number.POSITIVE_INFINITY,
   },
 };


### PR DESCRIPTION
## Problem

`resolveAuditLimitTier` resolves self-hosted deploys to the `paid` tier:

```ts
// src/server/features/audit/services/AuditService.ts
if (!(await isHostedServerAuthMode())) return "paid";
```

`paid` carries `maxCapacityUnits: 100_000`, and that bound is **cumulative, not concurrent**. `getAuditUsageForUser` sums over every audit row the user has ever started, with no status filter and no time window:

```ts
// src/server/features/audit/repositories/AuditRepository.ts:358
const rows = await db.query.audits.findMany({
  where: eq(audits.startedByUserId, userId),
  columns: { status: true, pagesTotal: true, lighthouseTotal: true },
});

return {
  capacityUnits: rows.reduce(
    (total, row) => total + row.pagesTotal + row.lighthouseTotal,
    0,
  ),
  runningCount: rows.filter((row) => row.status === "running").length,
};
```

On hosted that is exactly the intended abuse control, and I'm not proposing to change it there. On a self-hosted deploy it becomes a lifetime budget on the operator's own hardware:

| audit size | audits before `AUDIT_CAPACITY_REACHED` |
| ---------- | -------------------------------------- |
| 10,000 pages | ~10 |
| 500 pages | ~190 |
| 50 pages | ~2,000 |

Units are reserved from the **planned** page count, not the crawled one, so an audit configured for 10,000 pages that finishes after 300 still spends 10,020 units. Once the budget is gone, the only way to reclaim it is deleting old audit rows.

The self-hosted crawler runs on the operator's own compute and isn't credit-metered, so this bound isn't protecting anything.

## Change

Add a `self_hosted` tier with `maxCapacityUnits` lifted, and resolve non-hosted deploys to it. This matches how every other hosted-only gate already treats self-hosted — credits (`SamChatAgent`, `OnboardingChatAgent`), plan checks (`HostedPlanGate`), and DataForSEO metering (`meterDataforseoCall`) all skip it, with the existing code comments stating the intent explicitly:

> Self-hosted brings its own provider keys and has no Autumn balance, so it's ungated.

`maxPagesPerAudit` deliberately stays at the paid value. That one is a real technical ceiling (Workflow step budget, D1 row writes), not a plan limit, and a test pins it so it doesn't drift.

## Hosted behaviour

Unchanged. `free` and `paid` keep their existing bounds, and a hosted deploy can never resolve to the new tier. The one place the tier value leaves the server is the `plan_tier` property on the `site_audit:start` PostHog event — `captureServerEvent` no-ops when not hosted, so the new value can't reach analytics.

## Tests

- `audit-capacity.test.ts` — asserts the hosted tiers keep a finite cumulative bound while `self_hosted` does not, and that `self_hosted.maxPagesPerAudit` stays identical to `paid`.
- `AuditService.limitTier.test.ts` (new) — covers all four resolver paths: self-hosted resolves to `self_hosted` without consulting billing at all, hosted subscriber to `paid`, hosted without a paid plan to `free`, and hosted without managed access rejects with `PAYMENT_REQUIRED`.

`pnpm ci:check` passes. Full `vitest run` is green apart from `src/server/lib/dataforseo/client.test.ts > skips billing in non-hosted mode`, which also fails on an unmodified `main` on my machine (a 5s timeout under full-suite load, ~4.2s in isolation) and is unrelated to this change.

## Not in scope

Whether the cumulative counting in `getAuditUsageForUser` is the right shape for the hosted free tier is a separate question — a rolling window or an active-only filter would both be defensible. That's a behaviour change for paying-adjacent users and belongs in its own issue rather than riding along here.
