### PR TITLE
fix(audit): keep blank rows last when sorting results tables descending

### DIFF
--- a/src/client/components/table/nullSafeSort.test.ts
+++ b/src/client/components/table/nullSafeSort.test.ts
@@ -1,0 +1,105 @@
+import {
+  createTable,
+  getCoreRowModel,
+  getSortedRowModel,
+  type ColumnDef,
+} from "@tanstack/react-table";
+import { describe, expect, it } from "vitest";
+import {
+  numericNullsLast,
+  stringNullsLast,
+} from "@/client/components/table/nullSafeSort";
+
+type TestRow = { id: string; score: number | null; title: string | null };
+
+const columns: ColumnDef<TestRow>[] = [
+  { id: "score", accessorKey: "score", sortingFn: numericNullsLast },
+  { id: "title", accessorKey: "title", sortingFn: stringNullsLast },
+];
+
+/**
+ * Sort through a real table instance rather than calling the comparators
+ * directly: TanStack negates a comparator's result on a descending column, and
+ * surviving that flip is the whole point of these helpers.
+ */
+function sortedIds(
+  rows: TestRow[],
+  columnId: "score" | "title",
+  desc: boolean,
+): string[] {
+  const table = createTable<TestRow>({
+    data: rows,
+    columns,
+    state: { sorting: [{ id: columnId, desc }] },
+    onStateChange: () => {},
+    renderFallbackValue: null,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  });
+  return table.getSortedRowModel().rows.map((row) => row.original.id);
+}
+
+describe("numericNullsLast", () => {
+  const rows: TestRow[] = [
+    { id: "mid", score: 5, title: "beta" },
+    { id: "blank", score: null, title: null },
+    { id: "high", score: 10, title: "alpha" },
+  ];
+
+  it("orders ascending with nulls last", () => {
+    expect(sortedIds(rows, "score", false)).toEqual(["mid", "high", "blank"]);
+  });
+
+  it("keeps nulls last when descending", () => {
+    expect(sortedIds(rows, "score", true)).toEqual(["high", "mid", "blank"]);
+  });
+
+  it("treats 0 as a value, not as blank", () => {
+    const withZero: TestRow[] = [
+      { id: "zero", score: 0, title: "a" },
+      { id: "blank", score: null, title: null },
+      { id: "one", score: 1, title: "b" },
+    ];
+    expect(sortedIds(withZero, "score", true)).toEqual([
+      "one",
+      "zero",
+      "blank",
+    ]);
+  });
+
+  it("leaves multiple blanks in their original order in both directions", () => {
+    const manyBlanks: TestRow[] = [
+      { id: "blank-1", score: null, title: null },
+      { id: "scored", score: 3, title: "a" },
+      { id: "blank-2", score: null, title: null },
+    ];
+    const expected = ["scored", "blank-1", "blank-2"];
+    expect(sortedIds(manyBlanks, "score", false)).toEqual(expected);
+    expect(sortedIds(manyBlanks, "score", true)).toEqual(expected);
+  });
+});
+
+describe("stringNullsLast", () => {
+  const rows: TestRow[] = [
+    { id: "beta", score: 1, title: "beta" },
+    { id: "blank", score: null, title: null },
+    { id: "alpha", score: 2, title: "alpha" },
+  ];
+
+  it("orders ascending with blanks last", () => {
+    expect(sortedIds(rows, "title", false)).toEqual(["alpha", "beta", "blank"]);
+  });
+
+  it("keeps blanks last when descending", () => {
+    expect(sortedIds(rows, "title", true)).toEqual(["beta", "alpha", "blank"]);
+  });
+
+  it("counts an empty string as blank", () => {
+    const withEmpty: TestRow[] = [
+      { id: "empty", score: 1, title: "" },
+      { id: "named", score: 2, title: "alpha" },
+    ];
+    expect(sortedIds(withEmpty, "title", false)).toEqual(["named", "empty"]);
+    expect(sortedIds(withEmpty, "title", true)).toEqual(["named", "empty"]);
+  });
+});

