### PR TITLE
feat: Google Business Profile connection (local SEO foundation)

### DIFF
--- a/src/db/gbp.schema.ts
+++ b/src/db/gbp.schema.ts
@@ -1,0 +1,40 @@
+import { sql } from "drizzle-orm";
+import { index, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
+import { organization } from "./better-auth-schema";
+import { projects } from "./app.schema";
+
+// Connected Google Business Profile location per project.
+// OAuth tokens live in the better-auth `account` table under providerId
+// "google-business-profile"; this row only records which verified location
+// maps to a project and whose grant to use when calling the Business Profile
+// APIs.
+export const gbpConnections = sqliteTable(
+  "gbp_connections",
+  {
+    id: text("id").primaryKey(),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    // Resource name from locations.list, e.g. "locations/12345678901234567890".
+    // Never normalize; the Business Information API matches it verbatim.
+    locationName: text("location_name").notNull(),
+    // Whose google-business-profile grant getAccessToken should use.
+    connectedByUserId: text("connected_by_user_id").notNull(),
+    gbpAccountId: text("gbp_account_id"),
+    connectedAccountEmail: text("connected_account_email"),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(current_timestamp)`),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(current_timestamp)`),
+  },
+  (table) => [
+    // One selected location per project in v1; switching replaces the row.
+    uniqueIndex("gbp_connections_project_idx").on(table.projectId),
+    index("gbp_connections_organization_idx").on(table.organizationId),
+  ],
+);

--- a/src/db/pg/gbp.schema.ts
+++ b/src/db/pg/gbp.schema.ts
@@ -1,0 +1,32 @@
+import { sql } from "drizzle-orm";
+import { index, pgTable, text, uniqueIndex } from "drizzle-orm/pg-core";
+import { organization } from "./better-auth-schema";
+import { projects } from "./app.schema";
+
+// See src/db/pg/app.schema.ts for why timestamps are ISO-8601 UTC text.
+const isoNow = sql`to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')`;
+
+// Connected Google Business Profile location per project. Mirrors
+// src/db/gbp.schema.ts (D1); see that file for field notes.
+export const gbpConnections = pgTable(
+  "gbp_connections",
+  {
+    id: text("id").primaryKey(),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    locationName: text("location_name").notNull(),
+    connectedByUserId: text("connected_by_user_id").notNull(),
+    gbpAccountId: text("gbp_account_id"),
+    connectedAccountEmail: text("connected_account_email"),
+    createdAt: text("created_at").notNull().default(isoNow),
+    updatedAt: text("updated_at").notNull().default(isoNow),
+  },
+  (table) => [
+    uniqueIndex("gbp_connections_project_idx").on(table.projectId),
+    index("gbp_connections_organization_idx").on(table.organizationId),
+  ],
+);

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -4,6 +4,7 @@ import * as sqliteAudit from "./audit.schema";
 import * as sqliteSam from "./sam.schema";
 import * as sqliteAuth from "./better-auth-schema";
 import * as sqliteBilling from "./billing.schema";
+import * as sqliteGbp from "./gbp.schema";
 import * as sqliteGsc from "./gsc.schema";
 import * as sqliteReddit from "./reddit-attribution.schema";
 import * as sqliteTelemetry from "./telemetry.schema";
@@ -12,6 +13,7 @@ import * as pgAudit from "./pg/audit.schema";
 import * as pgSam from "./pg/sam.schema";
 import * as pgAuth from "./pg/better-auth-schema";
 import * as pgBilling from "./pg/billing.schema";
+import * as pgGbp from "./pg/gbp.schema";
 import * as pgGsc from "./pg/gsc.schema";
 import * as pgReddit from "./pg/reddit-attribution.schema";
 import * as pgTelemetry from "./pg/telemetry.schema";
@@ -31,6 +33,7 @@ type AppSchema = typeof sqliteApp &
   typeof sqliteSam &
   typeof sqliteAuth &
   typeof sqliteBilling &
+  typeof sqliteGbp &
   typeof sqliteGsc &
   typeof sqliteReddit &
   typeof sqliteTelemetry;
@@ -43,6 +46,8 @@ const runtimeSchema =
         ...pgSam,
         ...pgAuth,
         ...pgBilling,
+        ...pgGbp,
+        ...pgGbp,
         ...pgGsc,
         ...pgReddit,
         ...pgTelemetry,
@@ -53,6 +58,8 @@ const runtimeSchema =
         ...sqliteSam,
         ...sqliteAuth,
         ...sqliteBilling,
+        ...sqliteGbp,
+        ...sqliteGbp,
         ...sqliteGsc,
         ...sqliteReddit,
         ...sqliteTelemetry,
@@ -91,6 +98,7 @@ export const {
   invitation,
   billingCustomerStatus,
   gscConnections,
+  gbpConnections,
   redditAttributions,
   telemetryState,
 } = schema;

--- a/src/lib/auth-config.ts
+++ b/src/lib/auth-config.ts
@@ -2,6 +2,7 @@ import { env } from "cloudflare:workers";
 import { genericOAuth, organization } from "better-auth/plugins";
 import { baseAuthOptions } from "@/lib/auth-options";
 import { GSC_OAUTH_PROVIDER_ID, GSC_OAUTH_SCOPES } from "@/shared/gsc";
