### PR TITLE
fix(e2e): run keyword research specs without a DataForSEO API key

### DIFF
--- a/e2e/fixtures/keyword-research-fixtures.ts
+++ b/e2e/fixtures/keyword-research-fixtures.ts
@@ -1,4 +1,4 @@
-import type { KeywordResearchRow } from "@/types/keywords";
+import type { KeywordResearchRow, SerpResultItem } from "@/types/keywords";
 import type { ResolvedResearchKeywordsInput } from "@/types/schemas/keywords";
 
 const MONTHLY_SEARCHES = [
@@ -69,5 +69,32 @@ export function getKeywordResearchFixture(data: ResolvedResearchKeywordsInput) {
         },
       ],
     },
+  };
+}
+
+function makeSerpItem(keyword: string, index: number): SerpResultItem {
+  const rank = index + 1;
+  return {
+    rank,
+    title: `${keyword} - result ${rank}`,
+    url: `https://example-${rank}.com/${keyword.replace(/\s+/g, "-")}`,
+    domain: `example-${rank}.com`,
+    description: `Fixture SERP description for ${keyword}, position ${rank}.`,
+    etv: 5000 - index * 400,
+    estimatedPaidTrafficCost: Number((1200 - index * 90).toFixed(2)),
+    referringDomains: 900 - index * 60,
+    backlinks: 12_000 - index * 800,
+    isNew: false,
+    rankChange: null,
+  };
+}
+
+export function getSerpAnalysisFixture(data: { keyword: string }) {
+  const keyword = data.keyword.trim().toLowerCase();
+  return {
+    requestedKeyword: keyword,
+    items: Array.from({ length: 10 }, (_, index) =>
+      makeSerpItem(keyword, index),
+    ),
   };
 }

--- a/src/serverFunctions/config.ts
+++ b/src/serverFunctions/config.ts
@@ -2,9 +2,19 @@ import { env } from "cloudflare:workers";
 import { createServerFn } from "@tanstack/react-start";
 import { requireAuthenticatedContext } from "@/serverFunctions/middleware";
 
+// E2E runs serve fixture data and never call DataForSEO, so a missing key must
+// not raise the blocking setup modal — it covers the page and eats every click.
+function shouldUseE2eFixtures() {
+  return (
+    import.meta.env.VITE_E2E_KEYWORD_FIXTURES === "1" ||
+    import.meta.env.VITE_E2E_DOMAIN_FIXTURES === "1"
+  );
+}
+
 export const getSeoApiKeyStatus = createServerFn({ method: "GET" })
   .middleware(requireAuthenticatedContext)
   .handler(() => {
-    const configured = Boolean(env.DATAFORSEO_API_KEY?.trim());
+    const configured =
+      shouldUseE2eFixtures() || Boolean(env.DATAFORSEO_API_KEY?.trim());
     return { configured };
   });

--- a/src/serverFunctions/keywords.ts
+++ b/src/serverFunctions/keywords.ts
@@ -123,13 +123,16 @@ export const refreshSavedKeywordMetrics = createServerFn({ method: "POST" })
 export const getSerpAnalysis = createServerFn({ method: "POST" })
   .middleware(requireProjectContext)
   .validator(serpAnalysisSchema)
-  .handler(async ({ data, context }) =>
-    KeywordResearchService.getSerpAnalysis(
-      {
-        ...data,
-        ...resolveMarket(data, context.project),
-        projectId: context.projectId,
-      },
-      context,
-    ),
-  );
+  .handler(async ({ data, context }) => {
+    const input = {
+      ...data,
+      ...resolveMarket(data, context.project),
+      projectId: context.projectId,
+    };
+    if (shouldUseKeywordE2eFixtures()) {
+      const fixtures = await getKeywordE2eFixtures();
+      return fixtures.getSerpAnalysisFixture(input);
+    }
+
+    return KeywordResearchService.getSerpAnalysis(input, context);
+  });


### PR DESCRIPTION
### Problem

The keyword research E2E tests use fixture data when `VITE_E2E_KEYWORD_FIXTURES` is enabled, so they shouldn't require DataForSEO credentials. However, two code paths still required `DATAFORSEO_API_KEY`, causing `pnpm test:e2e` to fail on a fresh checkout.

1. **`getSerpAnalysis` had no fixture support**

   * Unlike `researchKeywords`, it always called `KeywordResearchService`.
   * Without `DATAFORSEO_API_KEY`, the server failed with:

     ```
     Missing required environment variable: DATAFORSEO_API_KEY
     ```

2. **`getSeoApiKeyStatus` reported the API key as missing**

   * Even with fixtures enabled, it returned `configured: false`.
   * This showed the **"One quick setup step / Add your DataForSEO API key"** modal.
   * The modal's full-screen overlay blocked Playwright from clicking the page:

     ```
     <div ... class="fixed inset-0 z-50 ..."> subtree intercepts pointer events
     ```
   * All three tests timed out on tab clicks because the modal was covering the page.

### Fix

* Added `getSerpAnalysisFixture` alongside `getKeywordResearchFixture`.
* Updated `getSerpAnalysis` to use fixture data when E2E fixtures are enabled.
* Updated `getSeoApiKeyStatus` to return `configured: true` when either E2E fixture flag is enabled.

This follows the existing pattern used in `serverFunctions/keywords.ts` and `serverFunctions/domain.ts`.

Production behavior is unchanged because the fixture flags are only enabled by `playwright.config.ts`.

### Verification

Ran without `DATAFORSEO_API_KEY`:

```bash
pnpm exec playwright test e2e/keyword-research-navigation.spec.ts
```

Result:

```
3 passed (44.7s)
```

Also verified:

* ✅ `pnpm test:ci` (768 passed)
* ✅ `tsc --noEmit`
* ✅ `oxlint . --type-aware`

### Notes for Maintainers

While working on this, I noticed two unrelated issues that I can send as separate PRs:

1. **Windows E2E startup**

   * `playwright.config.ts` uses POSIX-style inline environment variables:

     ```bash
     NODE_OPTIONS= AUTH_MODE=... pnpm exec vite dev
     ```
   * This doesn't work in `cmd.exe`, so `pnpm test:e2e` cannot start on Windows.
   * Moving these variables into Playwright's `env` block makes it work cross-platform.

2. **Line endings on Windows**

   * The repository has no `.gitattributes` file.
   * On Windows with `core.autocrlf=true`, `prettier --check` reports changes for 811 files, making `pnpm ci:check` difficult to use locally.
   * Adding a `.gitattributes` file would keep line endings consistent across platforms.
