### PR TITLE
fix(docker): drop the duplicate OPENROUTER_API_KEY entry from compose

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -19,9 +19,6 @@ services:
       - OPENSEO_TELEMETRY_DISABLED=${OPENSEO_TELEMETRY_DISABLED:-}
       - DO_NOT_TRACK=${DO_NOT_TRACK:-}
       - DATAFORSEO_API_KEY=${DATAFORSEO_API_KEY}
-      # Optional: AI features (SAM, onboarding chat). Without this the setup
-      # gate in the app asks for the key, but nothing here would forward it.
-      - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
       # Optional: Google Search Console. See
       # docs/SELF_HOSTING_GOOGLE_SEARCH_CONSOLE.md
       - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID:-}


### PR DESCRIPTION
## Problem

`compose.yaml` names `OPENROUTER_API_KEY` twice under `environment:`:

```yaml
      # Optional: AI features (SAM, onboarding chat). Without this the setup
      # gate in the app asks for the key, but nothing here would forward it.
      - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
      ...
      # Optional: AI features (SAM, the in-app SEO agent)
      - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
      - OPENROUTER_MODEL=${OPENROUTER_MODEL:-}
```

This is my fault. #428 had already generalised the passthrough with `env_file: .env` and listed the key next to `OPENROUTER_MODEL`. My #152 was merged on top a day later without a rebase, adding a second entry for the same variable.

Nothing is broken: Compose takes the last entry and both resolve to `${OPENROUTER_API_KEY:-}`, so the rendered value is unchanged and no warning is emitted. But the duplicate is dead weight, and the comment above my entry now says the opposite of the truth — it claims nothing would forward the key, which stopped being the case the moment `env_file` landed.

## Change

Remove my entry and its stale comment. Keep the one that sits with `OPENROUTER_MODEL`.

## Verification

With a `.env` containing both variables, `docker compose config` renders the same values before and after:

```
      OPENROUTER_API_KEY: sk-or-test
      OPENROUTER_MODEL: some/model
```

`pnpm ci:check` passes.

Verified and tested by hand. The description was drafted with AI assistance — I'd rather let the diff do the talking than a long write-up.