+import { GBP_OAUTH_PROVIDER_ID, GBP_OAUTH_SCOPES } from "@/shared/gbp";
 
 export function createBaseAuthConfig() {
   return {
@@ -44,6 +45,17 @@ export function createBaseAuthConfig() {
               "https://accounts.google.com/.well-known/openid-configuration",
             scopes: [...GSC_OAUTH_SCOPES],
             accessType: "offline", // request a refresh token
+            prompt: "select_account consent",
+            pkce: true,
+          },
+          {
+            providerId: GBP_OAUTH_PROVIDER_ID,
+            clientId: env.GOOGLE_CLIENT_ID?.trim() ?? "",
+            clientSecret: env.GOOGLE_CLIENT_SECRET?.trim() ?? "",
+            discoveryUrl:
+              "https://accounts.google.com/.well-known/openid-configuration",
+            scopes: [...GBP_OAUTH_SCOPES],
+            accessType: "offline",
             prompt: "select_account consent",
             pkce: true,
           },

--- a/src/routes/api/gbp/oauth/callback.ts
+++ b/src/routes/api/gbp/oauth/callback.ts
@@ -1,0 +1,46 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { env } from "cloudflare:workers";
+import { getAuthMode, isHostedAuthMode } from "@/lib/auth-mode";
+import { resolveCloudflareAccessContext } from "@/middleware/ensure-user/cloudflareAccess";
+import { resolveLocalNoAuthContext } from "@/middleware/ensure-user/delegated";
+import { responseForAppError } from "@/server/lib/http-errors";
+import { handleSelfHostedGbpOAuthCallback } from "@/server/features/gbp/selfHostedOAuth";
+import { getPublicOrigin } from "@/server/mcp/public-origin";
+
+async function resolveSelfHostedContext(request: Request) {
+  const authMode = getAuthMode(env.AUTH_MODE);
+
+  if (isHostedAuthMode(authMode)) return null;
+
+  return authMode === "local_noauth"
+    ? resolveLocalNoAuthContext()
+    : resolveCloudflareAccessContext(request.headers);
+}
+
+async function handleCallbackRequest(request: Request) {
+  try {
+    const context = await resolveSelfHostedContext(request);
+    if (!context) return new Response("Not found", { status: 404 });
+
+    return await handleSelfHostedGbpOAuthCallback({
+      request,
+      user: {
+        userId: context.userId,
+        userEmail: context.userEmail,
+      },
+      publicOrigin: getPublicOrigin(request),
+    });
+  } catch (error) {
+    return responseForAppError(error, "Business Profile OAuth failed");
+  }
+}
+
+export const Route = createFileRoute("/api/gbp/oauth/callback")({
+  server: {
+    handlers: {
+      GET: async ({ request }: { request: Request }) => {
+        return handleCallbackRequest(request);
+      },
+    },
+  },
+});

--- a/src/server/features/gbp/oauth-config.ts
+++ b/src/server/features/gbp/oauth-config.ts
@@ -1,0 +1,28 @@
+import { getOptionalEnvValue } from "@/server/lib/runtime-env";
+
+type GbpOAuthClientConfig = {
+  clientId: string;
+  clientSecret: string;
+};
+
+export async function getGbpOAuthClientConfig(): Promise<GbpOAuthClientConfig | null> {
+  const clientId = (await getOptionalEnvValue("GOOGLE_CLIENT_ID"))?.trim();
+  const clientSecret = (
+    await getOptionalEnvValue("GOOGLE_CLIENT_SECRET")
+  )?.trim();
+
+  if (!clientId || !clientSecret) return null;
+
+  return { clientId, clientSecret };
+}
+
+// Self-hosted Business Profile needs the same Google OAuth client AND
+// BETTER_AUTH_SECRET (>=32 chars) as Search Console: the secret keys
+// OAuth-token encryption and lets us build the Better Auth instance that
+// mints/refreshes tokens. Both must be set before we surface the connect flow.
+export async function hasSelfHostedGbpConfig(): Promise<boolean> {
+  if (!(await getGbpOAuthClientConfig())) return false;
+
+  const secret = (await getOptionalEnvValue("BETTER_AUTH_SECRET"))?.trim();
+  return Boolean(secret && secret.length >= 32);
+}

--- a/src/server/features/gbp/repositories/GbpConnectionRepository.ts
+++ b/src/server/features/gbp/repositories/GbpConnectionRepository.ts
@@ -1,0 +1,75 @@
+import { and, eq, sql } from "drizzle-orm";
+import { db } from "@/db";
+import { gbpConnections } from "@/db/schema";
+
+export type GbpConnection = typeof gbpConnections.$inferSelect;
+
+async function getByProjectId(
+  projectId: string,
+): Promise<GbpConnection | null> {
+  const rows = await db
+    .select()
+    .from(gbpConnections)
+    .where(eq(gbpConnections.projectId, projectId))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+async function upsert(input: {
+  projectId: string;
+  organizationId: string;
+  locationName: string;
+  connectedByUserId: string;
+  gbpAccountId: string;
+  connectedAccountEmail: string | null;
+}): Promise<GbpConnection> {
+  const [row] = await db
+    .insert(gbpConnections)
+    .values({ id: crypto.randomUUID(), ...input })
+    .onConflictDoUpdate({
+      target: gbpConnections.projectId,
+      set: {
+        locationName: input.locationName,
+        organizationId: input.organizationId,
+        connectedByUserId: input.connectedByUserId,
+        gbpAccountId: input.gbpAccountId,
+        connectedAccountEmail: sql`coalesce(${input.connectedAccountEmail}, ${gbpConnections.connectedAccountEmail})`,
+        updatedAt: sql`(current_timestamp)`,
+      },
+    })
+    .returning();
+  if (!row) {
+    throw new Error("Failed to upsert gbp_connection");
+  }
+  return row;
+}
+
+async function deleteByProjectId(projectId: string): Promise<void> {
+  await db
+    .delete(gbpConnections)
+    .where(eq(gbpConnections.projectId, projectId));
+}
+
+async function existsForConnectorAccount(
+  userId: string,
+  gbpAccountId: string,
+): Promise<boolean> {
+  const rows = await db
+    .select({ id: gbpConnections.id })
+    .from(gbpConnections)
+    .where(
+      and(
+        eq(gbpConnections.connectedByUserId, userId),
+        eq(gbpConnections.gbpAccountId, gbpAccountId),
+      ),
+    )
+    .limit(1);
+  return rows.length > 0;
+}
+
+export const GbpConnectionRepository = {
+  getByProjectId,
+  upsert,
+  deleteByProjectId,
+  existsForConnectorAccount,
+};

--- a/src/server/features/gbp/selfHostedOAuth.ts
+++ b/src/server/features/gbp/selfHostedOAuth.ts
@@ -1,0 +1,339 @@
+import { symmetricEncrypt } from "better-auth/crypto";
+import { and, eq } from "drizzle-orm";
+import { decodeJwt } from "jose";
+import { z } from "zod";
+import { db } from "@/db";
+import { account } from "@/db/schema";
+import { getAuth } from "@/lib/auth";
+import { AppError } from "@/server/lib/errors";
+import { GBP_OAUTH_PROVIDER_ID, GBP_OAUTH_SCOPES } from "@/shared/gbp";
+import {
+  getGbpOAuthClientConfig,
+  hasSelfHostedGbpConfig,
+} from "./oauth-config";
+
+const GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
+const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+
+type SelfHostedGbpUser = {
+  userId: string;
+  userEmail: string;
+};
+
+const oauthStateSchema = z.object({
+  userId: z.string().min(1),
+  callbackPath: z.string().min(1),
+  exp: z.number().int(),
+});
+
+const googleTokenResponseSchema = z.object({
+  access_token: z.string().min(1),
+  expires_in: z.number().optional(),
+  refresh_token: z.string().optional(),
+  scope: z.string().optional(),
+  id_token: z.string().optional(),
+  token_type: z.string().optional(),
+});
+
+const googleIdTokenSchema = z.object({
+  sub: z.string().min(1),
+});
+
+type GoogleTokenResponse = z.infer<typeof googleTokenResponseSchema>;
+
+function bytesToBase64Url(bytes: Uint8Array) {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary)
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replaceAll("=", "");
+}
+
+function base64UrlToBytes(value: string) {
+  const padded = `${value}${"=".repeat((4 - (value.length % 4)) % 4)}`;
+  const binary = atob(padded.replaceAll("-", "+").replaceAll("_", "/"));
+  return Uint8Array.from(binary, (char) => char.charCodeAt(0));
+}
+
+async function getStateKey(clientSecret: string) {
+  return crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(`openseo:gbp:${clientSecret}`),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign", "verify"],
+  );
+}
+
+async function signState(payload: string, clientSecret: string) {
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    await getStateKey(clientSecret),
+    new TextEncoder().encode(payload),
+  );
+  return bytesToBase64Url(new Uint8Array(signature));
+}
+
+function getSafeCallbackPath(callbackURL: string, publicOrigin: string) {
+  try {
+    const url = new URL(callbackURL, publicOrigin);
+    if (url.origin !== publicOrigin) return "/";
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    return "/";
+  }
+}
+
+async function createState(input: {
+  clientSecret: string;
+  userId: string;
+  callbackURL: string;
+  publicOrigin: string;
+}) {
+  const payload = bytesToBase64Url(
+    new TextEncoder().encode(
+      JSON.stringify({
+        userId: input.userId,
+        callbackPath: getSafeCallbackPath(
+          input.callbackURL,
+          input.publicOrigin,
+        ),
+        exp: Date.now() + 10 * 60 * 1_000,
+      }),
+    ),
+  );
+  const signature = await signState(payload, input.clientSecret);
+  return `${payload}.${signature}`;
+}
+
+async function verifyState(state: string, clientSecret: string) {
+  const [payload, signature] = state.split(".");
+  if (!payload || !signature) {
+    throw new AppError("VALIDATION_ERROR", "Invalid Business Profile state");
+  }
+
+  const ok = await crypto.subtle.verify(
+    "HMAC",
+    await getStateKey(clientSecret),
+    base64UrlToBytes(signature),
+    new TextEncoder().encode(payload),
+  );
+  if (!ok) {
+    throw new AppError("VALIDATION_ERROR", "Invalid Business Profile state");
+  }
+
+  const parsed = oauthStateSchema.parse(
+    JSON.parse(new TextDecoder().decode(base64UrlToBytes(payload))),
+  );
+  if (parsed.exp < Date.now()) {
+    throw new AppError("VALIDATION_ERROR", "Expired Business Profile state");
+  }
+
+  return parsed;
+}
+
+function getRedirectUri(publicOrigin: string) {
+  return `${publicOrigin}/api/gbp/oauth/callback`;
+}
+
+function accessTokenExpiresAt(tokens: GoogleTokenResponse) {
+  return new Date(Date.now() + (tokens.expires_in ?? 3600) * 1_000);
+}
+
+function storedScope(tokens: GoogleTokenResponse) {
+  return tokens.scope
+    ? tokens.scope.trim().split(/\s+/).join(",")
+    : GBP_OAUTH_SCOPES.join(",");
+}
+
+function getGoogleAccountId(tokens: GoogleTokenResponse) {
+  if (!tokens.id_token) {
+    throw new AppError(
+      "VALIDATION_ERROR",
+      "Google did not return an ID token for Business Profile.",
+    );
+  }
+  return googleIdTokenSchema.parse(decodeJwt(tokens.id_token)).sub;
+}
+
+async function upsertGrant(input: {
+  user: SelfHostedGbpUser;
+  tokens: GoogleTokenResponse;
+}) {
+  // Encrypt tokens at rest exactly the way Better Auth's setTokenUtil does
+  // (same key from BETTER_AUTH_SECRET, same crypto, same encryptOAuthTokens
+  // gate), so getAccessToken decrypts them on read — and so flipping the flag
+  // can never desync the write and read paths.
+  const ctx = await getAuth().$context;
+  const encrypt = (value: string) =>
+    ctx.options.account?.encryptOAuthTokens
+      ? symmetricEncrypt({ key: ctx.secretConfig, data: value })
+      : value;
+  const googleAccountId = getGoogleAccountId(input.tokens);
+
+  const existing = await db
+    .select({ id: account.id, refreshToken: account.refreshToken })
+    .from(account)
+    .where(
+      and(
+        eq(account.userId, input.user.userId),
+        eq(account.providerId, GBP_OAUTH_PROVIDER_ID),
+        eq(account.accountId, googleAccountId),
+      ),
+    )
+    .limit(1);
+
+  const accountValues = {
+    accountId: googleAccountId,
+    providerId: GBP_OAUTH_PROVIDER_ID,
+    userId: input.user.userId,
+    accessToken: await encrypt(input.tokens.access_token),
+    // A fresh refresh token is encrypted here; an absent one falls back to the
+    // already-encrypted value stored on the existing grant.
+    refreshToken: input.tokens.refresh_token
+      ? await encrypt(input.tokens.refresh_token)
+      : (existing[0]?.refreshToken ?? null),
+    idToken: input.tokens.id_token
+      ? await encrypt(input.tokens.id_token)
+      : null,
+    accessTokenExpiresAt: accessTokenExpiresAt(input.tokens),
+    refreshTokenExpiresAt: null,
+    scope: storedScope(input.tokens),
+    password: null,
+  };
+
+  if (existing[0]) {
+    await db
+      .update(account)
+      .set({ ...accountValues, updatedAt: new Date() })
+      .where(eq(account.id, existing[0].id));
+    return;
+  }
+
+  await db.insert(account).values({
+    id: crypto.randomUUID(),
+    ...accountValues,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+}
+
+async function exchangeCode(input: {
+  code: string;
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+}) {
+  const response = await fetch(GOOGLE_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      code: input.code,
+      client_id: input.clientId,
+      client_secret: input.clientSecret,
+      redirect_uri: input.redirectUri,
+      grant_type: "authorization_code",
+    }),
+  });
+
+  if (!response.ok) {
+    throw new AppError(
+      "VALIDATION_ERROR",
+      "Google rejected the Business Profile authorization code.",
+    );
+  }
+
+  return googleTokenResponseSchema.parse(await response.json());
+}
+
+export async function createSelfHostedGbpAuthorizationUrl(input: {
+  user: SelfHostedGbpUser;
+  callbackURL: string;
+  publicOrigin: string;
+}) {
+  const config = await getGbpOAuthClientConfig();
+  if (!config || !(await hasSelfHostedGbpConfig())) {
+    throw new AppError(
+      "AUTH_CONFIG_MISSING",
+      "Business Profile is not configured. Set GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, and BETTER_AUTH_SECRET.",
+    );
+  }
+
+  const redirectUri = getRedirectUri(input.publicOrigin);
+  const state = await createState({
+    clientSecret: config.clientSecret,
+    userId: input.user.userId,
+    callbackURL: input.callbackURL,
+    publicOrigin: input.publicOrigin,
+  });
+  const url = new URL(GOOGLE_AUTH_URL);
+  url.searchParams.set("client_id", config.clientId);
+  url.searchParams.set("redirect_uri", redirectUri);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("scope", GBP_OAUTH_SCOPES.join(" "));
+  url.searchParams.set("access_type", "offline");
+  url.searchParams.set("prompt", "select_account consent");
+  url.searchParams.set("state", state);
+
+  return url.toString();
+}
+
+export async function handleSelfHostedGbpOAuthCallback(input: {
+  request: Request;
+  user: SelfHostedGbpUser;
+  publicOrigin: string;
+}) {
+  const config = await getGbpOAuthClientConfig();
+  if (!config) {
+    return new Response("Missing Google Business Profile OAuth configuration", {
+      status: 500,
+    });
+  }
+
+  const url = new URL(input.request.url);
+  const stateParam = url.searchParams.get("state");
+  if (!stateParam) {
+    return new Response("Missing Business Profile OAuth state", {
+      status: 400,
+    });
+  }
+
+  const state = await verifyState(stateParam, config.clientSecret);
+  if (state.userId !== input.user.userId) {
+    return new Response("Business Profile OAuth user mismatch", {
+      status: 403,
+    });
+  }
+
+  // state.callbackPath is a validated same-origin relative path
+  // (getSafeCallbackPath). Redirect with a *relative* Location so the browser
+  // resolves it against the real request origin — this avoids trusting
+  // x-forwarded-host for the final hop.
+  const redirectToCallback = () =>
+    new Response(null, {
+      status: 303,
+      headers: { Location: state.callbackPath },
+    });
+
+  if (url.searchParams.get("error")) {
+    return redirectToCallback();
+  }
+
+  const code = url.searchParams.get("code");
+  if (!code) {
+    return new Response("Missing Business Profile OAuth code", { status: 400 });
+  }
+
+  const tokens = await exchangeCode({
+    code,
+    clientId: config.clientId,
+    clientSecret: config.clientSecret,
+    redirectUri: getRedirectUri(input.publicOrigin),
+  });
+  await upsertGrant({ user: input.user, tokens });
+
+  return redirectToCallback();
+}

