### PR TITLE
feat(audit): flag indexable pages with no structured data

### DIFF
--- a/src/server/lib/audit/issues/page-reporters.test.ts
+++ b/src/server/lib/audit/issues/page-reporters.test.ts
@@ -45,7 +45,7 @@ function makePage(overrides: Partial<CrawledPageResult>): CrawledPageResult {
     imagesMissingAlt: 0,
     images: [],
     links: [HEALTHY_LINK],
-    hasStructuredData: false,
+    hasStructuredData: true,
     hreflangTags: [],
     isIndexable: true,
     responseTimeMs: 200,
@@ -135,6 +135,42 @@ describe("runPageReporters", () => {
       contentHash: null,
     });
     expect(issueTypes(nonHtml)).toEqual([]);
+  });
+
+  it("reports missing-structured-data on an indexable page without markup", () => {
+    expect(issueTypes(makePage({ hasStructuredData: false }))).toEqual([
+      "missing-structured-data",
+    ]);
+  });
+
+  it("does not report missing-structured-data when markup is present", () => {
+    expect(issueTypes(makePage({ hasStructuredData: true }))).not.toContain(
+      "missing-structured-data",
+    );
+  });
+
+  it("does not report missing-structured-data on a noindex page", () => {
+    // The page is explicitly kept out of the index, so rich results are moot.
+    expect(
+      issueTypes(makePage({ hasStructuredData: false, isIndexable: false })),
+    ).not.toContain("missing-structured-data");
+  });
+
+  it("does not report missing-structured-data on non-HTML responses", () => {
+    expect(
+      issueTypes(
+        makePage({
+          isHtml: false,
+          hasStructuredData: false,
+          title: "",
+          metaDescription: "",
+          h1Count: 0,
+          headingOrder: [],
+          wordCount: 0,
+          contentHash: null,
+        }),
+      ),
+    ).not.toContain("missing-structured-data");
   });
 
   it("still checks empty-shell HTML pages", () => {

--- a/src/server/lib/audit/issues/page-reporters.ts
+++ b/src/server/lib/audit/issues/page-reporters.ts
@@ -142,6 +142,12 @@ export function runPageReporters(page: CrawledPageResult): DetectedIssue[] {
     });
   }
 
+  // Rich-result eligibility. Only meaningful for pages that are allowed in the
+  // index — a noindex page can't earn a rich result in the first place.
+  if (page.isIndexable && !page.hasStructuredData) {
+    report("missing-structured-data");
+  }
+
   // Structure
   if (page.isIndexable && page.links.length === 0) {
     report("no-outgoing-links");

--- a/src/shared/audit-issues.ts
+++ b/src/shared/audit-issues.ts
@@ -224,6 +224,14 @@ export const AUDIT_ISSUE_TYPES = {
     howToFix:
       "If this page should rank on its own, set its canonical to itself. Otherwise no action is needed.",
   },
+  "missing-structured-data": {
+    severity: "info",
+    title: "No structured data",
+    explanation:
+      "The page carries no structured data (JSON-LD, Microdata, or RDFa). Structured data is what makes a page eligible for rich results — review stars, prices, FAQs, breadcrumbs — and it gives AI search engines an unambiguous description of the page instead of leaving them to infer one from prose.",
+    howToFix:
+      "Add JSON-LD in the page head, matching the page's actual content: Product with offers and price on product pages, Article on posts, LocalBusiness with NAP on contact pages, BreadcrumbList on any page inside a hierarchy. Validate the result with Google's Rich Results Test.",
+  },
   "deep-page": {
     severity: "info",
     title: "Page is deep in the site structure",


### PR DESCRIPTION
Site audits have no signal for structured data today, even though the crawler already records `hasStructuredData` on every page. A page that could be earning rich results — and that AI search engines otherwise have to interpret from prose alone — passes the audit silently.

This adds a `missing-structured-data` issue, reported for indexable HTML pages whose markup carries no JSON-LD, Microdata, or RDFa.

**Severity: `info`.** Missing markup is a missed opportunity rather than a defect, which matches how `noindex-page` and `deep-page` are treated.

**Noindex pages are skipped.** They cannot earn a rich result, so flagging them would only add noise to reports.

No new crawler work: the reporter reads a field `page-analyzer` already populates, so audits cost exactly what they did before.

### Testing

Four tests cover the new reporter: markup absent, markup present, noindex, and non-HTML. The shared `makePage` fixture now defaults to `hasStructuredData: true` so it keeps representing a healthy page.

- `pnpm test:ci` — 772 tests across 94 files, all passing
- `pnpm ci:check` — prettier, knip, both `tsc` configs, oxlint type-aware: clean
- `pnpm vite build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)