### PR TITLE
fix(rank-tracking): advance schedule when skipping unpaid cron configs

### DIFF
--- a/src/server/features/rank-tracking/services/scheduledRankChecks.test.ts
+++ b/src/server/features/rank-tracking/services/scheduledRankChecks.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getDueConfigsWithOrganization: vi.fn(),
+  getKeywordCountForConfig: vi.fn(),
+  updateConfig: vi.fn(),
+  customerHasPaidPlan: vi.fn(),
+  isHostedServerAuthMode: vi.fn(),
+  beginRankCheckRun: vi.fn(),
+  computeNextCheckAt: vi.fn(
+    (_interval: string, previous: string | null | undefined) =>
+      previous === "2026-07-01T00:00:00.000Z"
+        ? "2026-07-02T00:00:00.000Z"
+        : "2026-07-08T00:00:00.000Z",
+  ),
+}));
+
+vi.mock("cloudflare:workers", () => ({ env: {} }));
+vi.mock(
+  "@/server/features/rank-tracking/repositories/RankTrackingRepository",
+  () => ({ RankTrackingRepository: mocks }),
+);
+vi.mock("@/server/billing/subscription", () => ({
+  customerHasPaidPlan: mocks.customerHasPaidPlan,
+}));
+vi.mock("@/server/lib/runtime-env", () => ({
+  isHostedServerAuthMode: mocks.isHostedServerAuthMode,
+}));
+vi.mock("@/server/features/rank-tracking/services/rankCheckRunGuards", () => ({
+  beginRankCheckRun: mocks.beginRankCheckRun,
+}));
+vi.mock("@/shared/rank-tracking", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/shared/rank-tracking")>();
+  return {
+    ...actual,
+    computeNextCheckAt: mocks.computeNextCheckAt,
+  };
+});
+
+const unpaidConfig = {
+  id: "config_unpaid",
+  projectId: "project_1",
+  domain: "free.example",
+  locationCode: 2840,
+  languageCode: "en",
+  locationName: null,
+  devices: "both" as const,
+  serpDepth: 20,
+  scheduleInterval: "daily" as const,
+  nextCheckAt: "2026-07-01T00:00:00.000Z",
+  organizationId: "org_free",
+};
+
+const paidConfig = {
+  ...unpaidConfig,
+  id: "config_paid",
+  domain: "paid.example",
+  organizationId: "org_paid",
+  nextCheckAt: "2026-07-01T12:00:00.000Z",
+};
+
+describe("runScheduledRankChecks", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    for (const mock of Object.values(mocks)) mock.mockReset();
+    mocks.computeNextCheckAt.mockImplementation(
+      (_interval: string, previous: string | null | undefined) =>
+        previous === "2026-07-01T00:00:00.000Z"
+          ? "2026-07-02T00:00:00.000Z"
+          : "2026-07-08T00:00:00.000Z",
+    );
+    mocks.isHostedServerAuthMode.mockResolvedValue(true);
+    mocks.updateConfig.mockResolvedValue(undefined);
+    mocks.beginRankCheckRun.mockResolvedValue({ ok: true, runId: "run_1" });
+  });
+
+  it("advances nextCheckAt for unpaid orgs so they cannot starve the due queue", async () => {
+    mocks.getDueConfigsWithOrganization.mockResolvedValue([
+      unpaidConfig,
+      paidConfig,
+    ]);
+    mocks.customerHasPaidPlan.mockImplementation(
+      async (orgId: string) => orgId === "org_paid",
+    );
+    mocks.getKeywordCountForConfig.mockResolvedValue(3);
+
+    const { runScheduledRankChecks } = await import("./scheduledRankChecks");
+    await runScheduledRankChecks({
+      RANK_CHECK_WORKFLOW: {},
+    } as Env);
+
+    expect(mocks.updateConfig).toHaveBeenCalledWith(
+      "config_unpaid",
+      "project_1",
+      { nextCheckAt: "2026-07-02T00:00:00.000Z" },
+    );
+    expect(mocks.beginRankCheckRun).toHaveBeenCalledTimes(1);
+    expect(mocks.beginRankCheckRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({ id: "config_paid" }),
+      }),
+    );
+  });
+});