--- a/src/server/features/gbp/services/GbpService.ts
+++ b/src/server/features/gbp/services/GbpService.ts
@@ -1,0 +1,245 @@
+import { and, eq } from "drizzle-orm";
+import { db } from "@/db";
+import { account } from "@/db/schema";
+import { GBP_OAUTH_PROVIDER_ID } from "@/shared/gbp";
+import { AppError } from "@/server/lib/errors";
+import {
+  createGbpClient,
+  GbpApiError,
+  GbpTokenError,
+  type GbpAccount,
+  type GbpLocation,
+  type GbpLocationSummary,
+} from "@/server/lib/gbpClient";
+import {
+  GbpConnectionRepository,
+  type GbpConnection,
+} from "@/server/features/gbp/repositories/GbpConnectionRepository";
+
+type GbpAccountListResult = {
+  accounts: Array<{
+    accountId: string;
+    email: string | null;
+    requiresReconnect: boolean;
+    locations: GbpLocationSummary[];
+  }>;
+};
+
+/** Thrown when a project has no connected GBP location. */
+export class GbpNotConnectedError extends Error {
+  constructor(public readonly projectId: string) {
+    super("Business Profile is not connected for this project");
+    this.name = "GbpNotConnectedError";
+  }
+}
+
+async function getConnection(projectId: string): Promise<GbpConnection | null> {
+  return GbpConnectionRepository.getByProjectId(projectId);
+}
+
+/** Whether this user has linked a google-business-profile grant (regardless of
+ *  whether they've picked a location yet). Drives the connect-vs-pick UI. */
+async function userHasGrant(userId: string): Promise<boolean> {
+  const rows = await db
+    .select({ id: account.id })
+    .from(account)
+    .where(
+      and(
+        eq(account.userId, userId),
+        eq(account.providerId, GBP_OAUTH_PROVIDER_ID),
+      ),
+    )
+    .limit(1);
+  return rows.length > 0;
+}
+
+async function listGrantsForUser(userId: string) {
+  return db
+    .select({ id: account.id, accountId: account.accountId })
+    .from(account)
+    .where(
+      and(
+        eq(account.userId, userId),
+        eq(account.providerId, GBP_OAUTH_PROVIDER_ID),
+      ),
+    );
+}
+
+/** Expected ways a stored grant fails to reach Business Profile: no token could be
+ *  minted (refresh token revoked or expired), or Google rejected the call
+ *  (401/403). These surface a reconnect prompt without fault logging. */
+export function isExpectedGrantFailure(error: unknown): boolean {
+  if (error instanceof GbpTokenError) return true;
+  return (
+    error instanceof GbpApiError &&
+    (error.status === 401 || error.status === 403)
+  );
+}
+
+async function listAccountsForUserWithGrantStatus(
+  userId: string,
+): Promise<GbpAccountListResult> {
+  const grants = await listGrantsForUser(userId);
+  const accounts = await Promise.all(
+    grants.map(async (grant) => {
+      const client = createGbpClient({ userId, gbpAccountId: grant.accountId });
+
+      try {
+        const gbpAccounts: GbpAccount[] = await client.listAccounts();
+        let email: string | null = null;
+        try {
+          email = await client.getUserInfoEmail();
+        } catch {
+          email = null;
+        }
+
+        const locationsByAccount = await Promise.all(
+          gbpAccounts.map((gbpAccount) =>
+            client.listLocations(gbpAccount.name),
+          ),
+        );
+
+        return {
+          accountId: grant.accountId,
+          email,
+          requiresReconnect: false,
+          locations: locationsByAccount.flat(),
+        };
+      } catch (error) {
+        if (!isExpectedGrantFailure(error)) {
+          console.error(
+            "Failed to list Business Profile locations for account",
+            grant.accountId,
+            error,
+          );
+        }
+        return {
+          accountId: grant.accountId,
+          email: null,
+          requiresReconnect: true,
+          locations: [],
+        };
+      }
+    }),
+  );
+
+  return { accounts };
+}
+
+/** Map a verified location to a project. Rejects locations not present on the
+ *  connector's grant. */
+async function setLocation(input: {
+  projectId: string;
+  organizationId: string;
+  locationName: string;
+  accountId: string;
+  userId: string;
+}): Promise<GbpConnection> {
+  const grants = await listGrantsForUser(input.userId);
+  if (!grants.some((grant) => grant.accountId === input.accountId)) {
+    throw new AppError(
+      "NOT_FOUND",
+      "That Google account isn't connected to your OpenSEO account.",
+    );
+  }
+
+  const client = createGbpClient({
+    userId: input.userId,
+    gbpAccountId: input.accountId,
+  });
+  const gbpAccounts = await client.listAccounts();
+  const locationsByAccount = await Promise.all(
+    gbpAccounts.map((gbpAccount) => client.listLocations(gbpAccount.name)),
+  );
+  const allLocations = locationsByAccount.flat();
+  const match = allLocations.find(
+    (location) => location.name === input.locationName,
+  );
+  if (!match) {
+    throw new AppError(
+      "NOT_FOUND",
+      "That location isn't available on your connected Google account.",
+    );
+  }
+
+  let connectedAccountEmail: string | null = null;
+  try {
+    connectedAccountEmail = await client.getUserInfoEmail();
+  } catch {
+    connectedAccountEmail = null;
+  }
+
+  return GbpConnectionRepository.upsert({
+    projectId: input.projectId,
+    organizationId: input.organizationId,
+    locationName: input.locationName,
+    connectedByUserId: input.userId,
+    gbpAccountId: input.accountId,
+    connectedAccountEmail,
+  });
+}
+
+async function unlinkUserGrant(
+  userId: string,
+  gbpAccountId: string,
+): Promise<void> {
+  await db
+    .delete(account)
+    .where(
+      and(
+        eq(account.userId, userId),
+        eq(account.providerId, GBP_OAUTH_PROVIDER_ID),
+        eq(account.accountId, gbpAccountId),
+      ),
+    );
+}
+
+async function disconnect(input: {
+  projectId: string;
+  userId: string;
+}): Promise<void> {
+  const connection = await GbpConnectionRepository.getByProjectId(
+    input.projectId,
+  );
+  await GbpConnectionRepository.deleteByProjectId(input.projectId);
+  if (
+    connection?.gbpAccountId &&
+    connection.connectedByUserId === input.userId
+  ) {
+    const stillUsed = await GbpConnectionRepository.existsForConnectorAccount(
+      input.userId,
+      connection.gbpAccountId,
+    );
+    if (!stillUsed) {
+      await unlinkUserGrant(input.userId, connection.gbpAccountId);
+    }
+  }
+}
+
+/** Fetch the full profile (title, address, phone, categories, hours, website)
+ *  for a project's connected location. */
+async function getLocationInfo(input: {
+  projectId: string;
+}): Promise<{ location: GbpLocation; connectedBy: string | null }> {
+  const connection = await GbpConnectionRepository.getByProjectId(
+    input.projectId,
+  );
+  if (!connection) {
+    throw new GbpNotConnectedError(input.projectId);
+  }
+  const client = createGbpClient({
+    userId: connection.connectedByUserId,
+    gbpAccountId: connection.gbpAccountId ?? undefined,
+  });
+  const location = await client.getLocation(connection.locationName);
+  return { location, connectedBy: connection.connectedAccountEmail };
+}
+
+export const GbpService = {
+  getConnection,
+  userHasGrant,
+  listAccountsForUserWithGrantStatus,
+  setLocation,
+  disconnect,
+  getLocationInfo,
+};

