### PR TITLE
fix(rank-tracking): batch bulk keyword deletes to stay under D1's bound-parameter limit

### DIFF
--- a/src/server/features/rank-tracking/repositories/RankTrackingRepository.ts
+++ b/src/server/features/rank-tracking/repositories/RankTrackingRepository.ts
@@ -258,14 +258,19 @@ async function removeKeywordsFromConfig(
   keywordIds: string[],
   configId: string,
 ) {
-  await db
-    .delete(rankTrackingKeywords)
-    .where(
-      and(
-        inArray(rankTrackingKeywords.id, keywordIds),
-        eq(rankTrackingKeywords.configId, configId),
+  // Batched one-per-id: a single `inArray(id, keywordIds)` delete binds one
+  // parameter per keyword and breaks D1's ~100-bound-params limit when many
+  // keywords are selected at once.
+  await executeInBatches(keywordIds, (tx, id) =>
+    tx
+      .delete(rankTrackingKeywords)
+      .where(
+        and(
+          eq(rankTrackingKeywords.id, id),
+          eq(rankTrackingKeywords.configId, configId),
+        ),
       ),
-    );
+  );
 }
 
 async function getConfigSummaries(projectId: string) {


### PR DESCRIPTION
## Problem

Selecting many keywords in rank tracking and deleting them at once fails with a generic "An unexpected error occurred" toast. The server log shows:

```
D1_ERROR: too many SQL variables at offset 378: SQLITE_ERROR
    at Object.removeKeywordsFromConfig ...
```

`removeKeywordsFromConfig` builds a single `DELETE ... WHERE id IN (...)` with one bound parameter per keyword id. D1 caps bound parameters at ~100 per statement, so deleting more than ~100 selected keywords always fails (reproduced with 670 keywords on a self-hosted Docker install). Deleting a few keywords works, which makes the failure look intermittent to users.

## Fix

Route the delete through the existing `executeInBatches` helper (one delete per id, batched atomically in chunks of 100), exactly like `addKeywordsToConfig` and `updateKeywordMetrics` already do in the same file. The sibling snapshot queries already chunk for the same reason (`snapshotQueries.ts` uses `CHUNK_SIZE = 90`); the delete path was the one remaining unbatched bulk operation.

## Testing

- `pnpm ci:check`, `pnpm test:ci`, `pnpm vite build` all pass.
- Manually verified on a self-hosted Docker install (D1/SQLite): deleting 670 selected keywords now succeeds; single deletes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