--- a/src/client/components/table/nullSafeSort.ts
+++ b/src/client/components/table/nullSafeSort.ts
@@ -2,14 +2,24 @@ import type { Row } from "@tanstack/react-table";
 
 /**
  * Null/undefined-aware sorting functions that keep blank rows at the bottom
- * regardless of direction. TanStack's built-in `sortUndefined: "last"` gets
- * inverted by the desc sign flip — these helpers read the column's sort
- * direction from the cell context and return a value that survives the flip.
+ * regardless of direction. TanStack's built-in `sortUndefined: "last"` only
+ * inspects `undefined`, so a column backed by a nullable DB value falls through
+ * to its `sortingFn` — whose result is then negated on a descending sort. These
+ * helpers read the column's sort direction from the cell context and return a
+ * value that survives the flip.
  */
 
 function isDescending<TData>(row: Row<TData>, columnId: string): boolean {
   const cell = row.getAllCells().find((c) => c.column.id === columnId);
   return cell?.column.getIsSorted() === "desc";
+}
+
+/**
+ * Sort value for a pair where exactly one side is blank, pre-compensated for
+ * the `* -1` TanStack applies to comparator results on a descending column.
+ */
+function blankLast(aIsBlank: boolean, descending: boolean): number {
+  return (aIsBlank ? 1 : -1) * (descending ? -1 : 1);
 }
 
 /**
@@ -22,11 +32,23 @@ function compareNumericNullsLast(
   descending: boolean,
 ): number {
   if (a == null && b == null) return 0;
-  if (a == null || b == null) {
-    const sign = descending ? -1 : 1;
-    return (a == null ? 1 : -1) * sign;
-  }
+  if (a == null || b == null) return blankLast(a == null, descending);
   return a - b;
+}
+
+/**
+ * Compare two nullable strings with blanks always at the bottom, regardless of
+ * the column's current sort direction. Empty strings count as blank — a crawled
+ * page can carry `""` for a tag that is present but empty.
+ */
+function compareStringNullsLast(
+  a: string | null | undefined,
+  b: string | null | undefined,
+  descending: boolean,
+): number {
+  if (!a && !b) return 0;
+  if (!a || !b) return blankLast(!a, descending);
+  return a.localeCompare(b);
 }
 
 export function numericNullsLast<TData>(
@@ -37,6 +59,18 @@ export function numericNullsLast<TData>(
   return compareNumericNullsLast(
     rowA.getValue<number | null | undefined>(columnId),
     rowB.getValue<number | null | undefined>(columnId),
+    isDescending(rowA, columnId),
+  );
+}
+
+export function stringNullsLast<TData>(
+  rowA: Row<TData>,
+  rowB: Row<TData>,
+  columnId: string,
+): number {
+  return compareStringNullsLast(
+    rowA.getValue<string | null | undefined>(columnId),
+    rowB.getValue<string | null | undefined>(columnId),
     isDescending(rowA, columnId),
   );
 }

--- a/src/client/features/audit/results/AuditResultsTableFilterLogic.ts
+++ b/src/client/features/audit/results/AuditResultsTableFilterLogic.ts
@@ -163,29 +163,3 @@ function parseFilterNumber(value: string) {
   const parsed = Number(trimmed);
   return Number.isFinite(parsed) ? parsed : null;
 }
-
-export function nullableNumberSort(
-  left: { getValue: (columnId: string) => number | null },
-  right: { getValue: (columnId: string) => number | null },
-  columnId: string,
-) {
-  const a = left.getValue(columnId);
-  const b = right.getValue(columnId);
-  if (a == null && b == null) return 0;
-  if (a == null) return 1;
-  if (b == null) return -1;
-  return a - b;
-}
-
-export function nullableStringSort(
-  left: { getValue: (columnId: string) => string | null },
-  right: { getValue: (columnId: string) => string | null },
-  columnId: string,
-) {
-  const a = left.getValue(columnId);
-  const b = right.getValue(columnId);
-  if (!a && !b) return 0;
-  if (!a) return 1;
-  if (!b) return -1;
-  return a.localeCompare(b);
-}

--- a/src/client/features/audit/results/PagesTable.tsx
+++ b/src/client/features/audit/results/PagesTable.tsx
@@ -25,11 +25,13 @@ import {
 import {
   EMPTY_PAGES_FILTERS,
   filterPages,
-  nullableNumberSort,
-  nullableStringSort,
   type PageRow,
   type PagesFilters,
 } from "@/client/features/audit/results/AuditResultsTableFilterLogic";
+import {
+  numericNullsLast,
+  stringNullsLast,
+} from "@/client/components/table/nullSafeSort";
 
 const pageColumnHelper = createColumnHelper<PageRow>();
 
@@ -112,7 +114,7 @@ function buildPagesColumns({
     pageColumnHelper.accessor("statusCode", {
       header: ({ column }) => <SortableHeader column={column} label="Status" />,
       cell: ({ getValue }) => <HttpStatusBadge code={getValue()} />,
-      sortingFn: nullableNumberSort,
+      sortingFn: numericNullsLast,
     }),
     pageColumnHelper.accessor("title", {
       header: ({ column }) => <SortableHeader column={column} label="Title" />,
@@ -137,7 +139,7 @@ function buildPagesColumns({
           <EmptyCell />
         );
       },
-      sortingFn: nullableStringSort,
+      sortingFn: stringNullsLast,
       meta: { cellClassName: "max-w-[360px]" },
     }),
     pageColumnHelper.accessor("h1Count", {
@@ -178,7 +180,7 @@ function buildPagesColumns({
           <EmptyCell />
         );
       },
-      sortingFn: nullableNumberSort,
+      sortingFn: numericNullsLast,
     }),
   ];
 }

--- a/src/client/features/audit/results/ResultsTables.tsx
+++ b/src/client/features/audit/results/ResultsTables.tsx
@@ -26,11 +26,13 @@ import {
   EMPTY_PERFORMANCE_FILTERS,
   filterPerformanceRows,
   isLighthouseFailure,
-  nullableNumberSort,
-  nullableStringSort,
   type PerformanceFilters,
   type PerformanceRowData,
 } from "@/client/features/audit/results/AuditResultsTableFilterLogic";
+import {
+  numericNullsLast,
+  stringNullsLast,
+} from "@/client/components/table/nullSafeSort";
 
 const performanceColumnHelper = createColumnHelper<PerformanceRowData>();
 
@@ -126,7 +128,7 @@ function buildPerformanceColumns({
       cell: ({ getValue }) => (
         <span className="text-xs">{getValue() ?? "-"}</span>
       ),
-      sortingFn: nullableStringSort,
+      sortingFn: stringNullsLast,
       meta: { cellClassName: "max-w-[180px] truncate" },
     }),
     performanceColumnHelper.accessor("strategy", {
@@ -161,17 +163,17 @@ function buildPerformanceColumns({
     performanceColumnHelper.accessor("performanceScore", {
       header: ({ column }) => <SortableHeader column={column} label="Perf" />,
       cell: ({ getValue }) => <LighthouseScoreBadge score={getValue()} />,
-      sortingFn: nullableNumberSort,
+      sortingFn: numericNullsLast,
     }),
     performanceColumnHelper.accessor("accessibilityScore", {
       header: ({ column }) => <SortableHeader column={column} label="A11y" />,
       cell: ({ getValue }) => <LighthouseScoreBadge score={getValue()} />,
-      sortingFn: nullableNumberSort,
+      sortingFn: numericNullsLast,
     }),
     performanceColumnHelper.accessor("seoScore", {
       header: ({ column }) => <SortableHeader column={column} label="SEO" />,
       cell: ({ getValue }) => <LighthouseScoreBadge score={getValue()} />,
-      sortingFn: nullableNumberSort,
+      sortingFn: numericNullsLast,
     }),
     performanceColumnHelper.accessor("lcpMs", {
       header: ({ column }) => <SortableHeader column={column} label="LCP" />,
@@ -183,7 +185,7 @@ function buildPerformanceColumns({
           <span className="text-xs text-base-content/40">-</span>
         );
       },
-      sortingFn: nullableNumberSort,
+      sortingFn: numericNullsLast,
     }),
     performanceColumnHelper.accessor("cls", {
       header: ({ column }) => <SortableHeader column={column} label="CLS" />,
@@ -195,7 +197,7 @@ function buildPerformanceColumns({
           <span className="text-xs text-base-content/40">-</span>
         );
       },
-      sortingFn: nullableNumberSort,
+      sortingFn: numericNullsLast,
     }),
     performanceColumnHelper.accessor("inpMs", {
       header: ({ column }) => <SortableHeader column={column} label="INP" />,
@@ -207,7 +209,7 @@ function buildPerformanceColumns({
           <span className="text-xs text-base-content/40">-</span>
         );
       },
-      sortingFn: nullableNumberSort,
+      sortingFn: numericNullsLast,
     }),
     performanceColumnHelper.accessor("ttfbMs", {
       header: ({ column }) => <SortableHeader column={column} label="TTFB" />,
@@ -219,7 +221,7 @@ function buildPerformanceColumns({
           <span className="text-xs text-base-content/40">-</span>
         );
       },
-      sortingFn: nullableNumberSort,
+      sortingFn: numericNullsLast,
     }),
     performanceColumnHelper.display({
       id: "issues",


### PR DESCRIPTION
## Summary

Sorting any nullable column in the Site Audit **Pages** or **Performance** table descending moves the blank rows to the *top* instead of leaving them at the bottom. The two comparators those tables use return `±1` for a blank side, and TanStack negates a comparator's result on a descending column, so the intent is inverted on the second header click.

This reuses the helper the repo already has for exactly this problem — `src/client/components/table/nullSafeSort.ts` — instead of keeping a second, direction-blind copy. 11 sortable columns are affected.

## Problem

`getSortedRowModel` applies the descending flip *after* calling the column's `sortingFn` ([`table-core@8.21.3`](https://github.com/TanStack/table/blob/main/packages/table-core/src/utils/getSortedRowModel.ts)):

```ts
if (sortInt === 0) {
  sortInt = columnInfo.sortingFn(rowA, rowB, sortEntry.id)
}

// If sorting is non-zero, take care of desc and inversion
if (sortInt !== 0) {
  if (isDesc) {
    sortInt *= -1
  }
```

So a comparator that hard-codes "blank goes after" gets "blank goes before" on desc:

```ts
// src/client/features/audit/results/AuditResultsTableFilterLogic.ts:167
export function nullableNumberSort(left, right, columnId) {
  const a = left.getValue(columnId);
  const b = right.getValue(columnId);
  if (a == null && b == null) return 0;
  if (a == null) return 1;   // becomes -1 when the column is desc
  if (b == null) return -1;
  return a - b;
}
```

Verified against a real table instance — with rows `score: [5, null, 10]` and the column sorted desc, the old comparator returns `[null, 10, 5]`.

The user-visible sting is on the Performance tab. `isLighthouseFailure` is defined as "has no category scores" (`AuditResultsTableFilterLogic.ts:60-71`), so the null rows *are* the failed audits. Clicking **Perf**, **A11y** or **SEO** to see your worst pages first fills the top of the table with rows that have no scores at all, pushing the real data below the fold. Same for LCP / CLS / INP / TTFB, for **Status** and **Title** on the Pages tab (pages that aren't HTML documents have no title), and for the Performance **URL** column.

Note that `sortUndefined: "last"` is not an option here: it returns early *before* the flip, so it is direction-safe, but it only inspects `undefined` and these columns carry `null` straight from the DB.

## Solution

`nullSafeSort.ts` already solves this for the Brand Lookup tables (added in `faf7a29`) by reading the column's sort direction off the cell and pre-compensating for the flip. This PR:

- adds `stringNullsLast`, a sibling of the existing `numericNullsLast`, for the URL/Title columns — empty strings count as blank, preserving the old `!a` behaviour;
- factors the shared "one side is blank" sign into a small `blankLast` helper used by both;
- points the 3 Pages columns and 8 Performance columns at the shared helpers;
- deletes `nullableNumberSort` / `nullableStringSort`, so there is one implementation of this rule rather than two.

There is a second working pattern in the repo — `RankTrackingColumns.tsx` maps `accessorFn: (row) => row.cpc ?? undefined` and lets `sortUndefined: "last"` do the work. That would also fix these tables, but it needs an `accessorFn` on all 11 columns, so reusing the existing comparator seemed like the smaller change. Happy to switch if you'd rather converge on the rank-tracking approach.

## Out of scope

- `KeywordSuggestionStep.tsx:70-124` has the same class of issue via sentinels (`position ?? 999`, `searchVolume ?? 0`), so unranked suggestions lead on a descending position sort. Different feature and it needs a call on whether `0` should mean "unknown" for volume/traffic, so I left it alone.
- No change to the audit filter logic, the tables' markup, or any other feature's sorting.

## Test plan

- [x] New `src/client/components/table/nullSafeSort.test.ts` drives a real headless `createTable` + `getSortedRowModel`, so it exercises TanStack's own desc flip rather than asserting my reading of it. Covers nulls-last in both directions, `0` not treated as blank, blanks keeping their relative order, and `""` counting as blank.
- [x] Confirmed the new tests fail against the removed comparators (blank sorts first on desc) and pass with the shared ones.
- [x] `pnpm test` — 92 files, 740 tests passing.
- [x] `pnpm ci:check` — prettier, knip, `tsc --noEmit` (both projects) and `oxlint --type-aware` all clean.

## Related

- `src/client/components/table/nullSafeSort.ts` — the existing fix for this bug class, used by the Brand Lookup citation tables.
- `src/client/features/rank-tracking/RankTrackingColumns.tsx` — the `null` -> `undefined` + `sortUndefined: "last"` variant of the same fix.

Made with [Cursor](https://cursor.com)