### PR TITLE
harden(audit): apply the URL policy to sitemap discovery fetches

### DIFF
--- a/src/server/lib/audit/discovery.ts
+++ b/src/server/lib/audit/discovery.ts
@@ -4,6 +4,7 @@
 import robotsParser from "robots-parser";
 import { XMLParser } from "fast-xml-parser";
 import { isSameOrigin, normalizeUrl } from "./url-utils";
+import { isCrawlableUrl } from "./url-policy";
 
 const SITEMAP_FETCH_TIMEOUT_MS = 15_000;
 const MAX_SITEMAP_DEPTH = 3;
@@ -126,6 +127,14 @@ async function fetchSitemapDocumentWithRetry(sitemapUrl: string): Promise<{
 }> {
   const normalizedSitemapUrl = normalizeUrl(sitemapUrl);
   if (!normalizedSitemapUrl) {
+    return { nestedSitemaps: [], pageUrls: [], timedOut: false };
+  }
+  // Sitemap URLs are declared by the target's robots.txt and by nested
+  // <sitemap><loc> entries, so they are attacker-controlled. Apply the same
+  // URL policy used for start URLs and mid-crawl links before fetching, so a
+  // sitemap can't point the crawler at private/loopback/metadata addresses.
+  // (Every sitemap, including nested ones, is fetched through this function.)
+  if (!isCrawlableUrl(normalizedSitemapUrl)) {
     return { nestedSitemaps: [], pageUrls: [], timedOut: false };
   }
 


### PR DESCRIPTION
### What
Sitemap URLs discovered during an audit come from the target's `robots.txt` (`robots.getSitemaps()`) and from nested `<sitemap><loc>` entries, so they are controlled by the audited site rather than by us. `fetchSitemapDocumentWithRetry` fetched them after only `normalizeUrl`, without the `isCrawlableUrl` policy check that start URLs (`normalizeAndValidateStartUrl`) and mid-crawl links (`siteAuditWorkflowCrawl`) already pass through.

### Change
Apply `isCrawlableUrl` at the top of `fetchSitemapDocumentWithRetry`, before the fetch. Every sitemap, including nested ones (which are re-fetched through the same function), passes this single check, so a sitemap can't point the crawler at private / loopback / metadata hosts. `isCrawlableUrl` is already covered by `url-policy.test.ts`.

Keeps the URL policy consistent across all three fetch entry points (start URL, mid-crawl links, and sitemap discovery).
