### PR TITLE
refactor: extract the shared GSC MCP helpers into gsc-shared.ts

### DIFF
--- a/src/server/mcp/tools/gsc-shared.ts
+++ b/src/server/mcp/tools/gsc-shared.ts
@@ -1,0 +1,58 @@
+import { buildProjectMeta } from "@/server/mcp/context";
+import { mcpResponse } from "@/server/mcp/formatters";
+import { buildDashboardUrl } from "@/server/mcp/urls";
+import { hasSelfHostedGscConfig } from "@/server/features/gsc/oauth-config";
+import { isHostedServerAuthMode } from "@/server/lib/runtime-env";
+import { GscNotConnectedError } from "@/server/features/gsc/services/GscService";
+import { GscApiError, GscTokenError } from "@/server/lib/gscClient";
+import { GSC_SELF_HOSTED_SETUP_DOCS_URL } from "@/shared/gsc";
+
+/** Minimal shape of the MCP project-auth context the GSC helpers need. */
+type GscProjectAuthContext = {
+  auth: { organizationId: string };
+  baseUrl: string;
+};
+
+export function connectGscUrl(baseUrl: string, projectId: string): string {
+  // GSC Insights hosts the connection card AND the data the user came for,
+  // so land them there rather than in settings.
+  return buildDashboardUrl(baseUrl, `/p/${projectId}/search-performance`);
+}
+
+/** Self-hosted GSC requires the operator to provide a Google OAuth client and
+ *  BETTER_AUTH_SECRET. Hosted mode always has both; self-hosted tools return this
+ *  setup nudge before attempting a token lookup when either is missing. */
+export async function missingSelfHostedGoogleClientResponse(
+  context: GscProjectAuthContext,
+  projectId: string,
+) {
+  const [hosted, configured] = await Promise.all([
+    isHostedServerAuthMode(),
+    hasSelfHostedGscConfig(),
+  ]);
+  if (hosted || configured) return null;
+
+  return mcpResponse({
+    text: `This self-hosted OpenSEO deployment is not configured for Search Console yet. Set GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, and BETTER_AUTH_SECRET, then reconnect Search Console from the project's settings page. Setup docs: ${GSC_SELF_HOSTED_SETUP_DOCS_URL}`,
+    meta: buildProjectMeta(context, projectId),
+    structuredContent: {
+      ok: false,
+      connected: false,
+      reason: "gsc_oauth_not_configured",
+      setupDocsUrl: GSC_SELF_HOSTED_SETUP_DOCS_URL,
+    },
+  });
+}
+
+export function describeGscError(error: unknown): string {
+  if (error instanceof GscNotConnectedError) {
+    return "Search Console is not connected for this project.";
+  }
+  if (error instanceof GscTokenError) {
+    return "The Search Console connection has expired or was revoked. Reconnect it to continue.";
+  }
+  if (error instanceof GscApiError) {
+    return error.message;
+  }
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/server/mcp/tools/search-console-tools.ts
+++ b/src/server/mcp/tools/search-console-tools.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines */
 import { z } from "zod";
 import { buildProjectMeta } from "@/server/mcp/context";
 import { mcpResponse } from "@/server/mcp/formatters";
@@ -6,9 +5,11 @@ import { optionalMetaOutputSchema } from "@/server/mcp/output-schemas";
 import { withMcpProjectAuth } from "@/server/mcp/project-auth";
 import { formatMcpTable, type McpTableColumn } from "@/server/mcp/table";
 import { projectIdSchema } from "@/server/mcp/schemas";
-import { buildDashboardUrl } from "@/server/mcp/urls";
-import { hasSelfHostedGscConfig } from "@/server/features/gsc/oauth-config";
-import { isHostedServerAuthMode } from "@/server/lib/runtime-env";
+import {
+  connectGscUrl,
+  describeGscError,
+  missingSelfHostedGoogleClientResponse,
+} from "@/server/mcp/tools/gsc-shared";
 import {
   GscNotConnectedError,
   GscService,
@@ -22,8 +23,6 @@ import {
   GSC_SEARCH_TYPES,
   type GscPerformanceInput,
 } from "@/server/features/gsc/searchAnalytics";
-import { GscApiError, GscTokenError } from "@/server/lib/gscClient";
-import { GSC_SELF_HOSTED_SETUP_DOCS_URL } from "@/shared/gsc";
 
 const TEXT_SUMMARY_ROWS = 15;
 
@@ -52,42 +51,6 @@ const GSC_PERF_COLUMNS: McpTableColumn<GscPerfRow>[] = [
   },
 ];
 
-type ProjectAuthContext = {
-  auth: { organizationId: string };
-  baseUrl: string;
-};
-
-function connectGscUrl(baseUrl: string, projectId: string): string {
-  // GSC Insights hosts the connection card AND the data the user came for,
-  // so land them there rather than in settings.
-  return buildDashboardUrl(baseUrl, `/p/${projectId}/search-performance`);
-}
-
-/** Self-hosted GSC requires the operator to provide a Google OAuth client and
- *  BETTER_AUTH_SECRET. Hosted mode always has both; self-hosted tools return this
- *  setup nudge before attempting a token lookup when either is missing. */
-async function missingSelfHostedGoogleClientResponse(
-  context: ProjectAuthContext,
-  projectId: string,
-) {
-  const [hosted, configured] = await Promise.all([
-    isHostedServerAuthMode(),
-    hasSelfHostedGscConfig(),
-  ]);
-  if (hosted || configured) return null;
-
-  return mcpResponse({
-    text: `This self-hosted OpenSEO deployment is not configured for Search Console yet. Set GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, and BETTER_AUTH_SECRET, then reconnect Search Console from the project's settings page. Setup docs: ${GSC_SELF_HOSTED_SETUP_DOCS_URL}`,
-    meta: buildProjectMeta(context, projectId),
-    structuredContent: {
-      ok: false,
-      connected: false,
-      reason: "gsc_oauth_not_configured",
-      setupDocsUrl: GSC_SELF_HOSTED_SETUP_DOCS_URL,
-    },
-  });
-}
-
 function invalidRequest(
   meta: ReturnType<typeof buildProjectMeta>,
   message: string,
@@ -97,19 +60,6 @@ function invalidRequest(
     meta,
     structuredContent: { ok: false, reason: "invalid_request" },
   });
-}
-
-function describeGscError(error: unknown): string {
-  if (error instanceof GscNotConnectedError) {
-    return "Search Console is not connected for this project.";
-  }
-  if (error instanceof GscTokenError) {
-    return "The Search Console connection has expired or was revoked. Reconnect it to continue.";
-  }
-  if (error instanceof GscApiError) {
-    return error.message;
-  }
-  return error instanceof Error ? error.message : String(error);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
`search-console-tools.ts` opens with `/* eslint-disable max-lines */`. Three of
its helpers are about Search Console *connection state* rather than about either
tool defined in the file:

- `connectGscUrl` — where to send someone who needs to connect
- `missingSelfHostedGoogleClientResponse` — the self-hosted setup nudge
- `describeGscError` — the `GscNotConnectedError` / `GscTokenError` / `GscApiError` wording

Moving them into `gsc-shared.ts` is what that disable comment was standing in
for, and the file drops back under the cap so the suppression goes with them.

## No behaviour change

The three functions move verbatim. The file-local `ProjectAuthContext` type moves
with them as `GscProjectAuthContext`. Nothing else in the file changes beyond the
import block.

The payoff is for the next GSC-backed MCP tool: today it would have to restate
"not connected", "token expired", and the setup nudge, and the three copies would
drift. Downstream I have four such tools sharing this module, which is how the
extraction came up.

## Test plan

```bash
pnpm ci:check    # prettier + knip + tsc + oxlint --type-aware
pnpm test
```

`knip` is the meaningful one here — it would flag any of the three exports if the
move left a caller behind.