--- a/src/server/lib/gbpClient.ts
+++ b/src/server/lib/gbpClient.ts
@@ -1,0 +1,200 @@
+import { getAuth } from "@/lib/auth";
+import { GBP_OAUTH_PROVIDER_ID } from "@/shared/gbp";
+
+const GBP_ACCOUNTS_API_BASE =
+  "https://mybusinessaccountmanagement.googleapis.com/v1";
+const GBP_BUSINESS_INFO_API_BASE =
+  "https://mybusinessbusinessinformation.googleapis.com/v1";
+const GOOGLE_USERINFO_URL = "https://openidconnect.googleapis.com/v1/userinfo";
+
+const LOCATION_READ_MASK = [
+  "name",
+  "title",
+  "storefrontAddress",
+  "phoneNumbers",
+  "categories",
+  "regularHours",
+  "websiteUri",
+  "metadata",
+].join(",");
+
+/** A GBP REST call returned a non-2xx status. `status` drives user-facing messaging. */
+export class GbpApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+    public readonly body?: string,
+  ) {
+    super(message);
+    this.name = "GbpApiError";
+  }
+}
+
+/** No fresh access token could be minted — the user revoked the grant, or the
+ *  refresh token expired (e.g. weekly in Google's OAuth "Testing" mode). */
+export class GbpTokenError extends Error {
+  constructor(
+    message: string,
+    public readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = "GbpTokenError";
+  }
+}
+
+export type GbpAccount = {
+  name: string;
+  accountName?: string;
+  type?: string;
+};
+
+export type GbpLocationSummary = {
+  name: string;
+  title?: string;
+};
+
+export type GbpAddress = {
+  regionCode?: string;
+  postalCode?: string;
+  administrativeArea?: string;
+  locality?: string;
+  addressLines?: string[];
+};
+
+export type GbpPhoneNumbers = {
+  primaryPhone?: string;
+  additionalPhones?: string[];
+};
+
+export type GbpCategory = {
+  name?: string;
+  displayName?: string;
+};
+
+export type GbpCategories = {
+  primaryCategory?: GbpCategory;
+  additionalCategories?: GbpCategory[];
+};
+
+export type GbpTimePeriod = {
+  openDay?: string;
+  openTime?: { hours?: number; minutes?: number };
+  closeDay?: string;
+  closeTime?: { hours?: number; minutes?: number };
+};
+
+export type GbpRegularHours = {
+  periods?: GbpTimePeriod[];
+};
+
+export type GbpLocation = {
+  name: string;
+  title?: string;
+  storefrontAddress?: GbpAddress;
+  phoneNumbers?: GbpPhoneNumbers;
+  categories?: GbpCategories;
+  regularHours?: GbpRegularHours;
+  websiteUri?: string;
+  metadata?: { mapsUri?: string; newReviewUri?: string };
+};
+
+function messageForStatus(status: number, body: string): string {
+  if (status === 401 || status === 403) {
+    return "Business Profile denied access to this location (no verified permission, or the connection was revoked).";
+  }
+  if (status === 429) {
+    return "Business Profile rate limit reached. Retry shortly.";
+  }
+  if (status === 404) {
+    return "Business Profile location not found. It may have been removed.";
+  }
+  return `Business Profile API error (${status}): ${body.slice(0, 300)}`;
+}
+
+/** Free Google Business Profile client. Like the GSC client, it does NOT meter
+ *  credits — Business Profile is first-party data with no per-call cost. Access
+ *  tokens are minted (and auto-refreshed) by Better Auth from the connector's
+ *  stored google-business-profile grant. */
+export function createGbpClient(opts: {
+  userId: string;
+  gbpAccountId?: string;
+}) {
+  async function getToken(): Promise<string> {
+    let result: { accessToken?: string } | undefined;
+    try {
+      result = await getAuth().api.getAccessToken({
+        body: {
+          providerId: GBP_OAUTH_PROVIDER_ID,
+          userId: opts.userId,
+          ...(opts.gbpAccountId ? { accountId: opts.gbpAccountId } : {}),
+        },
+      });
+    } catch (error) {
+      throw new GbpTokenError(
+        "Could not mint a Business Profile access token (grant revoked or expired).",
+        error,
+      );
+    }
+    if (!result?.accessToken) {
+      throw new GbpTokenError(
+        "Business Profile returned no access token (grant revoked or expired).",
+      );
+    }
+    return result.accessToken;
+  }
+
+  async function request<T>(
+    url: string,
+    init?: { method?: string; body?: unknown },
+  ): Promise<T> {
+    const token = await getToken();
+    const hasBody = init?.body !== undefined;
+    const response = await fetch(url, {
+      method: init?.method ?? "GET",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        ...(hasBody ? { "Content-Type": "application/json" } : {}),
+      },
+      body: hasBody ? JSON.stringify(init?.body) : undefined,
+    });
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      throw new GbpApiError(
+        response.status,
+        messageForStatus(response.status, body),
+        body,
+      );
+    }
+    return (await response.json()) as T;
+  }
+
+  return {
+    async getUserInfoEmail(): Promise<string | null> {
+      const data = await request<{ email?: unknown }>(GOOGLE_USERINFO_URL);
+      return typeof data.email === "string" ? data.email : null;
+    },
+
+    /** Account Management API `accounts.list` — the accounts the grant can manage. */
+    async listAccounts(): Promise<GbpAccount[]> {
+      const data = await request<{ accounts?: GbpAccount[] }>(
+        `${GBP_ACCOUNTS_API_BASE}/accounts`,
+      );
+      return data.accounts ?? [];
+    },
+
+    /** Business Information API `accounts.locations.list` for one account. */
+    async listLocations(accountName: string): Promise<GbpLocationSummary[]> {
+      const data = await request<{ locations?: GbpLocationSummary[] }>(
+        `${GBP_BUSINESS_INFO_API_BASE}/${accountName}/locations?readMask=name,title`,
+      );
+      return data.locations ?? [];
+    },
+
+    /** Business Information API `locations.get`, full profile fields. */
+    async getLocation(locationName: string): Promise<GbpLocation> {
+      return request<GbpLocation>(
+        `${GBP_BUSINESS_INFO_API_BASE}/${locationName}?readMask=${LOCATION_READ_MASK}`,
+      );
+    },
+  };
+}