--- a/src/server/features/rank-tracking/services/scheduledRankChecks.ts
+++ b/src/server/features/rank-tracking/services/scheduledRankChecks.ts
@@ -7,6 +7,21 @@ import {
   isScheduledRankTrackingInterval,
 } from "@/shared/rank-tracking";
 
+async function advanceNextCheckAt(config: {
+  id: string;
+  projectId: string;
+  scheduleInterval: string | null;
+  nextCheckAt: string | null;
+}) {
+  const interval = isScheduledRankTrackingInterval(config.scheduleInterval)
+    ? config.scheduleInterval
+    : null;
+  if (!interval) return;
+  await RankTrackingRepository.updateConfig(config.id, config.projectId, {
+    nextCheckAt: computeNextCheckAt(interval, config.nextCheckAt),
+  });
+}
+
 // Cron body for the `scheduled` Worker handler: start a rank-check run for every
 // config that's due. Wrapped in `withPgClient` at the entrypoint (server.ts).
 export async function runScheduledRankChecks(env: Env) {
@@ -18,8 +33,13 @@ export async function runScheduledRankChecks(env: Env) {
 
   for (const config of dueConfigs) {
     try {
-      // Skip configs whose org doesn't have a paid plan
+      // Skip unpaid orgs, but still advance nextCheckAt. Leaving unpaid rows
+      // due forever fills the 50-config cron limit and starves paying orgs.
       if (isHosted && !(await customerHasPaidPlan(config.organizationId))) {
+        console.log(
+          `[cron] Skipping config ${config.id} (${config.domain}) — unpaid plan`,
+        );
+        await advanceNextCheckAt(config);
         continue;
       }
 
@@ -31,33 +51,12 @@ export async function runScheduledRankChecks(env: Env) {
         console.log(
           `[cron] Skipping config ${config.id} (${config.domain}) — no keywords`,
         );
-        // Still advance schedule so this config doesn't stay due forever
-        const skipInterval = isScheduledRankTrackingInterval(
-          config.scheduleInterval,
-        )
-          ? config.scheduleInterval
-          : null;
-        if (skipInterval) {
-          await RankTrackingRepository.updateConfig(
-            config.id,
-            config.projectId,
-            {
-              nextCheckAt: computeNextCheckAt(skipInterval, config.nextCheckAt),
-            },
-          );
-        }
+        await advanceNextCheckAt(config);
         continue;
       }
 
       // Advance nextCheckAt immediately to prevent retry storms if the run fails
-      const interval = isScheduledRankTrackingInterval(config.scheduleInterval)
-        ? config.scheduleInterval
-        : null;
-      if (interval) {
-        await RankTrackingRepository.updateConfig(config.id, config.projectId, {
-          nextCheckAt: computeNextCheckAt(interval, config.nextCheckAt),
-        });
-      }
+      await advanceNextCheckAt(config);
 
       const result = await beginRankCheckRun({
         workflow: env.RANK_CHECK_WORKFLOW,


### PR DESCRIPTION
## Summary
- Hosted scheduled rank-check cron loads up to 50 due configs, then skipped unpaid orgs with `continue` and never advanced `nextCheckAt`.
- Those rows stayed due forever, filled the limit, and could starve paying orgs of scheduled checks.
- Unpaid skips now advance the schedule the same way empty-keyword skips already do.

## How to review
1. `scheduledRankChecks.ts` — unpaid path calls shared `advanceNextCheckAt`
2. Unit test: unpaid config is rescheduled; paid config still starts a run

## Test plan
- [x] `pnpm exec vitest run src/server/features/rank-tracking/services/scheduledRankChecks.test.ts`
- [x] Confirm a hosted unpaid due config is pushed forward on the next cron tick without starting a workflow