### PR TITLE
Allow required native deps to build under pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,5 +145,13 @@
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.2.6",
     "wrangler": "^4.105.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "workerd",
+      "sharp",
+      "msgpackr-extract"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- Whitelist `esbuild`, `workerd`, `sharp`, and `msgpackr-extract` in `pnpm.onlyBuiltDependencies` so pnpm 10 runs their install scripts.
- Unblocks local installs and Cloudflare self-host deploys that depend on those native binaries.

## Test plan
- [ ] Run `pnpm install` and confirm the listed packages build without `approve-builds`
- [ ] Confirm `workerd` and `esbuild` binaries exist under `node_modules`
- [ ] Smoke-check `pnpm deploy:selfhost --yes` preflight still passes env/auth checks


Made with [Cursor](https://cursor.com)