### PR TITLE
feat(rank-tracking): opt-in env toggles to run manual rank checks via the task queue

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -22,6 +22,9 @@ services:
       # Optional: AI features (SAM, onboarding chat). Without this the setup
       # gate in the app asks for the key, but nothing here would forward it.
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
+      # Optional rank-tracking cost controls: docs/SELF_HOSTING_CLOUDFLARE.md
+      - RANK_CHECK_MANUAL_METHOD=${RANK_CHECK_MANUAL_METHOD:-}
+      - RANK_CHECK_QUEUE_LIVE_FALLBACK=${RANK_CHECK_QUEUE_LIVE_FALLBACK:-}
       # Optional: Google Search Console. See
       # docs/SELF_HOSTING_GOOGLE_SEARCH_CONSOLE.md
       - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID:-}

--- a/docs/SELF_HOSTING_CLOUDFLARE.md
+++ b/docs/SELF_HOSTING_CLOUDFLARE.md
@@ -50,6 +50,11 @@ Copy the template and fill in the required values:
 cp .env.selfhost.example .env.selfhost
 ```
 
+Optional rank-tracking cost controls (also work as Worker variables):
+
+- `RANK_CHECK_MANUAL_METHOD` — set to `queued` to route manual rank checks ("Check now") through DataForSEO's standard task queue (~30% of the live endpoint's cost). Results then arrive within ~5-15 minutes instead of seconds. Scheduled checks always use the queue.
+- `RANK_CHECK_QUEUE_LIVE_FALLBACK` — set to `off` to never re-check queued stragglers via the live endpoint. The run then polls the queue for ~2 hours instead of ~15 minutes; keywords still missing afterwards are reported as unchecked rather than billed at live prices.
+
 ## 4) Deploy
 
 ```bash