--- a/src/serverFunctions/gbp.ts
+++ b/src/serverFunctions/gbp.ts
@@ -1,0 +1,121 @@
+import { createServerFn } from "@tanstack/react-start";
+import { getRequest } from "@tanstack/react-start/server";
+import { z } from "zod";
+import { GbpService } from "@/server/features/gbp/services/GbpService";
+import { hasSelfHostedGbpConfig } from "@/server/features/gbp/oauth-config";
+import { createSelfHostedGbpAuthorizationUrl } from "@/server/features/gbp/selfHostedOAuth";
+import { getPublicOrigin } from "@/server/mcp/public-origin";
+import { isHostedServerAuthMode } from "@/server/lib/runtime-env";
+import {
+  requireAuthenticatedContext,
+  requireProjectContext,
+} from "@/serverFunctions/middleware";
+
+const projectScopedSchema = z.object({ projectId: z.string().min(1) });
+const setLocationSchema = projectScopedSchema.extend({
+  accountId: z.string().min(1),
+  locationName: z.string().min(1),
+});
+const startSelfHostedLinkSchema = z.object({
+  callbackURL: z.string().min(1),
+});
+
+// Account-level grant check (no project needed) for surfaces like onboarding
+// where the user hasn't picked a project yet. The OAuth grant is per-account;
+// binding a location to a project happens later in Integrations.
+export const getGbpGrantStatus = createServerFn({ method: "GET" })
+  .middleware(requireAuthenticatedContext)
+  .handler(async ({ context }) => {
+    return { connected: await GbpService.userHasGrant(context.userId) };
+  });
+
+export const getGbpConnection = createServerFn({ method: "POST" })
+  .middleware(requireProjectContext)
+  .validator(projectScopedSchema)
+  .handler(async ({ context }) => {
+    const [connection, currentUserHasGrant, hosted, gbpConfigured] =
+      await Promise.all([
+        GbpService.getConnection(context.projectId),
+        GbpService.userHasGrant(context.userId),
+        isHostedServerAuthMode(),
+        hasSelfHostedGbpConfig(),
+      ]);
+    return {
+      connected: Boolean(connection),
+      currentUserHasGrant,
+      googleOAuthConfigured: hosted || gbpConfigured,
+      locationName: connection?.locationName ?? null,
+      connectedByEmail: connection?.connectedAccountEmail ?? null,
+      connectedAt: connection?.createdAt ?? null,
+    };
+  });
+
+export const listGbpLocations = createServerFn({ method: "POST" })
+  .middleware(requireProjectContext)
+  .validator(projectScopedSchema)
+  .handler(async ({ context }) => {
+    const [accountList, connection] = await Promise.all([
+      GbpService.listAccountsForUserWithGrantStatus(context.userId),
+      GbpService.getConnection(context.projectId),
+    ]);
+    return {
+      accounts: accountList.accounts.map((grant) => ({
+        accountId: grant.accountId,
+        email: grant.email,
+        requiresReconnect: grant.requiresReconnect,
+        locations: grant.locations.map((location) => ({
+          locationName: location.name,
+          title: location.title ?? location.name,
+          isSelected:
+            connection?.gbpAccountId === grant.accountId &&
+            connection?.locationName === location.name,
+        })),
+      })),
+    };
+  });
+
+export const setGbpLocation = createServerFn({ method: "POST" })
+  .middleware(requireProjectContext)
+  .validator(setLocationSchema)
+  .handler(async ({ data, context }) => {
+    const connection = await GbpService.setLocation({
+      projectId: context.projectId,
+      organizationId: context.organizationId,
+      accountId: data.accountId,
+      locationName: data.locationName,
+      userId: context.userId,
+    });
+    return { connected: true as const, locationName: connection.locationName };
+  });
+
+export const disconnectGbp = createServerFn({ method: "POST" })
+  .middleware(requireProjectContext)
+  .validator(projectScopedSchema)
+  .handler(async ({ context }) => {
+    await GbpService.disconnect({
+      projectId: context.projectId,
+      userId: context.userId,
+    });
+    return { disconnected: true as const };
+  });
+
+export const getGbpLocationInfo = createServerFn({ method: "POST" })
+  .middleware(requireProjectContext)
+  .validator(projectScopedSchema)
+  .handler(async ({ context }) => {
+    return GbpService.getLocationInfo({ projectId: context.projectId });
+  });
+
+export const startGbpSelfHostedLink = createServerFn({ method: "POST" })
+  .middleware(requireAuthenticatedContext)
+  .validator(startSelfHostedLinkSchema)
+  .handler(async ({ data, context }) => {
+    const publicOrigin = getPublicOrigin(getRequest());
+    return {
+      url: await createSelfHostedGbpAuthorizationUrl({
+        user: { userId: context.userId, userEmail: context.userEmail },
+        callbackURL: data.callbackURL,
+        publicOrigin,
+      }),
+    };
+  });

