### PR TITLE
fix(audit): stop re-billing Lighthouse on workflow and parse retries

### DIFF
--- a/src/server/lib/audit/lighthouse.ts
+++ b/src/server/lib/audit/lighthouse.ts
@@ -1,6 +1,7 @@
 import { detectUrlTemplate, canonicalUrlKey } from "./url-utils";
 import type { BillingCustomerContext } from "@/server/billing/subscription";
 import { createDataforseoClient } from "@/server/lib/dataforseo";
+import { DataforseoChargedTaskError } from "@/server/lib/dataforseo/envelope";
 import type { LighthouseResult, LighthouseStrategy } from "./types";
 import { putTextToR2 } from "@/server/lib/r2";
 
@@ -64,6 +65,11 @@ async function fetchLighthouseResult(
         `Lighthouse attempt ${attempt + 1} failed for ${url}:`,
         lastError.message,
       );
+      // Already billed by DataForSEO (and metered). Retrying would call again
+      // and charge a second time — soft-fail with null scores instead.
+      if (error instanceof DataforseoChargedTaskError) {
+        break;
+      }
     }
   }
 

--- a/src/server/lib/dataforseo/lighthouse.test.ts
+++ b/src/server/lib/dataforseo/lighthouse.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("dataforseo-client", () => ({
+  OnPageLighthouseLiveJsonRequestInfo: class {
+    constructor(public input: unknown) {}
+  },
+}));
+
+vi.mock("@/server/lib/dataforseo/core", () => ({
+  onPageApi: vi.fn(),
+}));
+
+import { onPageApi } from "@/server/lib/dataforseo/core";
+import { DataforseoChargedTaskError } from "@/server/lib/dataforseo/envelope";
+import { fetchLighthouseResult } from "@/server/lib/dataforseo/lighthouse";
+
+const lighthouseLiveJson = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(onPageApi).mockReturnValue({
+    lighthouseLiveJson,
+  } as never);
+});
+
+describe("fetchLighthouseResult", () => {
+  it("throws DataforseoChargedTaskError when parse fails after a billed success", async () => {
+    lighthouseLiveJson.mockResolvedValue({
+      status_code: 20000,
+      status_message: "Ok.",
+      tasks: [
+        {
+          id: "task-1",
+          status_code: 20000,
+          status_message: "Ok.",
+          path: ["v3", "on_page", "lighthouse", "live", "json"],
+          cost: 0.00425,
+          result: [
+            {
+              requestedUrl: "https://example.com/",
+              finalUrl: "https://example.com/",
+              categories: {},
+              audits: {},
+            },
+          ],
+        },
+      ],
+    });
+
+    try {
+      await fetchLighthouseResult({
+        url: "https://example.com/",
+        strategy: "mobile",
+      });
+      throw new Error("expected fetchLighthouseResult to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(DataforseoChargedTaskError);
+      if (error instanceof DataforseoChargedTaskError) {
+        expect(error.billing).toEqual({
+          path: ["v3", "on_page", "lighthouse", "live", "json"],
+          costUsd: 0.00425,
+        });
+        expect(error.message).toMatch(/no category scores/);
+      }
+    }
+  });
+});

--- a/src/server/lib/dataforseo/lighthouse.ts
+++ b/src/server/lib/dataforseo/lighthouse.ts
@@ -9,6 +9,7 @@ import { onPageApi } from "@/server/lib/dataforseo/core";
 import {
   assertOk,
   buildTaskBilling,
+  DataforseoChargedTaskError,
   type DataforseoApiResponse,
 } from "@/server/lib/dataforseo/envelope";
 
@@ -25,8 +26,15 @@ export async function fetchLighthouseResult(input: {
   ]);
 
   // assertOk handles status / charged-task billing; parse extracts the scores.
+  // Build billing before parse so a post-charge parse failure still meters via
+  // DataforseoChargedTaskError (plain Error would skip metering and get retried).
   const task = assertOk(response);
-  const data = parseDataforseoLighthousePayload(response, input);
-
-  return { data, billing: buildTaskBilling(task) };
+  const billing = buildTaskBilling(task);
+  try {
+    const data = parseDataforseoLighthousePayload(response, input);
+    return { data, billing };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new DataforseoChargedTaskError(message, billing);
+  }
 }

--- a/src/server/workflows/siteAuditWorkflowPhases.ts
+++ b/src/server/workflows/siteAuditWorkflowPhases.ts
@@ -20,6 +20,15 @@ import { pgStep } from "@/server/workflows/pgStep";
 
 const LIGHTHOUSE_URL_BATCH_SIZE = 10;
 
+// Metered DataForSEO calls live inside this step. Default Workflow retries
+// (limit 5) would re-fetch every URL in the batch after a mid-step failure
+// (e.g. R2/D1 write), double-billing the customer. Rank-check uses the same
+// single-attempt pattern for metered posts.
+const LIGHTHOUSE_BATCH_STEP_CONFIG = {
+  retries: { limit: 0, delay: "1 second" as const },
+  timeout: "15 minutes" as const,
+};
+
 // Workflows rejects step outputs over 1MiB; keep the sitemap seed list well
 // under that. The crawl visits at most maxPages URLs, so extra seeds are moot.
 const SITEMAP_SEED_BYTE_BUDGET = 768 * 1024;
@@ -170,7 +179,7 @@ async function runLighthousePhase(
     const counts = await pgStep(
       step,
       `lighthouse-batch-${lighthouseBatchIndex}`,
-      undefined,
+      LIGHTHOUSE_BATCH_STEP_CONFIG,
       async () => {
         const perUrlResults = await Promise.all(
           batch.map(async ({ url, pageId }) => {


### PR DESCRIPTION
## Summary
- Site-audit Lighthouse batches used default Cloudflare Workflow retries (limit 5). A mid-batch failure after DataForSEO already charged (e.g. R2/D1 write) re-ran the whole batch and billed again.
- Post-`assertOk` Lighthouse parse failures threw plain `Error`, so Autumn metering skipped the spend and in-process retries called DataForSEO again.
- Aligns metered Lighthouse steps with rank-check’s single-attempt pattern, meters charged parse failures, and soft-fails instead of retrying billed errors.

## How to review
1. `siteAuditWorkflowPhases.ts` — `LIGHTHOUSE_BATCH_STEP_CONFIG` with `retries.limit: 0`
2. `dataforseo/lighthouse.ts` — billing built before parse; parse failures become `DataforseoChargedTaskError`
3. `audit/lighthouse.ts` — break the 3-attempt loop on charged errors
4. Unit test covers the parse-after-bill path

## Test plan
- [x] `pnpm exec vitest run src/server/lib/dataforseo/lighthouse.test.ts src/server/lib/audit/lighthouse.test.ts`
- [x] Spot-check a hosted site audit Lighthouse batch failure does not re-fetch already-charged URLs