### PR TITLE
feat(mcp): add run_rank_tracker to trigger a check off-schedule

### DIFF
--- a/src/client/features/ai-mcp/AvailableTools.tsx
+++ b/src/client/features/ai-mcp/AvailableTools.tsx
@@ -24,6 +24,11 @@ const toolCategories: ToolCategory[] = [
         description: "Read tracked keyword positions.",
       },
       {
+        name: "run_rank_tracker",
+        title: "Run a rank check",
+        description: "Check a tracker's keywords now, off-schedule.",
+      },
+      {
         name: "get_keyword_metrics",
         title: "Get keyword metrics",
         description:

--- a/src/server/mcp/server.ts
+++ b/src/server/mcp/server.ts
@@ -5,6 +5,7 @@ import { getBacklinksProfileTool } from "@/server/mcp/tools/get-backlinks-profil
 import { getDomainKeywordSuggestionsTool } from "@/server/mcp/tools/get-domain-keyword-suggestions";
 import { getDomainOverviewTool } from "@/server/mcp/tools/get-domain-overview";
 import { getRankTrackerTool } from "@/server/mcp/tools/get-rank-tracker";
+import { runRankTrackerTool } from "@/server/mcp/tools/run-rank-tracker";
 import { getSerpResultsTool } from "@/server/mcp/tools/get-serp-results";
 import { createProjectTool } from "@/server/mcp/tools/create-project";
 import { listProjectsTool } from "@/server/mcp/tools/list-projects";
@@ -143,6 +144,15 @@ export function registerOpenSeoMcpTools(server: McpServer) {
       getRankTrackerTool.name,
       getRankTrackerTool.config.outputSchema,
       getRankTrackerTool.handler,
+    ),
+  );
+  server.registerTool(
+    runRankTrackerTool.name,
+    runRankTrackerTool.config,
+    instrumentMcpToolHandler(
+      runRankTrackerTool.name,
+      runRankTrackerTool.config.outputSchema,
+      runRankTrackerTool.handler,
     ),
   );
   server.registerTool(

--- a/src/server/mcp/tools/get-rank-tracker.ts
+++ b/src/server/mcp/tools/get-rank-tracker.ts
@@ -46,7 +46,7 @@ export const getRankTrackerTool = {
   config: {
     title: "Get rank tracker",
     description:
-      "Read-only access to rank tracker configs and their latest results. With `trackerId`, returns config + latest snapshot per keyword. Without it, lists all trackers in the project. Uses no credits — reads from OpenSEO state, no DataForSEO call. To trigger a new check, use the dashboard.",
+      "Read-only access to rank tracker configs and their latest results. With `trackerId`, returns config + latest snapshot per keyword. Without it, lists all trackers in the project. Uses no credits — reads from OpenSEO state, no DataForSEO call. `lastCheckedAt` tells you how fresh the positions are; to trigger a new check, use run_rank_tracker.",
     inputSchema,
     outputSchema: z
       .object({

--- a/src/server/mcp/tools/run-rank-tracker.test.ts
+++ b/src/server/mcp/tools/run-rank-tracker.test.ts
@@ -1,0 +1,145 @@
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ToolExtra } from "@/server/mcp/context";
+import { MCP_AUTH_CONTEXT_PROP } from "@/server/mcp/context";
+
+// run_rank_tracker spends credits, so the two outcomes that matter are
+// "a run started" and "one was already in flight". The second must not read
+// as a failure — a caller that treats it as one retries and double-charges.
+
+const mocks = vi.hoisted(() => ({
+  getProjectForOrganization: vi.fn(),
+  getConfigById: vi.fn(),
+  triggerCheck: vi.fn(),
+  captureServerEvent: vi.fn(),
+}));
+
+vi.mock("cloudflare:workers", () => ({ env: {} }));
+vi.mock("@/server/features/projects/services/ProjectService", () => ({
+  ProjectService: {
+    getProjectForOrganization: mocks.getProjectForOrganization,
+  },
+}));
+vi.mock(
+  "@/server/features/rank-tracking/repositories/RankTrackingRepository",
+  () => ({
+    RankTrackingRepository: { getConfigById: mocks.getConfigById },
+  }),
+);
+vi.mock("@/server/features/rank-tracking/services/RankTrackingService", () => ({
+  RankTrackingService: { triggerCheck: mocks.triggerCheck },
+}));
+vi.mock("@/server/lib/posthog", () => ({
+  captureServerEvent: mocks.captureServerEvent,
+}));
+
+const authContext = {
+  userId: "user_123",
+  userEmail: "alice@example.com",
+  organizationId: "org_123",
+  clientId: "client_123",
+  scopes: ["mcp"],
+  audience: "https://open-seo.test/mcp",
+  subject: "user_123",
+  baseUrl: "https://open-seo.test",
+};
+
+const toolExtra: ToolExtra = {
+  signal: new AbortController().signal,
+  requestId: 1,
+  sendNotification: vi.fn(),
+  sendRequest: vi.fn(),
+  authInfo: {
+    token: "token",
+    clientId: "client_123",
+    scopes: ["mcp"],
+    resource: new URL("https://open-seo.test/mcp"),
+    extra: { [MCP_AUTH_CONTEXT_PROP]: authContext },
+  } satisfies AuthInfo,
+};
+
+function text(result: { content?: Array<{ type: string; text?: string }> }) {
+  const first = result.content?.[0];
+  return first?.type === "text" ? (first.text ?? "") : "";
+}
+
+const config = {
+  id: "tracker_1",
+  domain: "example.com",
+  scheduleInterval: "weekly",
+  devices: "desktop",
+  serpDepth: 40,
+};
+
+describe("run_rank_tracker", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    for (const mock of Object.values(mocks)) mock.mockReset();
+    mocks.getProjectForOrganization.mockResolvedValue({
+      id: "project_1",
+      locationCode: 2840,
+      languageCode: "en",
+    });
+    mocks.captureServerEvent.mockResolvedValue(undefined);
+  });
+
+  it("starts a check and returns the run id", async () => {
+    mocks.getConfigById.mockResolvedValue(config);
+    mocks.triggerCheck.mockResolvedValue({ ok: true, runId: "run_1" });
+    const { runRankTrackerTool } = await import("./run-rank-tracker");
+
+    const result = await runRankTrackerTool.handler(
+      { projectId: "project_1", trackerId: "tracker_1" },
+      toolExtra,
+    );
+
+    expect(mocks.triggerCheck).toHaveBeenCalledWith(
+      expect.objectContaining({
+        configId: "tracker_1",
+        projectId: "project_1",
+      }),
+    );
+    expect(text(result)).toContain("run_1");
+    expect(text(result)).toContain("example.com");
+    expect(result.structuredContent).toMatchObject({
+      runId: "run_1",
+      started: true,
+    });
+  });
+
+  it("reports an in-flight run as started:false without charging again", async () => {
+    mocks.getConfigById.mockResolvedValue(config);
+    mocks.triggerCheck.mockResolvedValue({
+      ok: false,
+      reason: "already_running",
+      blockingRunId: "run_0",
+    });
+    const { runRankTrackerTool } = await import("./run-rank-tracker");
+
+    const result = await runRankTrackerTool.handler(
+      { projectId: "project_1", trackerId: "tracker_1" },
+      toolExtra,
+    );
+
+    const out = text(result);
+    expect(out).toContain("already running");
+    expect(out).toContain("run_0");
+    expect(out).toContain("nothing was charged");
+    expect(result.structuredContent).toMatchObject({ started: false });
+    // No telemetry for a run that never began.
+    expect(mocks.captureServerEvent).not.toHaveBeenCalled();
+  });
+
+  it("rejects a tracker that does not belong to the project", async () => {
+    mocks.getConfigById.mockResolvedValue(null);
+    const { runRankTrackerTool } = await import("./run-rank-tracker");
+
+    await expect(
+      runRankTrackerTool.handler(
+        { projectId: "project_1", trackerId: "tracker_missing" },
+        toolExtra,
+      ),
+    ).rejects.toThrow(/not found/i);
+    expect(mocks.triggerCheck).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/mcp/tools/run-rank-tracker.ts
+++ b/src/server/mcp/tools/run-rank-tracker.ts
@@ -1,0 +1,93 @@
+import { z } from "zod";
+import { RankTrackingRepository } from "@/server/features/rank-tracking/repositories/RankTrackingRepository";
+import { RankTrackingService } from "@/server/features/rank-tracking/services/RankTrackingService";
+import { AppError } from "@/server/lib/errors";
+import { captureServerEvent } from "@/server/lib/posthog";
+import { mcpResponse } from "@/server/mcp/formatters";
+import { buildProjectMeta } from "@/server/mcp/context";
+import { optionalMetaOutputSchema } from "@/server/mcp/output-schemas";
+import { withMcpProjectAuth } from "@/server/mcp/project-auth";
+import { projectIdSchema } from "@/server/mcp/schemas";
+
+const inputSchema = {
+  projectId: projectIdSchema,
+  trackerId: z
+    .string()
+    .min(1)
+    .describe(
+      "Rank tracker config ID to check. Get one from get_rank_tracker.",
+    ),
+} as const;
+
+type Args = z.infer<z.ZodObject<typeof inputSchema>>;
+
+export const runRankTrackerTool = {
+  name: "run_rank_tracker",
+  config: {
+    title: "Run rank tracker",
+    description:
+      "Trigger an on-demand rank check for a tracker's keywords. Charges credits — one SERP check per keyword per device, so a 50-keyword desktop-only tracker costs 50 checks. Runs in the background; poll get_rank_tracker with the same trackerId until `lastCheckedAt` advances, then read the positions. Use this when a scheduled check was missed or you need positions fresher than the tracker's interval; the schedule itself is unchanged.",
+    inputSchema,
+    outputSchema: z
+      .object({
+        runId: z.string().optional(),
+        started: z.boolean(),
+        ...optionalMetaOutputSchema,
+      })
+      .passthrough(),
+    annotations: {
+      readOnlyHint: false,
+      openWorldHint: true,
+      destructiveHint: false,
+    },
+  },
+  handler: withMcpProjectAuth(async (args: Args, context) => {
+    const trackerPath = `/p/${args.projectId}/rank-tracking/${args.trackerId}`;
+
+    const config = await RankTrackingRepository.getConfigById({
+      configId: args.trackerId,
+      projectId: args.projectId,
+    });
+    if (!config) {
+      throw new AppError(
+        "NOT_FOUND",
+        `Rank tracker ${args.trackerId} not found in project ${args.projectId}. List trackers with get_rank_tracker.`,
+      );
+    }
+
+    const result = await RankTrackingService.triggerCheck({
+      configId: args.trackerId,
+      projectId: args.projectId,
+      billingCustomer: context.billing,
+    });
+
+    // A check already in flight is an expected outcome, not a failure — report
+    // it plainly so the caller polls instead of retrying and double-charging.
+    if (!result.ok) {
+      return mcpResponse({
+        text: `A rank check is already running for ${config.domain}${
+          result.blockingRunId ? ` (run ${result.blockingRunId})` : ""
+        }. No new check was started and nothing was charged. Poll get_rank_tracker until \`lastCheckedAt\` advances.`,
+        meta: buildProjectMeta(context, args.projectId, trackerPath),
+        structuredContent: { started: false },
+      });
+    }
+
+    await captureServerEvent({
+      distinctId: context.auth.userId,
+      event: "rank_check:start",
+      organizationId: context.auth.organizationId,
+      properties: {
+        project_id: args.projectId,
+        tracker_id: args.trackerId,
+        source: "mcp",
+      },
+    });
+
+    return mcpResponse({
+      text: `Rank check ${result.runId} started for ${config.domain} (${config.devices}, top ${config.serpDepth}). Poll get_rank_tracker with trackerId ${args.trackerId} until \`lastCheckedAt\` advances, then read the positions.`,
+      meta: buildProjectMeta(context, args.projectId, trackerPath),
+      structuredContent: { runId: result.runId, started: true },
+    });
+  }),
+};


### PR DESCRIPTION
## Problem

Rank tracking is the only MCP surface with no way to act. `get_rank_tracker` reads configs and positions, but its description ends *"To trigger a new check, use the dashboard."* An agent that notices a tracker is stale has to hand the task back to a human.

This shows up in practice. I run weekly SEO reports for ~12 projects off this MCP. One project's weekly tracker stopped firing — `nextCheckAt` sat 2 days in the past with `isActive: true` and `lastSkipReason: null`, positions frozen at the previous run. From the MCP alone an agent can see the staleness but can't fix it, and can't distinguish "no movement" from "no check ran". Six other trackers had drifted to 14-day gaps, which is a subtle correctness problem: two consecutive snapshots reported as week-over-week movement are simply wrong, and the number itself looks real enough to survive review.

## What this adds

`run_rank_tracker(projectId, trackerId)` — triggers an on-demand check.

`RankTrackingService.triggerCheck` already implements this for the dashboard and `withMcpProjectAuth` already supplies `context.billing`, so this wires the existing service up exactly the way `run_site_audit` does. No new service or repository code.

Behaviour worth calling out:

- **`already_running` is not an error.** It returns `started: false` with an explanatory message instead of throwing, so a caller polls rather than retrying and double-charging.
- **Ownership is checked before spending.** A tracker outside the project throws `NOT_FOUND` before `triggerCheck`, so a bad id can't burn credits.
- **Telemetry only fires for a run that actually began.**
- **The cost is stated in the tool description** — one SERP check per keyword per device. This is the rare MCP tool that spends money, so the model should see that before calling it.

Also updates `get_rank_tracker`'s description to point at `run_rank_tracker` instead of the dashboard, and to mention `lastCheckedAt` as the freshness signal — an agent needs that to decide whether a check is worth paying for.

## Testing

`pnpm ci:check` and `pnpm test:ci` both pass (736 tests, 92 files).

New `run-rank-tracker.test.ts` covers the three outcomes that matter: a started run returns its id, an in-flight run reports `started: false` and skips telemetry, and an unknown tracker throws before `triggerCheck` is reached.

## Notes

Kept to one tool per the contributing guide. `create_rank_tracker` would be the natural follow-up — I also had to create a tracker by hand — but it pulls in keyword management, so it seemed better as a separate PR if you'd want it at all.

Happy to adjust naming, the description wording, or the `already_running` shape if you'd prefer it throw.