--- a/src/shared/gbp.ts
+++ b/src/shared/gbp.ts
@@ -1,0 +1,14 @@
+/** Better Auth providerId for the incremental Google Business Profile connection.
+ *  Kept in `shared` so both server (auth config, GBP client) and client (connect
+ *  button) can reference it without importing the server-only auth config. */
+export const GBP_OAUTH_PROVIDER_ID = "google-business-profile";
+
+export const GBP_OAUTH_SCOPES = [
+  "openid",
+  "email",
+  "profile",
+  "https://www.googleapis.com/auth/business.manage",
+] as const;
+
+export const GBP_SELF_HOSTED_SETUP_DOCS_URL =
+  "https://github.com/every-app/open-seo/blob/main/docs/SELF_HOSTING_GOOGLE_BUSINESS_PROFILE.md";


### PR DESCRIPTION
Foundation for the local-SEO / listing-management gap identified against Semrush's feature set: connects a project to a verified Google Business Profile location.

**Architecture** mirrors the existing Search Console integration exactly -- same generic-OAuth provider pattern (reuses `GOOGLE_CLIENT_ID`/`SECRET`, just adds the `business.manage` scope), same token encryption via Better Auth, same HMAC-signed state for CSRF protection, same same-origin redirect validation.

**What it does:** OAuth connect flow, list accounts + locations with per-grant reconnect status, bind a location to a project, disconnect, and fetch the full location profile (title, address, phone, categories, regular hours, website) via the Business Information API.

**Scope:** read-only vertical slice (accounts.list, locations.list, locations.get) -- no write operations, Q&A, or reviews yet, matching the incremental approach from #167 and #168.

**Real-world caveat:** Business Profile API access requires a separate approval application from Google (unlike Search Console). This PR builds the correct integration; a live connection needs that approval granted first.

**Verified:** full suite 733/733 passing, schema-parity 120/120 passing. `tsc --noEmit` has exactly one error -- the new callback route isn't in `routeTree.gen.ts` yet because this dev environment (Node 20.20.2) can't run `vite dev`/`build` at all (`@cloudflare/vite-plugin` needs `node:module`'s `registerHooks`, Node 22+) -- confirmed via `git stash` as the exact same pre-existing issue already documented in #167's knip failure, unrelated to this change. CI will regenerate the route tree normally.