### PR TITLE
feat: content quality / readability checker (MCP tool)

### DIFF
--- a/src/server/features/content-quality/services/ContentQualityService.ts
+++ b/src/server/features/content-quality/services/ContentQualityService.ts
@@ -1,0 +1,9 @@
+import { fetchAndAnalyze } from "@/server/lib/contentAnalyzer";
+
+async function checkUrl(input: { url: string; targetKeyword?: string }) {
+  return fetchAndAnalyze(input.url, { targetKeyword: input.targetKeyword });
+}
+
+export const ContentQualityService = {
+  checkUrl,
+} as const;

--- a/src/server/lib/contentAnalyzer.test.ts
+++ b/src/server/lib/contentAnalyzer.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { analyzeHtml } from "./contentAnalyzer";
+
+const SAMPLE_HTML = `
+<html>
+  <head>
+    <title>A Short Test Title</title>
+    <meta name="description" content="A short test description." />
+  </head>
+  <body>
+    <h1>Main Heading About Widgets</h1>
+    <h2>Sub Heading</h2>
+    <h2>Another Sub Heading</h2>
+    <p>Widgets are great. This page is about widgets. Widgets solve problems simply.</p>
+    <img src="a.jpg" alt="A widget" />
+    <img src="b.jpg" />
+    <a href="/internal-page">Internal link</a>
+    <a href="https://external.example.com/page">External link</a>
+  </body>
+</html>
+`;
+
+describe("analyzeHtml", () => {
+  it("extracts title and meta description", () => {
+    const result = analyzeHtml(SAMPLE_HTML, {
+      url: "https://example.com/page",
+    });
+    expect(result.title).toBe("A Short Test Title");
+    expect(result.metaDescription).toBe("A short test description.");
+  });
+
+  it("counts headings correctly", () => {
+    const result = analyzeHtml(SAMPLE_HTML, {
+      url: "https://example.com/page",
+    });
+    expect(result.headingCounts).toEqual({ h1: 1, h2: 2, h3: 0 });
+    expect(result.h1Text).toEqual(["Main Heading About Widgets"]);
+  });
+
+  it("flags images missing alt text", () => {
+    const result = analyzeHtml(SAMPLE_HTML, {
+      url: "https://example.com/page",
+    });
+    expect(result.imageCount).toBe(2);
+    expect(result.imagesMissingAlt).toBe(1);
+  });
+
+  it("splits internal and external links by host", () => {
+    const result = analyzeHtml(SAMPLE_HTML, {
+      url: "https://example.com/page",
+    });
+    expect(result.internalLinkCount).toBe(1);
+    expect(result.externalLinkCount).toBe(1);
+  });
+
+  it("detects target keyword placement and density", () => {
+    const result = analyzeHtml(SAMPLE_HTML, {
+      url: "https://example.com/page",
+      targetKeyword: "widgets",
+    });
+    expect(result.targetKeyword?.inTitle).toBe(false);
+    expect(result.targetKeyword?.inH1).toBe(true);
+    expect(result.targetKeyword?.inFirstParagraph).toBe(true);
+    expect(result.targetKeyword?.occurrences).toBeGreaterThan(0);
+  });
+
+  it("returns null targetKeyword when none is given", () => {
+    const result = analyzeHtml(SAMPLE_HTML, {
+      url: "https://example.com/page",
+    });
+    expect(result.targetKeyword).toBeNull();
+  });
+});

