### PR TITLE
fix: keep org slugs free of trailing dashes after truncation

### DIFF
--- a/src/server/auth/org-slug.test.ts
+++ b/src/server/auth/org-slug.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { slugify, toHex } from "@/server/auth/org-slug";
+
+describe("slugify", () => {
+  it("slugifies normal values", () => {
+    expect(slugify("My Workspace")).toBe("my-workspace");
+    expect(slugify("  Hello, World!  ")).toBe("hello-world");
+  });
+
+  it("strips leading and trailing separators", () => {
+    expect(slugify("---weird---")).toBe("weird");
+  });
+
+  it("falls back to 'workspace' when nothing is left", () => {
+    expect(slugify("")).toBe("workspace");
+    expect(slugify("!!!")).toBe("workspace");
+  });
+
+  it("does not leave a trailing dash when truncation lands on a separator", () => {
+    const value = `${"a".repeat(47)} extra words`;
+    const slug = slugify(value);
+
+    expect(slug.length).toBeLessThanOrEqual(48);
+    expect(slug.endsWith("-")).toBe(false);
+    expect(slug).toBe("a".repeat(47));
+  });
+});
+
+describe("toHex", () => {
+  it("encodes a string as lowercase hex", () => {
+    expect(toHex("abc")).toBe("616263");
+  });
+});

--- a/src/server/auth/org-slug.ts
+++ b/src/server/auth/org-slug.ts
@@ -1,10 +1,12 @@
 export function slugify(value: string) {
+  // Truncate before trimming dashes so a cut that lands on a "-" separator
+  // does not leave a leading or trailing dash in the final slug.
   const slug = value
     .toLowerCase()
     .trim()
     .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, 48);
+    .slice(0, 48)
+    .replace(/^-+|-+$/g, "");
 
   return slug || "workspace";
 }


### PR DESCRIPTION
**What**: Fixes a bug in `slugify` (`src/server/auth/org-slug.ts`).

`slugify` stripped leading and trailing dashes before truncating the value to 48 characters. When the 48 character cut lands on a `-` separator, the final slug still ends with a dash, which is exactly what the trailing-dash strip is meant to prevent.

For example, a long organization name can produce a slug like `my-really-long-org-name-that-goes-on-` (trailing dash), and in `default-hosted-organization.ts` that becomes `...goes-on--<suffix>` with a double dash once the suffix is appended.

**Fix**: truncate to 48 characters first, then strip leading and trailing dashes, so the slug never keeps a stray dash on either end. Normal inputs are unchanged.

**Testing**: added `src/server/auth/org-slug.test.ts` with vitest cases for normal values, edge trimming, the empty fallback, the truncation-on-separator case, and `toHex`.