--- a/src/client/features/rank-tracking/CheckConfirmModal.tsx
+++ b/src/client/features/rank-tracking/CheckConfirmModal.tsx
@@ -6,12 +6,14 @@ import {
   devicesCount,
   KEYWORDS_PER_BATCH,
   SECONDS_PER_BATCH,
+  type RankCheckMethod,
 } from "@/shared/rank-tracking";
 
 export function CheckConfirmModal({
   keywordCount,
   devices,
   serpDepth,
+  method = "live",
   isPending,
   onRunNow,
   onCancel,
@@ -19,6 +21,8 @@ export function CheckConfirmModal({
   keywordCount: number;
   devices: RankTrackingConfig["devices"];
   serpDepth: number;
+  /** Live by default; "queued" when RANK_CHECK_MANUAL_METHOD routes manual checks through the task queue. */
+  method?: RankCheckMethod;
   isPending: boolean;
   onRunNow: () => void;
   onCancel: () => void;
@@ -27,12 +31,18 @@ export function CheckConfirmModal({
     keywordCount,
     devices,
     serpDepth,
-    "live",
+    method,
   );
   const dc = devicesCount(devices);
   const totalChecks = keywordCount * dc;
   const liveTime =
     Math.ceil(totalChecks / KEYWORDS_PER_BATCH) * SECONDS_PER_BATCH;
+  const timeLabel =
+    method === "queued"
+      ? "~5-15 min"
+      : liveTime < 60
+        ? `~${liveTime}s`
+        : `~${Math.ceil(liveTime / 60)} min`;
 
   return (
     <Modal
@@ -62,8 +72,8 @@ export function CheckConfirmModal({
         <div className="flex-1">
           <p className="font-medium">Run Now</p>
           <p className="text-xs text-base-content/60">
-            Results in ~
-            {liveTime < 60 ? `${liveTime}s` : `${Math.ceil(liveTime / 60)} min`}
+            Results in {timeLabel}
+            {method === "queued" && " (task queue)"}
           </p>
         </div>
         <div className="text-right">

--- a/src/client/features/rank-tracking/RankTrackingDomainDetail.tsx
+++ b/src/client/features/rank-tracking/RankTrackingDomainDetail.tsx
@@ -344,6 +344,7 @@ export function RankTrackingDomainDetail({
           keywordCount={pendingCheck.count}
           devices={config.devices}
           serpDepth={config.serpDepth}
+          method={costEstimate?.method}
           isPending={isPending}
           onRunNow={() =>
             startCheck({

--- a/src/routes/_project/p/$projectId/rank-tracking/$configId.tsx
+++ b/src/routes/_project/p/$projectId/rank-tracking/$configId.tsx
@@ -31,6 +31,10 @@ function RankTrackingConfigRoute() {
     void queryClient.invalidateQueries({
       queryKey: ["rankTrackingConfigSummaries", projectId],
     });
+    // Depth/device edits change the per-check price shown in the header.
+    void queryClient.invalidateQueries({
+      queryKey: ["rankTrackingCostEstimate", projectId],
+    });
   };
 
   const handleBack = () => {

--- a/src/server/features/rank-tracking/services/RankTrackingService.ts
+++ b/src/server/features/rank-tracking/services/RankTrackingService.ts
@@ -14,6 +14,7 @@ import {
   beginRankCheckRun,
   reconcileActiveRankCheckRun,
 } from "./rankCheckRunGuards";
+import { resolveRankCheckMethod } from "@/server/workflows/rankCheckMethod";
 import {
   estimateRankCheckCredits,
   computeNextCheckAt,
@@ -332,18 +333,22 @@ async function estimateCost(configId: string, projectId: string) {
   const config = await getValidatedConfig(configId, projectId);
   const keywordCount =
     await RankTrackingRepository.getKeywordCountForConfig(configId);
-  // Estimates the cost of a manual "check now", which always runs live.
+  // Estimates the cost of a manual "check now". That runs live by default,
+  // but RANK_CHECK_MANUAL_METHOD=queued routes it through the cheaper task
+  // queue — the estimate (and the confirm dialog fed by it) must match.
+  const method = await resolveRankCheckMethod("manual");
   const { costUsd, costCredits } = estimateRankCheckCredits(
     keywordCount,
     config.devices,
     config.serpDepth,
-    "live",
+    method,
   );
   return {
     costUsd,
     costCredits,
     keywordCount,
     devicesCount: devicesCount(config.devices),
+    method,
   };
 }
 

--- a/src/server/workflows/RankCheckWorkflow.ts
+++ b/src/server/workflows/RankCheckWorkflow.ts
@@ -13,6 +13,10 @@ import {
   runQueuedCheck,
   type QueuedCheckStats,
 } from "@/server/workflows/rankCheckPaths";
+import {
+  resolveQueueLiveFallback,
+  resolveRankCheckMethod,
+} from "@/server/workflows/rankCheckMethod";
 import { pgStep } from "@/server/workflows/pgStep";
 import { createDataforseoClient } from "@/server/lib/dataforseo";
 import { captureServerEvent } from "@/server/lib/posthog";
@@ -80,15 +84,21 @@ async function prepareRankCheckKeywords(input: {
     throw new AppError("INTERNAL_ERROR", "No keywords to track");
   }
 
+  // Resolved inside this durable step so the live/queued decision and the
+  // fallback policy survive workflow replays even if the env toggles change
+  // mid-run.
+  const method = await resolveRankCheckMethod(input.trigger);
+  const queueLiveFallback = await resolveQueueLiveFallback();
+
   // Verify the user has enough credits for the full check before starting.
-  // Scheduled checks go through the cheaper task queue, so estimate at queued
+  // Queued checks go through the cheaper task queue, so estimate at queued
   // pricing — a live-price estimate would skip checks the user can afford.
   if (await isHostedServerAuthMode()) {
     const { costCredits } = estimateRankCheckCredits(
       trackingKeywords.length,
       input.devices,
       input.serpDepth,
-      input.trigger === "scheduled" ? "queued" : "live",
+      method,
     );
     const [monthlyCheck, topupCheck] = await Promise.all([
       autumn.check({
@@ -120,6 +130,8 @@ async function prepareRankCheckKeywords(input: {
       id: kw.id,
       keyword: kw.keyword,
     })),
+    method,
+    queueLiveFallback,
   };
 }
 
@@ -336,10 +348,13 @@ export class RankCheckWorkflow extends WorkflowEntrypoint<
           languageCode,
           locationName,
           runId,
+          queueLiveFallback: prepareResult.queueLiveFallback,
         };
-        // Scheduled checks use DataForSEO's task queue (~30% of live cost);
-        // manual checks stay on the live endpoint for instant results.
-        if (trigger === "scheduled") {
+        // Queued checks use DataForSEO's task queue (~30% of live cost).
+        // Scheduled runs always take it; manual runs stay on the live
+        // endpoint for instant results unless RANK_CHECK_MANUAL_METHOD=queued
+        // opts them into the queue too.
+        if (prepareResult.method === "queued") {
           queueStats = await runQueuedCheck(step, checkContext);
         } else {
           await runLiveCheck(step, checkContext);

--- a/src/server/workflows/rankCheckMethod.test.ts
+++ b/src/server/workflows/rankCheckMethod.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  resolveQueueLiveFallback,
+  resolveRankCheckMethod,
+} from "./rankCheckMethod";
+
+const mocks = vi.hoisted(() => ({
+  getOptionalEnvValue: vi.fn(),
+}));
+
+vi.mock("@/server/lib/runtime-env", () => ({
+  getOptionalEnvValue: mocks.getOptionalEnvValue,
+}));
+
+describe("resolveRankCheckMethod", () => {
+  beforeEach(() => {
+    mocks.getOptionalEnvValue.mockResolvedValue(undefined);
+  });
+
+  it("always uses the queue for scheduled checks", async () => {
+    mocks.getOptionalEnvValue.mockResolvedValue("live");
+    expect(await resolveRankCheckMethod("scheduled")).toBe("queued");
+  });
+
+  it("defaults manual checks to the live endpoint", async () => {
+    expect(await resolveRankCheckMethod("manual")).toBe("live");
+    expect(mocks.getOptionalEnvValue).toHaveBeenCalledWith(
+      "RANK_CHECK_MANUAL_METHOD",
+    );
+  });
+
+  it("routes manual checks to the queue when the env toggle is set", async () => {
+    mocks.getOptionalEnvValue.mockResolvedValue("queued");
+    expect(await resolveRankCheckMethod("manual")).toBe("queued");
+  });
+
+  it("keeps manual checks live for unknown toggle values", async () => {
+    mocks.getOptionalEnvValue.mockResolvedValue("fast");
+    expect(await resolveRankCheckMethod("manual")).toBe("live");
+  });
+});
+
+describe("resolveQueueLiveFallback", () => {
+  beforeEach(() => {
+    mocks.getOptionalEnvValue.mockResolvedValue(undefined);
+  });
+
+  it("enables the live fallback by default", async () => {
+    expect(await resolveQueueLiveFallback()).toBe(true);
+    expect(mocks.getOptionalEnvValue).toHaveBeenCalledWith(
+      "RANK_CHECK_QUEUE_LIVE_FALLBACK",
+    );
+  });
+
+  it("disables the live fallback when set to off", async () => {
+    mocks.getOptionalEnvValue.mockResolvedValue("off");
+    expect(await resolveQueueLiveFallback()).toBe(false);
+  });
+
+  it("keeps the fallback for unknown values", async () => {
+    mocks.getOptionalEnvValue.mockResolvedValue("no");
+    expect(await resolveQueueLiveFallback()).toBe(true);
+  });
+});

--- a/src/server/workflows/rankCheckMethod.ts
+++ b/src/server/workflows/rankCheckMethod.ts
@@ -1,0 +1,29 @@
+import { getOptionalEnvValue } from "@/server/lib/runtime-env";
+import type { RankCheckMethod } from "@/shared/rank-tracking";
+
+/**
+ * Resolve which DataForSEO path a rank check run uses. Scheduled checks always
+ * go through the cheaper standard task queue (~30% of live cost). Manual
+ * checks default to the live endpoint for instant results, but can be opted
+ * into the queue via RANK_CHECK_MANUAL_METHOD=queued — results then arrive
+ * within ~5-15 minutes instead of seconds.
+ */
+export async function resolveRankCheckMethod(
+  trigger: "manual" | "scheduled",
+): Promise<RankCheckMethod> {
+  if (trigger === "scheduled") return "queued";
+  const manualMethod = await getOptionalEnvValue("RANK_CHECK_MANUAL_METHOD");
+  return manualMethod === "queued" ? "queued" : "live";
+}
+
+/**
+ * Whether queued runs may re-check stragglers via the live endpoint. On by
+ * default; RANK_CHECK_QUEUE_LIVE_FALLBACK=off disables it — the run then
+ * polls the queue for ~2 hours instead and reports anything still missing as
+ * unchecked rather than paying live prices for it.
+ */
+export async function resolveQueueLiveFallback(): Promise<boolean> {
+  return (
+    (await getOptionalEnvValue("RANK_CHECK_QUEUE_LIVE_FALLBACK")) !== "off"
+  );
+}

--- a/src/server/workflows/rankCheckPaths.ts
+++ b/src/server/workflows/rankCheckPaths.ts
@@ -50,6 +50,12 @@ interface CheckContext {
   languageCode: string;
   locationName?: string;
   runId: string;
+  /**
+   * Whether queued stragglers may be re-checked via the live endpoint. When
+   * false, the queue is polled for ~2 hours instead and anything still
+   * missing stays unchecked (never billed at live prices).
+   */
+  queueLiveFallback: boolean;
 }
 
 /** Expand keywords into one task input per keyword/device pair. */
@@ -161,6 +167,19 @@ const QUEUED_POLL_INTERVALS = [
   "2 minutes",
   "2 minutes",
   "3 minutes",
+] as const;
+
+// With the live fallback disabled there is no safety net after the polling
+// window, so keep polling far longer — cumulative waits continue at
+// 30 / 45 / 60 / 75 / 105 / 135 minutes — before giving up on stragglers.
+const QUEUED_POLL_INTERVALS_NO_FALLBACK = [
+  ...QUEUED_POLL_INTERVALS,
+  "15 minutes",
+  "15 minutes",
+  "15 minutes",
+  "15 minutes",
+  "30 minutes",
+  "30 minutes",
 ] as const;
 
 /** Concurrent task_get requests within a collect step. */
@@ -327,16 +346,20 @@ export async function runQueuedCheck(
     fallbackChecked: 0,
   };
 
-  // Poll until everything is collected or the ~15 minute window closes. A
-  // collect failure (past its retries) leaves that round's tasks pending for
-  // the next round — or the live fallback — instead of failing the run; the
-  // posted tasks are already paid for.
+  // Poll until everything is collected or the polling window closes (~15
+  // minutes normally, ~2 hours when the live fallback is disabled). A collect
+  // failure (past its retries) leaves that round's tasks pending for the next
+  // round — or the live fallback — instead of failing the run; the posted
+  // tasks are already paid for.
+  const pollIntervals = ctx.queueLiveFallback
+    ? QUEUED_POLL_INTERVALS
+    : QUEUED_POLL_INTERVALS_NO_FALLBACK;
   for (
     let round = 0;
-    round < QUEUED_POLL_INTERVALS.length && pending.length > 0;
+    round < pollIntervals.length && pending.length > 0;
     round++
   ) {
-    await step.sleep(`wait-${round}`, QUEUED_POLL_INTERVALS[round]);
+    await step.sleep(`wait-${round}`, pollIntervals[round]);
 
     // Cap task_gets per round so one collect step stays well inside the
     // per-invocation subrequest limit at the 1000-keyword config ceiling.
@@ -369,6 +392,15 @@ export async function runQueuedCheck(
   const stragglers: RankCheckTaskInput[] = [...fallback, ...pending];
   stats.fallbackTasks = stragglers.length;
   if (stragglers.length === 0) return stats;
+
+  if (!ctx.queueLiveFallback) {
+    // RANK_CHECK_QUEUE_LIVE_FALLBACK=off: never bill live prices. Finalize
+    // reports the stragglers as "could not be checked" instead.
+    console.log(
+      `[rank-check] ${ctx.runId} live fallback disabled, leaving ${stragglers.length} task(s) unchecked`,
+    );
+    return stats;
+  }
 
   console.log(
     `[rank-check] ${ctx.runId} live fallback for ${stragglers.length} task(s)`,

--- a/src/shared/rank-tracking.ts
+++ b/src/shared/rank-tracking.ts
@@ -25,7 +25,7 @@ const QUEUED_EXTRA_PAGE_COST_USD = 0.00045;
  * How a rank check reaches DataForSEO: "live" is the instant endpoint used for
  * manual checks; "queued" is the cheaper task queue used for scheduled checks.
  */
-type RankCheckMethod = "live" | "queued";
+export type RankCheckMethod = "live" | "queued";
 
 /** How many keywords are checked per batch */
 export const KEYWORDS_PER_BATCH = 10;


### PR DESCRIPTION
## Motivation

Scheduled rank checks already use DataForSEO's standard task queue (~30% of the live endpoint's cost), but manual "Check now" runs always pay live prices. For self-hosters who track a few hundred keywords and don't mind waiting a few minutes, that's a ~3.3x cost difference with identical data — both paths send the same request parameters and parse results through the same `buildRankCheckResult`.

This PR adds two opt-in env toggles so self-hosters can choose cost over speed. **Default behavior is completely unchanged** — without the variables set, every code path resolves to today's behavior.

## Changes

**`RANK_CHECK_MANUAL_METHOD=queued`** routes manual checks through the existing `runQueuedCheck` path (task_post → task_get polling → live fallback). The decision is resolved inside the durable "prepare" workflow step via a new `resolveRankCheckMethod()` helper, so it survives workflow replays. The credit pre-check estimates at queued pricing accordingly.

**`RANK_CHECK_QUEUE_LIVE_FALLBACK=off`** disables the live fallback for queued stragglers (some self-hosters prefer "never bill live prices" over completeness). To compensate, the polling window extends from ~15 minutes to ~2¼ hours (cumulative waits 4/6/8/10/12/15/30/45/60/75/105/135 min). Anything still missing afterwards is reported by the existing finalize logic as "could not be checked" instead of being re-billed live.

**Cost estimate follows the resolved method:** `RankTrackingService.estimateCost` and the check-confirm dialog show queued pricing and realistic timing ("~5-15 min (task queue)") when the toggle is active, live pricing otherwise. Saving config edits now also invalidates the cached cost estimate so the header price updates without a reload (a small pre-existing staleness bug that also affects the default setup).

`compose.yaml` forwards both variables into the self-host container; `docs/SELF_HOSTING_CLOUDFLARE.md` documents them.

## Testing

- New unit tests for `resolveRankCheckMethod` / `resolveQueueLiveFallback` (7 cases).
- `pnpm ci:check`, `pnpm test:ci`, `pnpm vite build` all pass.
- Verified end-to-end on a self-hosted Docker install: with the toggles set, a manual 140-keyword check ran fully through the queue (140 posted, 140 collected, 0 live fallbacks, ~6 min) at queued cost; without the variables, behavior is byte-identical to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