--- a/src/server/lib/contentAnalyzer.ts
+++ b/src/server/lib/contentAnalyzer.ts
@@ -1,0 +1,222 @@
+import * as cheerio from "cheerio";
+
+export interface ContentAnalysis {
+  url: string;
+  title: string | null;
+  titleLength: number;
+  metaDescription: string | null;
+  metaDescriptionLength: number;
+  wordCount: number;
+  sentenceCount: number;
+  avgWordsPerSentence: number;
+  readingEaseScore: number;
+  readingEaseLabel: string;
+  headingCounts: { h1: number; h2: number; h3: number };
+  h1Text: string[];
+  imageCount: number;
+  imagesMissingAlt: number;
+  internalLinkCount: number;
+  externalLinkCount: number;
+  targetKeyword: {
+    keyword: string;
+    inTitle: boolean;
+    inH1: boolean;
+    inFirstParagraph: boolean;
+    occurrences: number;
+    densityPercent: number;
+  } | null;
+}
+
+const MAX_HTML_BYTES = 2_000_000;
+
+function countSyllables(word: string): number {
+  const normalized = word.toLowerCase().replace(/[^a-z]/g, "");
+  if (normalized.length === 0) return 0;
+  const matches = normalized.match(/[aeiouy]+/g);
+  let count = matches ? matches.length : 1;
+  if (normalized.endsWith("e") && !normalized.endsWith("le") && count > 1) {
+    count -= 1;
+  }
+  return Math.max(count, 1);
+}
+
+function readingEaseLabel(score: number): string {
+  if (score >= 90) return "very easy";
+  if (score >= 70) return "easy";
+  if (score >= 60) return "standard";
+  if (score >= 50) return "fairly difficult";
+  if (score >= 30) return "difficult";
+  return "very difficult";
+}
+
+export function analyzeHtml(
+  html: string,
+  options: { url: string; targetKeyword?: string },
+): ContentAnalysis {
+  const $ = cheerio.load(html);
+  $("script, style, noscript").remove();
+
+  const title = $("title").first().text().trim() || null;
+  const metaDescription =
+    $('meta[name="description"]').attr("content")?.trim() || null;
+
+  const bodyText = $("body").text().replace(/\s+/g, " ").trim();
+  const words = bodyText.length > 0 ? bodyText.split(" ") : [];
+  const wordCount = words.length;
+
+  const sentences = bodyText
+    .split(/[.!?]+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  const sentenceCount = Math.max(sentences.length, 1);
+  const avgWordsPerSentence = wordCount / sentenceCount;
+
+  const syllableCount = words.reduce(
+    (sum, word) => sum + countSyllables(word),
+    0,
+  );
+  const avgSyllablesPerWord = wordCount > 0 ? syllableCount / wordCount : 0;
+  const readingEaseScore =
+    wordCount > 0
+      ? Math.round(
+          206.835 - 1.015 * avgWordsPerSentence - 84.6 * avgSyllablesPerWord,
+        )
+      : 0;
+
+  const h1Text = $("h1")
+    .map((_, el) => $(el).text().trim())
+    .get();
+
+  const headingCounts = {
+    h1: $("h1").length,
+    h2: $("h2").length,
+    h3: $("h3").length,
+  };
+
+  const images = $("img");
+  const imageCount = images.length;
+  const imagesMissingAlt = images.filter(
+    (_, el) => !$(el).attr("alt")?.trim(),
+  ).length;
+
+  let internalLinkCount = 0;
+  let externalLinkCount = 0;
+  let pageHost: string | null = null;
+  try {
+    pageHost = new URL(options.url).host;
+  } catch {
+    pageHost = null;
+  }
+
+  $("a[href]").each((_, el) => {
+    const href = $(el).attr("href");
+    if (
+      !href ||
+      href.startsWith("#") ||
+      href.startsWith("mailto:") ||
+      href.startsWith("tel:")
+    ) {
+      return;
+    }
+    try {
+      const linkHost = new URL(href, options.url).host;
+      if (pageHost && linkHost === pageHost) {
+        internalLinkCount += 1;
+      } else {
+        externalLinkCount += 1;
+      }
+    } catch {
+      internalLinkCount += 1;
+    }
+  });
+
+  let targetKeyword: ContentAnalysis["targetKeyword"] = null;
+  if (options.targetKeyword && options.targetKeyword.trim().length > 0) {
+    const keyword = options.targetKeyword.trim();
+    const keywordLower = keyword.toLowerCase();
+    const bodyLower = bodyText.toLowerCase();
+    const occurrences = bodyLower.split(keywordLower).length - 1;
+    const firstParagraph = $("p").first().text().trim().toLowerCase();
+
+    targetKeyword = {
+      keyword,
+      inTitle: (title ?? "").toLowerCase().includes(keywordLower),
+      inH1: h1Text.some((text) => text.toLowerCase().includes(keywordLower)),
+      inFirstParagraph: firstParagraph.includes(keywordLower),
+      occurrences,
+      densityPercent:
+        wordCount > 0 ? Math.round((occurrences / wordCount) * 1000) / 10 : 0,
+    };
+  }
+
+  return {
+    url: options.url,
+    title,
+    titleLength: title?.length ?? 0,
+    metaDescription,
+    metaDescriptionLength: metaDescription?.length ?? 0,
+    wordCount,
+    sentenceCount,
+    avgWordsPerSentence: Math.round(avgWordsPerSentence * 10) / 10,
+    readingEaseScore,
+    readingEaseLabel: readingEaseLabel(readingEaseScore),
+    headingCounts,
+    h1Text,
+    imageCount,
+    imagesMissingAlt,
+    internalLinkCount,
+    externalLinkCount,
+    targetKeyword,
+  };
+}
+
+const BLOCKED_HOSTS = new Set(["localhost", "127.0.0.1", "0.0.0.0", "::1"]);
+
+function assertFetchableUrl(rawUrl: string): URL {
+  const url = new URL(rawUrl);
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("Only http/https URLs are supported.");
+  }
+  const hostname = url.hostname.toLowerCase();
+  if (
+    BLOCKED_HOSTS.has(hostname) ||
+    hostname.endsWith(".local") ||
+    /^10\./.test(hostname) ||
+    /^192\.168\./.test(hostname) ||
+    /^172\.(1[6-9]|2\d|3[0-1])\./.test(hostname)
+  ) {
+    throw new Error("This URL is not fetchable.");
+  }
+  return url;
+}
+
+export async function fetchAndAnalyze(
+  rawUrl: string,
+  options: { targetKeyword?: string } = {},
+): Promise<ContentAnalysis> {
+  const url = assertFetchableUrl(rawUrl);
+
+  const response = await fetch(url.toString(), {
+    headers: { "User-Agent": "OpenSEO-ContentQualityCheck/1.0" },
+    redirect: "follow",
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch page: ${response.status}`);
+  }
+
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!contentType.includes("text/html")) {
+    throw new Error(
+      `URL did not return HTML (content-type: ${contentType || "unknown"}).`,
+    );
+  }
+
+  const buffer = await response.arrayBuffer();
+  const truncated = buffer.slice(0, MAX_HTML_BYTES);
+  const html = new TextDecoder("utf-8").decode(truncated);
+
+  return analyzeHtml(html, {
+    url: url.toString(),
+    targetKeyword: options.targetKeyword,
+  });
+}

--- a/src/server/mcp/server.ts
+++ b/src/server/mcp/server.ts
@@ -3,6 +3,7 @@ import { instrumentMcpToolHandler } from "@/server/mcp/instrumentation";
 import { getBacklinksOverviewTool } from "@/server/mcp/tools/get-backlinks-overview";
 import { getBacklinksProfileTool } from "@/server/mcp/tools/get-backlinks-profile";
 import { getDomainKeywordSuggestionsTool } from "@/server/mcp/tools/get-domain-keyword-suggestions";
+import { checkContentQualityTool } from "@/server/mcp/tools/check-content-quality";
 import { getDomainOverviewTool } from "@/server/mcp/tools/get-domain-overview";
 import { getRankTrackerTool } from "@/server/mcp/tools/get-rank-tracker";
 import { getSerpResultsTool } from "@/server/mcp/tools/get-serp-results";
@@ -98,6 +99,15 @@ export function registerOpenSeoMcpTools(server: McpServer) {
       getDomainOverviewTool.name,
       getDomainOverviewTool.config.outputSchema,
       getDomainOverviewTool.handler,
+    ),
+  );
+  server.registerTool(
+    checkContentQualityTool.name,
+    checkContentQualityTool.config,
+    instrumentMcpToolHandler(
+      checkContentQualityTool.name,
+      checkContentQualityTool.config.outputSchema,
+      checkContentQualityTool.handler,
     ),
   );
   server.registerTool(

--- a/src/server/mcp/tools/check-content-quality.ts
+++ b/src/server/mcp/tools/check-content-quality.ts
@@ -1,0 +1,110 @@
+import { z } from "zod";
+import { ContentQualityService } from "@/server/features/content-quality/services/ContentQualityService";
+import { mcpResponse } from "@/server/mcp/formatters";
+import { buildProjectMeta } from "@/server/mcp/context";
+import { optionalMetaOutputSchema } from "@/server/mcp/output-schemas";
+import { withMcpProjectAuth } from "@/server/mcp/project-auth";
+import { projectIdSchema } from "@/server/mcp/schemas";
+
+const inputSchema = {
+  projectId: projectIdSchema,
+  url: z
+    .string()
+    .url()
+    .describe(
+      "The full URL of the page to analyze (e.g. 'https://example.com/blog/post').",
+    ),
+  targetKeyword: z
+    .string()
+    .min(1)
+    .optional()
+    .describe(
+      "Optional target keyword to check for in the title, H1, first paragraph, and body density.",
+    ),
+} as const;
+
+type Args = z.infer<z.ZodObject<typeof inputSchema>>;
+
+export const checkContentQualityTool = {
+  name: "check_content_quality",
+  config: {
+    title: "Check content quality",
+    description:
+      "Analyzes a live page's on-page content quality: word count, Flesch reading-ease score, heading structure, image alt-text coverage, internal/external link counts, and (optionally) target-keyword placement in the title, H1, first paragraph, and body density. Fetches the page directly — free, no credits charged.",
+    inputSchema,
+    outputSchema: z
+      .object({
+        url: z.string(),
+        title: z.string().nullable(),
+        titleLength: z.number(),
+        metaDescription: z.string().nullable(),
+        metaDescriptionLength: z.number(),
+        wordCount: z.number(),
+        sentenceCount: z.number(),
+        avgWordsPerSentence: z.number(),
+        readingEaseScore: z.number(),
+        readingEaseLabel: z.string(),
+        headingCounts: z.object({
+          h1: z.number(),
+          h2: z.number(),
+          h3: z.number(),
+        }),
+        h1Text: z.array(z.string()),
+        imageCount: z.number(),
+        imagesMissingAlt: z.number(),
+        internalLinkCount: z.number(),
+        externalLinkCount: z.number(),
+        targetKeyword: z
+          .object({
+            keyword: z.string(),
+            inTitle: z.boolean(),
+            inH1: z.boolean(),
+            inFirstParagraph: z.boolean(),
+            occurrences: z.number(),
+            densityPercent: z.number(),
+          })
+          .nullable(),
+        ...optionalMetaOutputSchema,
+      })
+      .passthrough(),
+    annotations: {
+      readOnlyHint: true,
+      openWorldHint: true,
+      destructiveHint: false,
+    },
+  },
+  handler: withMcpProjectAuth(async (args: Args, context) => {
+    const result = await ContentQualityService.checkUrl({
+      url: args.url,
+      targetKeyword: args.targetKeyword,
+    });
+
+    const text = [
+      `URL: ${result.url}`,
+      `Title: ${result.title ?? "(missing)"} (${result.titleLength} chars)`,
+      `Meta description: ${result.metaDescription ?? "(missing)"} (${result.metaDescriptionLength} chars)`,
+      `Word count: ${result.wordCount}`,
+      `Reading ease: ${result.readingEaseScore} (${result.readingEaseLabel})`,
+      `Headings: H1=${result.headingCounts.h1} H2=${result.headingCounts.h2} H3=${result.headingCounts.h3}`,
+      `Images: ${result.imageCount} total, ${result.imagesMissingAlt} missing alt text`,
+      `Links: ${result.internalLinkCount} internal, ${result.externalLinkCount} external`,
+      result.targetKeyword
+        ? `Target keyword "${result.targetKeyword.keyword}": in title=${result.targetKeyword.inTitle}, in H1=${result.targetKeyword.inH1}, in first paragraph=${result.targetKeyword.inFirstParagraph}, density=${result.targetKeyword.densityPercent}%`
+        : null,
+    ]
+      .filter((line): line is string => line !== null)
+      .join("\n");
+
+    return mcpResponse({
+      text,
+      meta: buildProjectMeta(
+        context,
+        args.projectId,
+        `/p/${args.projectId}/content-quality`,
+        { url: args.url },
+      ),
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- ContentAnalysis is a plain JSON-serializable object; mcpResponse's structuredContent just needs a Record view of it.
+      structuredContent: result as unknown as Record<string, unknown>,
+    });
+  }),
+};


### PR DESCRIPTION
Adds `check_content_quality`, a free MCP tool for on-page content quality analysis \u2014 part of closing the content-marketing-toolkit gap identified against Semrush's feature set.

**What it checks**, given a URL and optional target keyword:
- word/sentence counts, Flesch reading-ease score + label
- heading structure (H1/H2/H3 counts, H1 text)
- image alt-text coverage
- internal vs external link counts (split by host)
- target-keyword placement (title / H1 / first paragraph) and density, if provided

**Why MCP-only, no UI route:** mirrors the project's agent-first positioning \u2014 same reasoning as PR #167. Free (no DataForSEO credits), so no billing-context wiring needed either.

**Safety:** basic SSRF guards on the fetch \u2014 blocks localhost/private IP ranges and non-http(s) schemes, requires an HTML content-type, caps response size at 2MB.

Verified locally: `tsc --noEmit` clean (exit 0), full suite passing including 6 new unit tests for the analyzer. Same pre-existing `knip`/`vite.config.ts` environment issue as PR #167 applies here too, unrelated to this change.