### PR TITLE
release: v0.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "open-seo",
   "private": true,
   "sideEffects": false,
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "packageManager": "pnpm@10.30.1",
   "scripts": {

--- a/release-notes/v0.1.3.md
+++ b/release-notes/v0.1.3.md
@@ -1,0 +1,5 @@
+Website and docs only — no product changes.
+
+The app, the MCP tools, and the SEO data all behave exactly as they did in v0.1.2. What shipped since then is a Keyword Research Strategy Library on the website, a guides section on the feature pages, and a "Search Everywhere" interview — thanks @jeremypenguin-max
+
+Full Changelog: https://github.com/every-app/open-seo/compare/v0.1.2...v0.1.3


### PR DESCRIPTION
Website and docs only — no product changes.

The app, the MCP tools, and the SEO data all behave exactly as they did in v0.1.2. What shipped since then is a Keyword Research Strategy Library on the website, a guides section on the feature pages, and a "Search Everywhere" interview — thanks @jeremypenguin-max

Full Changelog: https://github.com/every-app/open-seo/compare/v0.1.2...v0.1.3
