### PR TITLE
fix: run billing:usage's main() after its lookup tables initialize

### DIFF
--- a/scripts/dataforseo-account-usage.ts
+++ b/scripts/dataforseo-account-usage.ts
@@ -7,8 +7,6 @@ loadLocalEnv();
 
 const args = parseArgs(process.argv.slice(2));
 
-await main();
-
 /**
  * Inspect real DataForSEO account spend via the FREE GET
  * /v3/appendix/user_data endpoint. Unlike the other billing:* scripts, this
@@ -114,3 +112,7 @@ function printUsageAndExit(message: string): never {
   console.error("Usage: pnpm billing:usage [--json=true]");
   process.exit(1);
 }
+
+// Last, not first: `main` hoists but the `const` tables it reads do not, so
+// invoking at the top of the module throws a TDZ ReferenceError.
+await main();


### PR DESCRIPTION
ReferenceError: Cannot access 'main' before initialization

`pnpm billing:usage` fails on every run today:

```
file:///.../scripts/dataforseo-account-usage.ts:10
await main();
      ^
ReferenceError: Cannot access 'main' before initialization
```

`await main()` sits at line 10, above the `const` price and endpoint tables the
function reads. `main` is a function declaration so it hoists, but those `const`
bindings stay in their temporal dead zone until the module finishes evaluating —
so the call is guaranteed to throw, not merely fragile.

## The fix

Move the call to the end of the module. The script has no other entry point and
nothing after it depends on ordering, so this is the entire change.

## Test plan

```bash
pnpm billing:usage           # prints the account summary instead of throwing
pnpm billing:usage --json=true
```

Both hit only the free GET `/v3/appendix/user_data` endpoint, so verifying costs
nothing.