### PR TITLE
fix(self-host): show "Check rankings" action for self-hosted instances

### DIFF
--- a/src/client/features/rank-tracking/RankTrackingDomainDetail.tsx
+++ b/src/client/features/rank-tracking/RankTrackingDomainDetail.tsx
@@ -1,15 +1,16 @@
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useCustomer } from "autumn-js/react";
 import {
   getLatestRankResults,
   getRankPositionMatrix,
   estimateRankCheckCost,
 } from "@/serverFunctions/rank-tracking";
 import { AlertTriangle, ArrowLeft } from "lucide-react";
-import { useSession } from "@/lib/auth-client";
-import { getCustomerPlanStatus } from "@/client/features/billing/plan-detection";
+import {
+  HostedPlanGate,
+  type HostedPlanGateState,
+} from "@/client/features/billing/HostedPlanGate";
 import { captureClientEvent } from "@/client/lib/posthog";
 import { FreePlanAlert } from "./FreePlanAlert";
 import { RankTrackingDetailHeader } from "./RankTrackingDetailHeader";
@@ -57,24 +58,35 @@ function deviceVisibility(
   };
 }
 
-export function RankTrackingDomainDetail({
-  config,
-  projectId,
-  onBack,
-  onEdit,
-}: {
+export function RankTrackingDomainDetail(props: {
   config: RankTrackingConfig;
   projectId: string;
   onBack: () => void;
   onEdit: () => void;
 }) {
-  const { data: session } = useSession();
-  const customerQuery = useCustomer({
-    queryOptions: { enabled: Boolean(session?.user?.id) },
-  });
-  const isFreePlan =
-    !!customerQuery.data &&
-    getCustomerPlanStatus(customerQuery.data) === "free";
+  return (
+    <HostedPlanGate>
+      {(planGate) => (
+        <RankTrackingDomainDetailInner {...props} planGate={planGate} />
+      )}
+    </HostedPlanGate>
+  );
+}
+
+function RankTrackingDomainDetailInner({
+  config,
+  projectId,
+  onBack,
+  onEdit,
+  planGate,
+}: {
+  config: RankTrackingConfig;
+  projectId: string;
+  onBack: () => void;
+  onEdit: () => void;
+  planGate: HostedPlanGateState;
+}) {
+  const { isFreePlan } = planGate;
 
   const queryClient = useQueryClient();
   const [showAddKeywords, setShowAddKeywords] = useState(false);


### PR DESCRIPTION
## Summary

- `RankTrackingDomainDetail.tsx` computed `isFreePlan` by calling `autumn-js`'s `useCustomer()` directly, with no awareness of self-hosted/`local_noauth` mode. Since self-hosted instances have no billing customer, this always resolved to "free plan" — and `ToolbarMenus.tsx`'s `MoreMenu` doesn't just disable the "Check rankings" item when `checkDisabled` is true, it omits it from the DOM entirely. So the action to manually trigger a rank check was invisible on every self-hosted instance.
- The server-side `triggerRankTrackingCheck` function already exempts self-hosted mode from this same plan check (`isHosted && !hasPaidPlan`), so self-hosted users could already run checks server-side — they just had no UI path to reach the action.
- Switches to `HostedPlanGate`, the render-prop component two other pages (`PromptExplorerPage`, `BrandLookupPage`) already use for this exact purpose: it short-circuits to `isFreePlan: false` without touching Autumn at all when `isHostedClientAuthMode()` is false, and only defers to the real billing check in hosted mode.

## Test plan

- [x] `pnpm run types:check` — clean.
- [x] `pnpm run lint` — clean, 0 warnings/errors.
- [x] Verified against a real self-hosted Docker instance: built a local image from this branch, recreated the running container in place (existing D1 data preserved), confirmed the "Check rankings" menu item now appears, and triggered a real manual check that completed successfully with live SERP positions returned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)