### PR TITLE
test(dataforseo): mock the google-ads section so the SDK stays out of the run

### DIFF
--- a/src/server/lib/dataforseo/client.test.ts
+++ b/src/server/lib/dataforseo/client.test.ts
@@ -92,6 +92,14 @@ vi.mock("@/server/lib/dataforseo/ai", () => ({
   fetchLlmCrossAggregatedMetrics: vi.fn(),
   fetchLlmResponse: vi.fn(),
 }));
+// Not wrapped by the client, but re-exported from the sections barrel that
+// loadDataforseoSections() pulls in — so leaving it unmocked is what drags the
+// ~3 MB dataforseo-client SDK into the run and makes the first test that
+// touches the client take seconds instead of milliseconds.
+vi.mock("@/server/lib/dataforseo/google-ads", () => ({
+  fetchAdsKeywordIdeas: vi.fn(),
+  fetchAdsSearchVolume: vi.fn(),
+}));
 
 import {
   createDataforseoClient,


### PR DESCRIPTION
## Problem

`src/server/lib/dataforseo/client.test.ts > meterDataforseoCall with split balances > skips billing in non-hosted mode` fails intermittently in a full `pnpm test:ci` run with `Test timed out in 5000ms`. It passes when the file is run on its own.

The test itself does almost nothing — one mocked call, three assertions, no timers. The time is spent loading a module.

## Cause

`client.test.ts` mocks the section modules the client wraps (`labs`, `serp`, `business`, `backlinks`, `lighthouse`, `ai`) under the comment _"Mock every section module the client wraps"_. But the client does not reach those modules directly — it reaches them through `loadDataforseoSections()`, a single lazy `import("@/server/lib/dataforseo/sections")`, and that barrel also re-exports from `google-ads.ts`:

```ts
// src/server/lib/dataforseo/sections.ts
export {
  fetchAdsKeywordIdeas,
  fetchAdsSearchVolume,
} from "@/server/lib/dataforseo/google-ads";
```

`google-ads.ts` is the one section module the test does not mock, and it statically imports `dataforseo-client`:

```ts
// src/server/lib/dataforseo/google-ads.ts
import { ... } from "dataforseo-client";
```

So the ~3 MB SDK gets loaded for real — precisely the subtree the lazy boundary in `client.ts` exists to keep out of the graph:

> the section fetchers and the ~3 MB dataforseo-client SDK they statically import stay out of the eager isolate startup graph and load once, on the first API call

The whole cost is charged to whichever test first touches the client. That happens to be `skips billing in non-hosted mode`, which is why the failure always names that test even though nothing is wrong with it. Measured locally, three consecutive isolated runs:

| | before | after |
| --- | --- | --- |
| `skips billing in non-hosted mode` | 2125 / 2032 / 2131 ms | 17 / 17 / 17 ms |
| next test, same code path | 1–2 ms | 1–2 ms |

Under a 12-thread suite run the 2.1s crosses the 5s default timeout and the file goes red.

## Change

Mock `@/server/lib/dataforseo/google-ads` alongside the other section modules. No assertion, fixture, or production file is touched.

## Result

Full `pnpm test:ci`, both runs warm, same machine:

| | main | this branch |
| --- | --- | --- |
| result | 1 failed, 732 passed | 733 passed |
| test time | 17.96s | 9.63s |
| wall duration | 16.93s | 14.62s |

All 18 tests in the file still pass. `pnpm ci:check` passes.

## Note

The underlying sharp edge is that the mock list has to track the barrel's re-exports rather than the client's own wrappers — the two differ by exactly this module, and nothing fails loudly when they drift, it just gets slow. If you'd like a guard against that (for example a `sections.ts` re-export assertion in the test, or moving the SDK-free type re-exports out of the barrel), happy to follow up in a separate PR.
