### PR TITLE
ci: skip the sourcemap upload when a fork has no PostHog env id

### DIFF
--- a/.github/workflows/sourcemaps.yml
+++ b/.github/workflows/sourcemaps.yml
@@ -8,7 +8,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   upload:
-    if: github.repository != 'every-app/open-seo'
+    if: github.repository != 'every-app/open-seo' && vars.POSTHOG_CLI_ENV_ID != ''
     runs-on: ubuntu-latest
     env:
       POSTHOG_SOURCEMAPS: "true"


### PR DESCRIPTION
The job guard is `github.repository != 'every-app/open-seo'`, which reads as "run
everywhere except upstream" — but the thing it actually needs is a PostHog env
id, and that is exactly what most forks lack.

A Deploy-button fork therefore gets a red check on every push to `main`:
`posthog-cli sourcemap upload` runs with an empty `POSTHOG_CLI_ENV_ID` and
fails. Nothing in the fork asked for PostHog, and nothing in the repo tells the
owner why the workflow is failing.

## The fix

```diff
-    if: github.repository != 'every-app/open-seo'
+    if: github.repository != 'every-app/open-seo' && vars.POSTHOG_CLI_ENV_ID != ''
```

`vars.*` is empty rather than undefined for an unset repository variable, so the
comparison is safe on repos that never define it.

## Test plan

- Fork without `POSTHOG_CLI_ENV_ID`: the `upload` job is skipped, the workflow is
  green.
- Fork with it set: unchanged — the guard still passes and the upload runs.
- Upstream `every-app/open-seo`: unchanged, still skipped by the first clause.