### PR TITLE
fix(rank-tracking): use dialect-native timestamp cutoffs for comparisons

### DIFF
--- a/src/server/features/rank-tracking/rankTrackingTimestamps.ts
+++ b/src/server/features/rank-tracking/rankTrackingTimestamps.ts
@@ -1,3 +1,21 @@
+import { getDatabaseProvider } from "@/db/provider";
+
+/** SQLite `current_timestamp` shape: `YYYY-MM-DD HH:MM:SS` (UTC, no millis). */
 export function toSqliteTimestamp(date: Date): string {
   return date.toISOString().slice(0, 19).replace("T", " ");
+}
+
+/**
+ * Lexicographic cutoff for rank-snapshot `checkedAt` comparisons.
+ *
+ * Postgres stores ISO text (`YYYY-MM-DDTHH:MM:SS.MSZ` via `isoNow`); SQLite
+ * stores space-separated `current_timestamp`. Mixing formats makes same-day
+ * cutoffs sort incorrectly (` ` < `T`), so history/compare windows miss or
+ * include the wrong rows on hosted Postgres.
+ */
+export function toRankTrackingCutoffTimestamp(date: Date): string {
+  if (getDatabaseProvider() === "postgres") {
+    return date.toISOString();
+  }
+  return toSqliteTimestamp(date);
 }

--- a/src/server/features/rank-tracking/repositories/snapshotQueries.test.ts
+++ b/src/server/features/rank-tracking/repositories/snapshotQueries.test.ts
@@ -1,10 +1,36 @@
-import { describe, expect, it } from "vitest";
-import { toSqliteTimestamp } from "@/server/features/rank-tracking/rankTrackingTimestamps";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-describe("rank tracking snapshot queries", () => {
-  it("formats comparison cutoffs like SQLite current_timestamp", () => {
+const getDatabaseProvider = vi.hoisted(() =>
+  vi.fn((): "d1" | "postgres" => "d1"),
+);
+
+vi.mock("@/db/provider", () => ({
+  getDatabaseProvider,
+}));
+
+import {
+  toRankTrackingCutoffTimestamp,
+  toSqliteTimestamp,
+} from "@/server/features/rank-tracking/rankTrackingTimestamps";
+
+describe("rank tracking timestamp cutoffs", () => {
+  beforeEach(() => {
+    getDatabaseProvider.mockReturnValue("d1");
+  });
+
+  it("formats SQLite cutoffs like current_timestamp", () => {
     expect(toSqliteTimestamp(new Date("2026-06-09T12:34:56.789Z"))).toBe(
       "2026-06-09 12:34:56",
     );
+    expect(
+      toRankTrackingCutoffTimestamp(new Date("2026-06-09T12:34:56.789Z")),
+    ).toBe("2026-06-09 12:34:56");
+  });
+
+  it("formats Postgres cutoffs as ISO text to match isoNow storage", () => {
+    getDatabaseProvider.mockReturnValue("postgres");
+    expect(
+      toRankTrackingCutoffTimestamp(new Date("2026-06-09T12:34:56.789Z")),
+    ).toBe("2026-06-09T12:34:56.789Z");
   });
 });

--- a/src/server/features/rank-tracking/repositories/snapshotQueries.ts
+++ b/src/server/features/rank-tracking/repositories/snapshotQueries.ts
@@ -13,7 +13,7 @@ import {
 } from "drizzle-orm";
 import { db } from "@/db";
 import { rankCheckRuns, rankSnapshots } from "@/db/schema";
-import { toSqliteTimestamp } from "@/server/features/rank-tracking/rankTrackingTimestamps";
+import { toRankTrackingCutoffTimestamp } from "@/server/features/rank-tracking/rankTrackingTimestamps";
 
 function completedRunIdsForConfig(configId: string) {
   return db
@@ -28,7 +28,7 @@ function completedRunIdsForConfig(configId: string) {
 }
 
 function cutoffTimestamp(sinceDays: number): string {
-  return toSqliteTimestamp(
+  return toRankTrackingCutoffTimestamp(
     new Date(Date.now() - sinceDays * 24 * 60 * 60 * 1000),
   );
 }

--- a/src/server/features/rank-tracking/services/rankTrackingResults.ts
+++ b/src/server/features/rank-tracking/services/rankTrackingResults.ts
@@ -1,5 +1,5 @@
 import { RankTrackingRepository } from "@/server/features/rank-tracking/repositories/RankTrackingRepository";
-import { toSqliteTimestamp } from "@/server/features/rank-tracking/rankTrackingTimestamps";
+import { toRankTrackingCutoffTimestamp } from "@/server/features/rank-tracking/rankTrackingTimestamps";
 import { AppError } from "@/server/lib/errors";
 import type { ComparePeriod } from "@/types/schemas/rank-tracking";
 import type {
@@ -27,7 +27,7 @@ export async function getLatestResults(
   run: { id: string; lastCheckedAt: string } | null;
 }> {
   const days = PERIOD_DAYS[comparePeriod];
-  const targetDate = toSqliteTimestamp(
+  const targetDate = toRankTrackingCutoffTimestamp(
     new Date(Date.now() - days * 24 * 60 * 60 * 1000),
   );
 


### PR DESCRIPTION
## Summary
- Rank-tracking history and compare cutoffs always formatted timestamps like SQLite `current_timestamp` (`YYYY-MM-DD HH:MM:SS`).
- Hosted Postgres stores `checkedAt` as ISO text (`YYYY-MM-DDTHH:MM:SS.MSZ`). Lexicographic `gte`/`lte` across those formats breaks same-day windows (` ` < `T`), so 1d/7d/30d deltas and history can be wrong.
- Cutoffs now match the active database dialect.

## How to review
1. `rankTrackingTimestamps.ts` — `toRankTrackingCutoffTimestamp`
2. Call sites in `snapshotQueries.ts` and `rankTrackingResults.ts`
3. Unit tests cover both D1 and Postgres formats

## Test plan
- [x] `pnpm exec vitest run src/server/features/rank-tracking/repositories/snapshotQueries.test.ts`
- [x] On hosted Postgres, verify a 1d compare includes same-calendar-day snapshots written after the cutoff