### PR TITLE
feat(ga4): add Google Analytics (GA4) connection and MCP tool

### DIFF
--- a/docs/SELF_HOSTING_GOOGLE_ANALYTICS.md
+++ b/docs/SELF_HOSTING_GOOGLE_ANALYTICS.md
@@ -1,0 +1,114 @@
+# Self-hosted Google Analytics (GA4)
+
+Connecting Google Analytics (GA4) lets OpenSEO pull your real sessions, users,
+and channel-mix data (organic search, direct, referral, email, paid), straight
+from Google — the total-visits and traffic-source questions Search Console
+can't answer on its own.
+
+It's **optional** and **independent of Search Console**: you can connect
+either, both, or neither. Connecting one never requires re-authorizing or
+affects the other.
+
+## What you'll need
+
+- A Google account with access to your GA4 property.
+- ~10 minutes in the [Google Cloud Console](https://console.cloud.google.com/).
+- The same three environment variables Search Console uses, if you've already
+  set those up — see [step 4](#4-set-environment-variables).
+
+## 1) Enable the required APIs
+
+In the same Google Cloud project you use (or would use) for Search Console:
+
+1. Open the [Google Cloud Console](https://console.cloud.google.com/).
+2. Enable the
+   [Google Analytics Data API](https://console.cloud.google.com/apis/library/analyticsdata.googleapis.com)
+   — this is what actually queries report data.
+3. Enable the
+   [Google Analytics Admin API](https://console.cloud.google.com/apis/library/analyticsadmin.googleapis.com)
+   — this is what lists the GA4 properties your account can see, for the
+   property picker after you connect.
+
+## 2) Configure the OAuth consent screen
+
+Under **APIs & Services → OAuth consent screen** — same requirements as
+Search Console. If you've already done this for Search Console, there's
+nothing more to do here; the same OAuth client is reused for both.
+
+## 3) Create or reuse an OAuth client ID
+
+If you already have an OAuth client configured for Search Console, reuse it —
+just add one more **Authorized redirect URI** to it:
+
+| Deployment   | Redirect URI                                             |
+| ------------ | --------------------------------------------------------- |
+| Deployed     | `https://your-openseo-domain.com/api/ga4/oauth/callback` |
+| Local Docker | `http://localhost:3001/api/ga4/oauth/callback`           |
+
+The scheme, host, and port must match exactly, with no trailing slash. If
+you're starting from scratch, follow steps 2–3 of the
+[Search Console guide](SELF_HOSTING_GOOGLE_SEARCH_CONSOLE.md) to create the
+client first, then add this redirect URI to it.
+
+## 4) Set environment variables
+
+Analytics uses the same three variables as Search Console — set them once,
+they cover both connections:
+
+| Variable               | Value                                                                   |
+| ---------------------- | ------------------------------------------------------------------------ |
+| `GOOGLE_CLIENT_ID`     | Client ID from step 3.                                                  |
+| `GOOGLE_CLIENT_SECRET` | Client secret from step 3.                                              |
+| `BETTER_AUTH_SECRET`   | A random string of **at least 32 characters** (encrypts stored tokens). |
+
+If Search Console is already connected, these are already set and you can
+skip straight to [step 5](#5-restart-and-connect).
+
+## 5) Restart and connect
+
+Restart OpenSEO so it picks up the new redirect URI / variables:
+
+```bash
+docker compose up -d --force-recreate open-seo
+```
+
+Then open **Integrations** (or Project Settings), click **Connect with
+Google** under the Analytics card, authorize the Google account that has
+access to your GA4 property, and pick the property to bind to your project.
+
+## How it works
+
+- Analytics gets its own OAuth grant, independent of Search Console's — a
+  separate provider ID, separate scope (`analytics.readonly`), separate stored
+  connection. Connecting or disconnecting one never touches the other.
+- OpenSEO stores the resulting grant with access and refresh tokens
+  **encrypted at rest** (keyed by `BETTER_AUTH_SECRET`), same as Search
+  Console.
+- Access tokens are minted and refreshed on demand — you only authorize once.
+- Analytics data comes from your own Google account, so OpenSEO never meters
+  credits for it.
+
+## Troubleshooting
+
+**`redirect_uri_mismatch` from Google** — the redirect URI in your OAuth
+client must exactly equal `<your-origin>/api/ga4/oauth/callback`. Re-check
+scheme (`http` vs `https`), host, port, and that there's no trailing slash.
+
+**"Google OAuth client not configured" / "not configured for Analytics yet"**
+(in the app or via the MCP tools) — one of `GOOGLE_CLIENT_ID`,
+`GOOGLE_CLIENT_SECRET`, or `BETTER_AUTH_SECRET` is missing, or the secret is
+shorter than 32 characters. Set all three and restart. On Docker, recreate the
+container so Compose reapplies `.env`:
+
+```bash
+docker compose up -d --force-recreate open-seo
+```
+
+**`access_denied` during sign-in** — the Google account isn't listed as a test
+user on the OAuth consent screen (while the app is in Testing mode). Add it
+under **OAuth consent screen → Test users**.
+
+**Connected, but no properties to pick** — the Google account you authorized
+doesn't have access to a GA4 property. Check
+[Google Analytics Admin → Property Access Management](https://analytics.google.com/)
+to confirm the account has at least Viewer access, then reconnect.

--- a/drizzle-pg/0014_futuristic_shadow_king.sql
+++ b/drizzle-pg/0014_futuristic_shadow_king.sql
@@ -1,0 +1,17 @@
+CREATE TABLE "ga4_connections" (
+	"id" text PRIMARY KEY NOT NULL,
+	"project_id" text NOT NULL,
+	"organization_id" text NOT NULL,
+	"property_id" text NOT NULL,
+	"property_display_name" text,
+	"connected_by_user_id" text NOT NULL,
+	"ga4_account_id" text,
+	"connected_account_email" text,
+	"created_at" text DEFAULT to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') NOT NULL,
+	"updated_at" text DEFAULT to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "ga4_connections" ADD CONSTRAINT "ga4_connections_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "ga4_connections" ADD CONSTRAINT "ga4_connections_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "ga4_connections_project_idx" ON "ga4_connections" USING btree ("project_id");--> statement-breakpoint
+CREATE INDEX "ga4_connections_organization_idx" ON "ga4_connections" USING btree ("organization_id");

--- a/drizzle-pg/meta/0014_snapshot.json
+++ b/drizzle-pg/meta/0014_snapshot.json
@@ -1,0 +1,3847 @@
+{
+  "id": "705b2467-fb27-4c78-9396-5132d895386d",
+  "prevId": "d61539b1-c4dd-4438-8a8b-7840b9122a72",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.backlink_snapshots": {
+      "name": "backlink_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backlinks": {
+          "name": "backlinks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referring_domains": {
+          "name": "referring_domains",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "broken_backlinks": {
+          "name": "broken_backlinks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_backlinks": {
+          "name": "new_backlinks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lost_backlinks": {
+          "name": "lost_backlinks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_referring_domains": {
+          "name": "new_referring_domains",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lost_referring_domains": {
+          "name": "lost_referring_domains",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "backlink_snapshots_project_captured_idx": {
+          "name": "backlink_snapshots_project_captured_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "backlink_snapshots_project_id_projects_id_fk": {
+          "name": "backlink_snapshots_project_id_projects_id_fk",
+          "tableFrom": "backlink_snapshots",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.keyword_metrics": {
+      "name": "keyword_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_code": {
+          "name": "location_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "search_volume": {
+          "name": "search_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpc": {
+          "name": "cpc",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "competition": {
+          "name": "competition",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keyword_difficulty": {
+          "name": "keyword_difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intent": {
+          "name": "intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monthly_searches": {
+          "name": "monthly_searches",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "keyword_metrics_unique_project_keyword_location_language": {
+          "name": "keyword_metrics_unique_project_keyword_location_language",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "keyword",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "keyword_metrics_lookup_idx": {
+          "name": "keyword_metrics_lookup_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "keyword",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "keyword_metrics_project_id_projects_id_fk": {
+          "name": "keyword_metrics_project_id_projects_id_fk",
+          "tableFrom": "keyword_metrics",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_activation_state": {
+      "name": "organization_activation_state",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_mcp_authorized_at": {
+          "name": "first_mcp_authorized_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_mcp_tool_call_at": {
+          "name": "first_mcp_tool_call_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_activation_state_organization_id_organization_id_fk": {
+          "name": "organization_activation_state_organization_id_organization_id_fk",
+          "tableFrom": "organization_activation_state",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_activation_state": {
+      "name": "project_activation_state",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "competitor_step_clicked_at": {
+          "name": "competitor_step_clicked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_card_dismissed_at": {
+          "name": "mcp_card_dismissed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_activation_state_project_id_projects_id_fk": {
+          "name": "project_activation_state_project_id_projects_id_fk",
+          "tableFrom": "project_activation_state",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_code": {
+          "name": "location_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2840
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "projects_one_default_per_organization_idx": {
+          "name": "projects_one_default_per_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"projects\".\"name\" = 'Default' AND \"projects\".\"domain\" IS NULL AND \"projects\".\"archived_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_organization_id_idx": {
+          "name": "projects_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_organization_id_organization_id_fk": {
+          "name": "projects_organization_id_organization_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rank_check_runs": {
+      "name": "rank_check_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "keywords_total": {
+          "name": "keywords_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "keywords_checked": {
+          "name": "keywords_checked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_subset_run": {
+          "name": "is_subset_run",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rank_check_runs_config_idx": {
+          "name": "rank_check_runs_config_idx",
+          "columns": [
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rank_check_runs_project_idx": {
+          "name": "rank_check_runs_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rank_check_runs_one_active_per_config_idx": {
+          "name": "rank_check_runs_one_active_per_config_idx",
+          "columns": [
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"rank_check_runs\".\"status\" IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rank_check_runs_config_id_rank_tracking_configs_id_fk": {
+          "name": "rank_check_runs_config_id_rank_tracking_configs_id_fk",
+          "tableFrom": "rank_check_runs",
+          "tableTo": "rank_tracking_configs",
+          "columnsFrom": [
+            "config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rank_check_runs_project_id_projects_id_fk": {
+          "name": "rank_check_runs_project_id_projects_id_fk",
+          "tableFrom": "rank_check_runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rank_snapshots": {
+      "name": "rank_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tracking_keyword_id": {
+          "name": "tracking_keyword_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device": {
+          "name": "device",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serp_features": {
+          "name": "serp_features",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "rank_snapshots_keyword_device_idx": {
+          "name": "rank_snapshots_keyword_device_idx",
+          "columns": [
+            {
+              "expression": "tracking_keyword_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rank_snapshots_run_keyword_device_idx": {
+          "name": "rank_snapshots_run_keyword_device_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tracking_keyword_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rank_snapshots_run_id_rank_check_runs_id_fk": {
+          "name": "rank_snapshots_run_id_rank_check_runs_id_fk",
+          "tableFrom": "rank_snapshots",
+          "tableTo": "rank_check_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rank_tracking_configs": {
+      "name": "rank_tracking_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_code": {
+          "name": "location_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2840
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "devices": {
+          "name": "devices",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'both'"
+        },
+        "serp_depth": {
+          "name": "serp_depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_interval": {
+          "name": "schedule_interval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'weekly'"
+        },
+        "location_name": {
+          "name": "location_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_check_at": {
+          "name": "next_check_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_skip_reason": {
+          "name": "last_skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "rank_tracking_configs_project_active_created_idx": {
+          "name": "rank_tracking_configs_project_active_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rank_tracking_configs_national_idx": {
+          "name": "rank_tracking_configs_national_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"rank_tracking_configs\".\"location_name\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rank_tracking_configs_local_idx": {
+          "name": "rank_tracking_configs_local_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"rank_tracking_configs\".\"location_name\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rank_tracking_configs_project_id_projects_id_fk": {
+          "name": "rank_tracking_configs_project_id_projects_id_fk",
+          "tableFrom": "rank_tracking_configs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rank_tracking_keywords": {
+      "name": "rank_tracking_keywords",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_volume": {
+          "name": "search_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keyword_difficulty": {
+          "name": "keyword_difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpc": {
+          "name": "cpc",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metrics_fetched_at": {
+          "name": "metrics_fetched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "rank_tracking_keywords_config_keyword_idx": {
+          "name": "rank_tracking_keywords_config_keyword_idx",
+          "columns": [
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "keyword",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rank_tracking_keywords_config_id_rank_tracking_configs_id_fk": {
+          "name": "rank_tracking_keywords_config_id_rank_tracking_configs_id_fk",
+          "tableFrom": "rank_tracking_keywords",
+          "tableTo": "rank_tracking_configs",
+          "columnsFrom": [
+            "config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_keyword_tag_assignments": {
+      "name": "saved_keyword_tag_assignments",
+      "schema": "",
+      "columns": {
+        "saved_keyword_id": {
+          "name": "saved_keyword_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "saved_keyword_tag_assignments_unique_idx": {
+          "name": "saved_keyword_tag_assignments_unique_idx",
+          "columns": [
+            {
+              "expression": "saved_keyword_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_keyword_tag_assignments_tag_idx": {
+          "name": "saved_keyword_tag_assignments_tag_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_keyword_tag_assignments_saved_keyword_id_saved_keywords_id_fk": {
+          "name": "saved_keyword_tag_assignments_saved_keyword_id_saved_keywords_id_fk",
+          "tableFrom": "saved_keyword_tag_assignments",
+          "tableTo": "saved_keywords",
+          "columnsFrom": [
+            "saved_keyword_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "saved_keyword_tag_assignments_tag_id_saved_keyword_tags_id_fk": {
+          "name": "saved_keyword_tag_assignments_tag_id_saved_keyword_tags_id_fk",
+          "tableFrom": "saved_keyword_tag_assignments",
+          "tableTo": "saved_keyword_tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_keyword_tags": {
+      "name": "saved_keyword_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "saved_keyword_tags_project_normalized_name_idx": {
+          "name": "saved_keyword_tags_project_normalized_name_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_keyword_tags_project_name_idx": {
+          "name": "saved_keyword_tags_project_name_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_keyword_tags_project_id_projects_id_fk": {
+          "name": "saved_keyword_tags_project_id_projects_id_fk",
+          "tableFrom": "saved_keyword_tags",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_keywords": {
+      "name": "saved_keywords",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_code": {
+          "name": "location_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2840
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "saved_keywords_unique_project_keyword_location_language": {
+          "name": "saved_keywords_unique_project_keyword_location_language",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "keyword",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_keywords_project_created_idx": {
+          "name": "saved_keywords_project_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_keywords_project_id_projects_id_fk": {
+          "name": "saved_keywords_project_id_projects_id_fk",
+          "tableFrom": "saved_keywords",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_onboarding_answers": {
+      "name": "user_onboarding_answers",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interested_features": {
+          "name": "interested_features",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "work_for": {
+          "name": "work_for",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_website_count": {
+          "name": "client_website_count",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "found_via": {
+          "name": "found_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_setup_intent": {
+          "name": "mcp_setup_intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gsc_nudge_dismissed_at": {
+          "name": "gsc_nudge_dismissed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "user_onboarding_answers_organization_idx": {
+          "name": "user_onboarding_answers_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_onboarding_answers_user_id_user_id_fk": {
+          "name": "user_onboarding_answers_user_id_user_id_fk",
+          "tableFrom": "user_onboarding_answers",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_onboarding_answers_organization_id_organization_id_fk": {
+          "name": "user_onboarding_answers_organization_id_organization_id_fk",
+          "tableFrom": "user_onboarding_answers",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_issues": {
+      "name": "audit_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "audit_id": {
+          "name": "audit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_url": {
+          "name": "page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_type": {
+          "name": "issue_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "details_json": {
+          "name": "details_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_issues_audit_type_idx": {
+          "name": "audit_issues_audit_type_idx",
+          "columns": [
+            {
+              "expression": "audit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_issues_page_id_idx": {
+          "name": "audit_issues_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_issues_audit_id_audits_id_fk": {
+          "name": "audit_issues_audit_id_audits_id_fk",
+          "tableFrom": "audit_issues",
+          "tableTo": "audits",
+          "columnsFrom": [
+            "audit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_issues_page_id_audit_pages_id_fk": {
+          "name": "audit_issues_page_id_audit_pages_id_fk",
+          "tableFrom": "audit_issues",
+          "tableTo": "audit_pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_lighthouse_results": {
+      "name": "audit_lighthouse_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "audit_id": {
+          "name": "audit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strategy": {
+          "name": "strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performance_score": {
+          "name": "performance_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessibility_score": {
+          "name": "accessibility_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "best_practices_score": {
+          "name": "best_practices_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seo_score": {
+          "name": "seo_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lcp_ms": {
+          "name": "lcp_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cls": {
+          "name": "cls",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inp_ms": {
+          "name": "inp_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ttfb_ms": {
+          "name": "ttfb_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_size_bytes": {
+          "name": "payload_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_lighthouse_results_audit_id_idx": {
+          "name": "audit_lighthouse_results_audit_id_idx",
+          "columns": [
+            {
+              "expression": "audit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_lighthouse_results_page_id_idx": {
+          "name": "audit_lighthouse_results_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_lighthouse_results_audit_id_audits_id_fk": {
+          "name": "audit_lighthouse_results_audit_id_audits_id_fk",
+          "tableFrom": "audit_lighthouse_results",
+          "tableTo": "audits",
+          "columnsFrom": [
+            "audit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_lighthouse_results_page_id_audit_pages_id_fk": {
+          "name": "audit_lighthouse_results_page_id_audit_pages_id_fk",
+          "tableFrom": "audit_lighthouse_results",
+          "tableTo": "audit_pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_links": {
+      "name": "audit_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "audit_id": {
+          "name": "audit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_page_id": {
+          "name": "source_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_url": {
+          "name": "target_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor": {
+          "name": "anchor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_internal": {
+          "name": "is_internal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_nofollow": {
+          "name": "is_nofollow",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "audit_links_audit_target_idx": {
+          "name": "audit_links_audit_target_idx",
+          "columns": [
+            {
+              "expression": "audit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_links_source_page_id_idx": {
+          "name": "audit_links_source_page_id_idx",
+          "columns": [
+            {
+              "expression": "source_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_links_audit_id_audits_id_fk": {
+          "name": "audit_links_audit_id_audits_id_fk",
+          "tableFrom": "audit_links",
+          "tableTo": "audits",
+          "columnsFrom": [
+            "audit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_links_source_page_id_audit_pages_id_fk": {
+          "name": "audit_links_source_page_id_audit_pages_id_fk",
+          "tableFrom": "audit_links",
+          "tableTo": "audit_pages",
+          "columnsFrom": [
+            "source_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_pages": {
+      "name": "audit_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "audit_id": {
+          "name": "audit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_url": {
+          "name": "canonical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "robots_meta": {
+          "name": "robots_meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_title": {
+          "name": "og_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_description": {
+          "name": "og_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_image": {
+          "name": "og_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "h1_count": {
+          "name": "h1_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "h2_count": {
+          "name": "h2_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "h3_count": {
+          "name": "h3_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "h4_count": {
+          "name": "h4_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "h5_count": {
+          "name": "h5_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "h6_count": {
+          "name": "h6_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "heading_order_json": {
+          "name": "heading_order_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "images_total": {
+          "name": "images_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "images_missing_alt": {
+          "name": "images_missing_alt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "images_json": {
+          "name": "images_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_link_count": {
+          "name": "internal_link_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "external_link_count": {
+          "name": "external_link_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "has_structured_data": {
+          "name": "has_structured_data",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hreflang_tags_json": {
+          "name": "hreflang_tags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_indexable": {
+          "name": "is_indexable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "x_robots_tag": {
+          "name": "x_robots_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "header_canonical_url": {
+          "name": "header_canonical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crawl_depth": {
+          "name": "crawl_depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "in_sitemap": {
+          "name": "in_sitemap",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetch_class": {
+          "name": "fetch_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ok'"
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_pages_audit_url_idx": {
+          "name": "audit_pages_audit_url_idx",
+          "columns": [
+            {
+              "expression": "audit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_pages_audit_id_audits_id_fk": {
+          "name": "audit_pages_audit_id_audits_id_fk",
+          "tableFrom": "audit_pages",
+          "tableTo": "audits",
+          "columnsFrom": [
+            "audit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audits": {
+      "name": "audits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_by_user_id": {
+          "name": "started_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_url": {
+          "name": "start_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "workflow_instance_id": {
+          "name": "workflow_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "pages_crawled": {
+          "name": "pages_crawled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pages_total": {
+          "name": "pages_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lighthouse_total": {
+          "name": "lighthouse_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lighthouse_completed": {
+          "name": "lighthouse_completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lighthouse_failed": {
+          "name": "lighthouse_failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_phase": {
+          "name": "current_phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'discovery'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audits_project_id_idx": {
+          "name": "audits_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audits_started_by_user_id_idx": {
+          "name": "audits_started_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "started_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audits_project_id_projects_id_fk": {
+          "name": "audits_project_id_projects_id_fk",
+          "tableFrom": "audits",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sam_project_memory": {
+      "name": "sam_project_memory",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sam_project_memory_project_id_projects_id_fk": {
+          "name": "sam_project_memory_project_id_projects_id_fk",
+          "tableFrom": "sam_project_memory",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "sam_project_memory_project_id_label_pk": {
+          "name": "sam_project_memory_project_id_label_pk",
+          "columns": [
+            "project_id",
+            "label"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sam_sessions": {
+      "name": "sam_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'New chat'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sam_sessions_project_updated_idx": {
+          "name": "sam_sessions_project_updated_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sam_sessions_project_id_projects_id_fk": {
+          "name": "sam_sessions_project_id_projects_id_fk",
+          "tableFrom": "sam_sessions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sam_sessions_user_id_user_id_fk": {
+          "name": "sam_sessions_user_id_user_id_fk",
+          "tableFrom": "sam_sessions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_accountId_providerId_idx": {
+          "name": "account_accountId_providerId_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_slug_uidx": {
+          "name": "organization_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "analytics_opted_out": {
+          "name": "analytics_opted_out",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verification_expiresAt_idx": {
+          "name": "verification_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_customer_status": {
+      "name": "billing_customer_status",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "is_paying": {
+          "name": "is_paying",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "paid_plan_id": {
+          "name": "paid_plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_plan_status": {
+          "name": "paid_plan_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_json": {
+          "name": "customer_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "billing_customer_status_organization_id_organization_id_fk": {
+          "name": "billing_customer_status_organization_id_organization_id_fk",
+          "tableFrom": "billing_customer_status",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gsc_connections": {
+      "name": "gsc_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_url": {
+          "name": "site_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gsc_account_id": {
+          "name": "gsc_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_account_email": {
+          "name": "connected_account_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "gsc_connections_project_idx": {
+          "name": "gsc_connections_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gsc_connections_organization_idx": {
+          "name": "gsc_connections_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gsc_connections_project_id_projects_id_fk": {
+          "name": "gsc_connections_project_id_projects_id_fk",
+          "tableFrom": "gsc_connections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gsc_connections_organization_id_organization_id_fk": {
+          "name": "gsc_connections_organization_id_organization_id_fk",
+          "tableFrom": "gsc_connections",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ga4_connections": {
+      "name": "ga4_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_display_name": {
+          "name": "property_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ga4_account_id": {
+          "name": "ga4_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_account_email": {
+          "name": "connected_account_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "ga4_connections_project_idx": {
+          "name": "ga4_connections_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ga4_connections_organization_idx": {
+          "name": "ga4_connections_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ga4_connections_project_id_projects_id_fk": {
+          "name": "ga4_connections_project_id_projects_id_fk",
+          "tableFrom": "ga4_connections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ga4_connections_organization_id_organization_id_fk": {
+          "name": "ga4_connections_organization_id_organization_id_fk",
+          "tableFrom": "ga4_connections",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reddit_attributions": {
+      "name": "reddit_attributions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "click_id": {
+          "name": "click_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "landing_page": {
+          "name": "landing_page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referrer": {
+          "name": "referrer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utm_source": {
+          "name": "utm_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utm_medium": {
+          "name": "utm_medium",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utm_campaign": {
+          "name": "utm_campaign",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utm_term": {
+          "name": "utm_term",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utm_content": {
+          "name": "utm_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signup_sent_at": {
+          "name": "signup_sent_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_sent_at": {
+          "name": "purchase_sent_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "reddit_attributions_user_idx": {
+          "name": "reddit_attributions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reddit_attributions_organization_idx": {
+          "name": "reddit_attributions_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reddit_attributions_user_id_user_id_fk": {
+          "name": "reddit_attributions_user_id_user_id_fk",
+          "tableFrom": "reddit_attributions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reddit_attributions_organization_id_organization_id_fk": {
+          "name": "reddit_attributions_organization_id_organization_id_fk",
+          "tableFrom": "reddit_attributions",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telemetry_state": {
+      "name": "telemetry_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "install_id": {
+          "name": "install_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_version": {
+          "name": "last_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_tool_call_count": {
+          "name": "mcp_tool_call_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle-pg/meta/_journal.json
+++ b/drizzle-pg/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1784426969390,
       "tag": "0013_sleepy_black_tarantula",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1786277526597,
+      "tag": "0014_futuristic_shadow_king",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/0037_cultured_reptil.sql
+++ b/drizzle/0037_cultured_reptil.sql
@@ -1,0 +1,17 @@
+CREATE TABLE `ga4_connections` (
+	`id` text PRIMARY KEY NOT NULL,
+	`project_id` text NOT NULL,
+	`organization_id` text NOT NULL,
+	`property_id` text NOT NULL,
+	`property_display_name` text,
+	`connected_by_user_id` text NOT NULL,
+	`ga4_account_id` text,
+	`connected_account_email` text,
+	`created_at` text DEFAULT (current_timestamp) NOT NULL,
+	`updated_at` text DEFAULT (current_timestamp) NOT NULL,
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`organization_id`) REFERENCES `organization`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `ga4_connections_project_idx` ON `ga4_connections` (`project_id`);--> statement-breakpoint
+CREATE INDEX `ga4_connections_organization_idx` ON `ga4_connections` (`organization_id`);

--- a/drizzle/meta/0037_snapshot.json
+++ b/drizzle/meta/0037_snapshot.json
@@ -1,0 +1,3504 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "1091364c-c26a-430c-a683-578fada1c85b",
+  "prevId": "3eed5245-3458-4f6b-b6ce-b970ca141bd8",
+  "tables": {
+    "backlink_snapshots": {
+      "name": "backlink_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "backlinks": {
+          "name": "backlinks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "referring_domains": {
+          "name": "referring_domains",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "broken_backlinks": {
+          "name": "broken_backlinks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "new_backlinks": {
+          "name": "new_backlinks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lost_backlinks": {
+          "name": "lost_backlinks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "new_referring_domains": {
+          "name": "new_referring_domains",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lost_referring_domains": {
+          "name": "lost_referring_domains",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "backlink_snapshots_project_captured_idx": {
+          "name": "backlink_snapshots_project_captured_idx",
+          "columns": [
+            "project_id",
+            "captured_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "backlink_snapshots_project_id_projects_id_fk": {
+          "name": "backlink_snapshots_project_id_projects_id_fk",
+          "tableFrom": "backlink_snapshots",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "keyword_metrics": {
+      "name": "keyword_metrics",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_code": {
+          "name": "location_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "search_volume": {
+          "name": "search_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cpc": {
+          "name": "cpc",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "competition": {
+          "name": "competition",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "keyword_difficulty": {
+          "name": "keyword_difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "intent": {
+          "name": "intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "monthly_searches": {
+          "name": "monthly_searches",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "keyword_metrics_unique_project_keyword_location_language": {
+          "name": "keyword_metrics_unique_project_keyword_location_language",
+          "columns": [
+            "project_id",
+            "keyword",
+            "location_code",
+            "language_code"
+          ],
+          "isUnique": true
+        },
+        "keyword_metrics_lookup_idx": {
+          "name": "keyword_metrics_lookup_idx",
+          "columns": [
+            "project_id",
+            "keyword",
+            "location_code",
+            "language_code",
+            "fetched_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "keyword_metrics_project_id_projects_id_fk": {
+          "name": "keyword_metrics_project_id_projects_id_fk",
+          "tableFrom": "keyword_metrics",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_activation_state": {
+      "name": "organization_activation_state",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_mcp_authorized_at": {
+          "name": "first_mcp_authorized_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_mcp_tool_call_at": {
+          "name": "first_mcp_tool_call_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_activation_state_organization_id_organization_id_fk": {
+          "name": "organization_activation_state_organization_id_organization_id_fk",
+          "tableFrom": "organization_activation_state",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_activation_state": {
+      "name": "project_activation_state",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "competitor_step_clicked_at": {
+          "name": "competitor_step_clicked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcp_card_dismissed_at": {
+          "name": "mcp_card_dismissed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_activation_state_project_id_projects_id_fk": {
+          "name": "project_activation_state_project_id_projects_id_fk",
+          "tableFrom": "project_activation_state",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location_code": {
+          "name": "location_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2840
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_one_default_per_organization_idx": {
+          "name": "projects_one_default_per_organization_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true,
+          "where": "\"projects\".\"name\" = 'Default' AND \"projects\".\"domain\" IS NULL AND \"projects\".\"archived_at\" IS NULL"
+        },
+        "projects_organization_id_idx": {
+          "name": "projects_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "projects_organization_id_organization_id_fk": {
+          "name": "projects_organization_id_organization_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rank_check_runs": {
+      "name": "rank_check_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "keywords_total": {
+          "name": "keywords_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "keywords_checked": {
+          "name": "keywords_checked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_subset_run": {
+          "name": "is_subset_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rank_check_runs_config_idx": {
+          "name": "rank_check_runs_config_idx",
+          "columns": [
+            "config_id",
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "rank_check_runs_project_idx": {
+          "name": "rank_check_runs_project_idx",
+          "columns": [
+            "project_id",
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "rank_check_runs_one_active_per_config_idx": {
+          "name": "rank_check_runs_one_active_per_config_idx",
+          "columns": [
+            "config_id"
+          ],
+          "isUnique": true,
+          "where": "\"rank_check_runs\".\"status\" IN ('pending', 'running')"
+        }
+      },
+      "foreignKeys": {
+        "rank_check_runs_config_id_rank_tracking_configs_id_fk": {
+          "name": "rank_check_runs_config_id_rank_tracking_configs_id_fk",
+          "tableFrom": "rank_check_runs",
+          "tableTo": "rank_tracking_configs",
+          "columnsFrom": [
+            "config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rank_check_runs_project_id_projects_id_fk": {
+          "name": "rank_check_runs_project_id_projects_id_fk",
+          "tableFrom": "rank_check_runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rank_snapshots": {
+      "name": "rank_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tracking_keyword_id": {
+          "name": "tracking_keyword_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device": {
+          "name": "device",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "serp_features": {
+          "name": "serp_features",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "rank_snapshots_keyword_device_idx": {
+          "name": "rank_snapshots_keyword_device_idx",
+          "columns": [
+            "tracking_keyword_id",
+            "device",
+            "checked_at"
+          ],
+          "isUnique": false
+        },
+        "rank_snapshots_run_keyword_device_idx": {
+          "name": "rank_snapshots_run_keyword_device_idx",
+          "columns": [
+            "run_id",
+            "tracking_keyword_id",
+            "device"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "rank_snapshots_run_id_rank_check_runs_id_fk": {
+          "name": "rank_snapshots_run_id_rank_check_runs_id_fk",
+          "tableFrom": "rank_snapshots",
+          "tableTo": "rank_check_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rank_tracking_configs": {
+      "name": "rank_tracking_configs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_code": {
+          "name": "location_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2840
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "devices": {
+          "name": "devices",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'both'"
+        },
+        "serp_depth": {
+          "name": "serp_depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_interval": {
+          "name": "schedule_interval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'weekly'"
+        },
+        "location_name": {
+          "name": "location_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_check_at": {
+          "name": "next_check_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_skip_reason": {
+          "name": "last_skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "rank_tracking_configs_project_active_created_idx": {
+          "name": "rank_tracking_configs_project_active_created_idx",
+          "columns": [
+            "project_id",
+            "is_active",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "rank_tracking_configs_national_idx": {
+          "name": "rank_tracking_configs_national_idx",
+          "columns": [
+            "project_id",
+            "domain",
+            "location_code"
+          ],
+          "isUnique": true,
+          "where": "\"rank_tracking_configs\".\"location_name\" IS NULL"
+        },
+        "rank_tracking_configs_local_idx": {
+          "name": "rank_tracking_configs_local_idx",
+          "columns": [
+            "project_id",
+            "domain",
+            "location_code",
+            "location_name"
+          ],
+          "isUnique": true,
+          "where": "\"rank_tracking_configs\".\"location_name\" IS NOT NULL"
+        }
+      },
+      "foreignKeys": {
+        "rank_tracking_configs_project_id_projects_id_fk": {
+          "name": "rank_tracking_configs_project_id_projects_id_fk",
+          "tableFrom": "rank_tracking_configs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rank_tracking_keywords": {
+      "name": "rank_tracking_keywords",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "search_volume": {
+          "name": "search_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "keyword_difficulty": {
+          "name": "keyword_difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cpc": {
+          "name": "cpc",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metrics_fetched_at": {
+          "name": "metrics_fetched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "rank_tracking_keywords_config_keyword_idx": {
+          "name": "rank_tracking_keywords_config_keyword_idx",
+          "columns": [
+            "config_id",
+            "keyword"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "rank_tracking_keywords_config_id_rank_tracking_configs_id_fk": {
+          "name": "rank_tracking_keywords_config_id_rank_tracking_configs_id_fk",
+          "tableFrom": "rank_tracking_keywords",
+          "tableTo": "rank_tracking_configs",
+          "columnsFrom": [
+            "config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "saved_keyword_tag_assignments": {
+      "name": "saved_keyword_tag_assignments",
+      "columns": {
+        "saved_keyword_id": {
+          "name": "saved_keyword_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "saved_keyword_tag_assignments_unique_idx": {
+          "name": "saved_keyword_tag_assignments_unique_idx",
+          "columns": [
+            "saved_keyword_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        },
+        "saved_keyword_tag_assignments_tag_idx": {
+          "name": "saved_keyword_tag_assignments_tag_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "saved_keyword_tag_assignments_saved_keyword_id_saved_keywords_id_fk": {
+          "name": "saved_keyword_tag_assignments_saved_keyword_id_saved_keywords_id_fk",
+          "tableFrom": "saved_keyword_tag_assignments",
+          "tableTo": "saved_keywords",
+          "columnsFrom": [
+            "saved_keyword_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "saved_keyword_tag_assignments_tag_id_saved_keyword_tags_id_fk": {
+          "name": "saved_keyword_tag_assignments_tag_id_saved_keyword_tags_id_fk",
+          "tableFrom": "saved_keyword_tag_assignments",
+          "tableTo": "saved_keyword_tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "saved_keyword_tags": {
+      "name": "saved_keyword_tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "saved_keyword_tags_project_normalized_name_idx": {
+          "name": "saved_keyword_tags_project_normalized_name_idx",
+          "columns": [
+            "project_id",
+            "normalized_name"
+          ],
+          "isUnique": true
+        },
+        "saved_keyword_tags_project_name_idx": {
+          "name": "saved_keyword_tags_project_name_idx",
+          "columns": [
+            "project_id",
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "saved_keyword_tags_project_id_projects_id_fk": {
+          "name": "saved_keyword_tags_project_id_projects_id_fk",
+          "tableFrom": "saved_keyword_tags",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "saved_keywords": {
+      "name": "saved_keywords",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_code": {
+          "name": "location_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2840
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "saved_keywords_unique_project_keyword_location_language": {
+          "name": "saved_keywords_unique_project_keyword_location_language",
+          "columns": [
+            "project_id",
+            "keyword",
+            "location_code",
+            "language_code"
+          ],
+          "isUnique": true
+        },
+        "saved_keywords_project_created_idx": {
+          "name": "saved_keywords_project_created_idx",
+          "columns": [
+            "project_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "saved_keywords_project_id_projects_id_fk": {
+          "name": "saved_keywords_project_id_projects_id_fk",
+          "tableFrom": "saved_keywords",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_onboarding_answers": {
+      "name": "user_onboarding_answers",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "interested_features": {
+          "name": "interested_features",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "work_for": {
+          "name": "work_for",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_website_count": {
+          "name": "client_website_count",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "found_via": {
+          "name": "found_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcp_setup_intent": {
+          "name": "mcp_setup_intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gsc_nudge_dismissed_at": {
+          "name": "gsc_nudge_dismissed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "user_onboarding_answers_organization_idx": {
+          "name": "user_onboarding_answers_organization_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_onboarding_answers_user_id_user_id_fk": {
+          "name": "user_onboarding_answers_user_id_user_id_fk",
+          "tableFrom": "user_onboarding_answers",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_onboarding_answers_organization_id_organization_id_fk": {
+          "name": "user_onboarding_answers_organization_id_organization_id_fk",
+          "tableFrom": "user_onboarding_answers",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_issues": {
+      "name": "audit_issues",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audit_id": {
+          "name": "audit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "page_url": {
+          "name": "page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issue_type": {
+          "name": "issue_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'info'"
+        },
+        "details_json": {
+          "name": "details_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "audit_issues_audit_type_idx": {
+          "name": "audit_issues_audit_type_idx",
+          "columns": [
+            "audit_id",
+            "issue_type"
+          ],
+          "isUnique": false
+        },
+        "audit_issues_page_id_idx": {
+          "name": "audit_issues_page_id_idx",
+          "columns": [
+            "page_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audit_issues_audit_id_audits_id_fk": {
+          "name": "audit_issues_audit_id_audits_id_fk",
+          "tableFrom": "audit_issues",
+          "tableTo": "audits",
+          "columnsFrom": [
+            "audit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_issues_page_id_audit_pages_id_fk": {
+          "name": "audit_issues_page_id_audit_pages_id_fk",
+          "tableFrom": "audit_issues",
+          "tableTo": "audit_pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_lighthouse_results": {
+      "name": "audit_lighthouse_results",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audit_id": {
+          "name": "audit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "strategy": {
+          "name": "strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "performance_score": {
+          "name": "performance_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accessibility_score": {
+          "name": "accessibility_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "best_practices_score": {
+          "name": "best_practices_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seo_score": {
+          "name": "seo_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lcp_ms": {
+          "name": "lcp_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cls": {
+          "name": "cls",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inp_ms": {
+          "name": "inp_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ttfb_ms": {
+          "name": "ttfb_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload_size_bytes": {
+          "name": "payload_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "audit_lighthouse_results_audit_id_idx": {
+          "name": "audit_lighthouse_results_audit_id_idx",
+          "columns": [
+            "audit_id"
+          ],
+          "isUnique": false
+        },
+        "audit_lighthouse_results_page_id_idx": {
+          "name": "audit_lighthouse_results_page_id_idx",
+          "columns": [
+            "page_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audit_lighthouse_results_audit_id_audits_id_fk": {
+          "name": "audit_lighthouse_results_audit_id_audits_id_fk",
+          "tableFrom": "audit_lighthouse_results",
+          "tableTo": "audits",
+          "columnsFrom": [
+            "audit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_lighthouse_results_page_id_audit_pages_id_fk": {
+          "name": "audit_lighthouse_results_page_id_audit_pages_id_fk",
+          "tableFrom": "audit_lighthouse_results",
+          "tableTo": "audit_pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_links": {
+      "name": "audit_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audit_id": {
+          "name": "audit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_page_id": {
+          "name": "source_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_url": {
+          "name": "target_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "anchor": {
+          "name": "anchor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_internal": {
+          "name": "is_internal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "is_nofollow": {
+          "name": "is_nofollow",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "audit_links_audit_target_idx": {
+          "name": "audit_links_audit_target_idx",
+          "columns": [
+            "audit_id",
+            "target_url"
+          ],
+          "isUnique": false
+        },
+        "audit_links_source_page_id_idx": {
+          "name": "audit_links_source_page_id_idx",
+          "columns": [
+            "source_page_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audit_links_audit_id_audits_id_fk": {
+          "name": "audit_links_audit_id_audits_id_fk",
+          "tableFrom": "audit_links",
+          "tableTo": "audits",
+          "columnsFrom": [
+            "audit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_links_source_page_id_audit_pages_id_fk": {
+          "name": "audit_links_source_page_id_audit_pages_id_fk",
+          "tableFrom": "audit_links",
+          "tableTo": "audit_pages",
+          "columnsFrom": [
+            "source_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_pages": {
+      "name": "audit_pages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audit_id": {
+          "name": "audit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "canonical_url": {
+          "name": "canonical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "robots_meta": {
+          "name": "robots_meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_title": {
+          "name": "og_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_description": {
+          "name": "og_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_image": {
+          "name": "og_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "h1_count": {
+          "name": "h1_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "h2_count": {
+          "name": "h2_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "h3_count": {
+          "name": "h3_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "h4_count": {
+          "name": "h4_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "h5_count": {
+          "name": "h5_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "h6_count": {
+          "name": "h6_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "heading_order_json": {
+          "name": "heading_order_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "images_total": {
+          "name": "images_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "images_missing_alt": {
+          "name": "images_missing_alt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "images_json": {
+          "name": "images_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "internal_link_count": {
+          "name": "internal_link_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "external_link_count": {
+          "name": "external_link_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "has_structured_data": {
+          "name": "has_structured_data",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "hreflang_tags_json": {
+          "name": "hreflang_tags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_indexable": {
+          "name": "is_indexable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "x_robots_tag": {
+          "name": "x_robots_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "header_canonical_url": {
+          "name": "header_canonical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "crawl_depth": {
+          "name": "crawl_depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "in_sitemap": {
+          "name": "in_sitemap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fetch_class": {
+          "name": "fetch_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ok'"
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "audit_pages_audit_url_idx": {
+          "name": "audit_pages_audit_url_idx",
+          "columns": [
+            "audit_id",
+            "url"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audit_pages_audit_id_audits_id_fk": {
+          "name": "audit_pages_audit_id_audits_id_fk",
+          "tableFrom": "audit_pages",
+          "tableTo": "audits",
+          "columnsFrom": [
+            "audit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audits": {
+      "name": "audits",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_by_user_id": {
+          "name": "started_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_url": {
+          "name": "start_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "workflow_instance_id": {
+          "name": "workflow_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "pages_crawled": {
+          "name": "pages_crawled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "pages_total": {
+          "name": "pages_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lighthouse_total": {
+          "name": "lighthouse_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lighthouse_completed": {
+          "name": "lighthouse_completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lighthouse_failed": {
+          "name": "lighthouse_failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "current_phase": {
+          "name": "current_phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'discovery'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "audits_project_id_idx": {
+          "name": "audits_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "audits_started_by_user_id_idx": {
+          "name": "audits_started_by_user_id_idx",
+          "columns": [
+            "started_by_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audits_project_id_projects_id_fk": {
+          "name": "audits_project_id_projects_id_fk",
+          "tableFrom": "audits",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sam_project_memory": {
+      "name": "sam_project_memory",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sam_project_memory_project_id_projects_id_fk": {
+          "name": "sam_project_memory_project_id_projects_id_fk",
+          "tableFrom": "sam_project_memory",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "sam_project_memory_project_id_label_pk": {
+          "columns": [
+            "project_id",
+            "label"
+          ],
+          "name": "sam_project_memory_project_id_label_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sam_sessions": {
+      "name": "sam_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'New chat'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sam_sessions_project_updated_idx": {
+          "name": "sam_sessions_project_updated_idx",
+          "columns": [
+            "project_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sam_sessions_project_id_projects_id_fk": {
+          "name": "sam_sessions_project_id_projects_id_fk",
+          "tableFrom": "sam_sessions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sam_sessions_user_id_user_id_fk": {
+          "name": "sam_sessions_user_id_user_id_fk",
+          "tableFrom": "sam_sessions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "account_accountId_providerId_idx": {
+          "name": "account_accountId_providerId_idx",
+          "columns": [
+            "account_id",
+            "provider_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invitation": {
+      "name": "invitation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "member": {
+      "name": "member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization": {
+      "name": "organization",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "organization_slug_uidx": {
+          "name": "organization_slug_uidx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "analytics_opted_out": {
+          "name": "analytics_opted_out",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        },
+        "verification_expiresAt_idx": {
+          "name": "verification_expiresAt_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "billing_customer_status": {
+      "name": "billing_customer_status",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_paying": {
+          "name": "is_paying",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "paid_plan_id": {
+          "name": "paid_plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "paid_plan_status": {
+          "name": "paid_plan_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "customer_json": {
+          "name": "customer_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "billing_customer_status_organization_id_organization_id_fk": {
+          "name": "billing_customer_status_organization_id_organization_id_fk",
+          "tableFrom": "billing_customer_status",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gsc_connections": {
+      "name": "gsc_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "site_url": {
+          "name": "site_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gsc_account_id": {
+          "name": "gsc_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connected_account_email": {
+          "name": "connected_account_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "gsc_connections_project_idx": {
+          "name": "gsc_connections_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": true
+        },
+        "gsc_connections_organization_idx": {
+          "name": "gsc_connections_organization_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gsc_connections_project_id_projects_id_fk": {
+          "name": "gsc_connections_project_id_projects_id_fk",
+          "tableFrom": "gsc_connections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gsc_connections_organization_id_organization_id_fk": {
+          "name": "gsc_connections_organization_id_organization_id_fk",
+          "tableFrom": "gsc_connections",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ga4_connections": {
+      "name": "ga4_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "property_display_name": {
+          "name": "property_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ga4_account_id": {
+          "name": "ga4_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connected_account_email": {
+          "name": "connected_account_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "ga4_connections_project_idx": {
+          "name": "ga4_connections_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": true
+        },
+        "ga4_connections_organization_idx": {
+          "name": "ga4_connections_organization_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "ga4_connections_project_id_projects_id_fk": {
+          "name": "ga4_connections_project_id_projects_id_fk",
+          "tableFrom": "ga4_connections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ga4_connections_organization_id_organization_id_fk": {
+          "name": "ga4_connections_organization_id_organization_id_fk",
+          "tableFrom": "ga4_connections",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reddit_attributions": {
+      "name": "reddit_attributions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "click_id": {
+          "name": "click_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "landing_page": {
+          "name": "landing_page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "referrer": {
+          "name": "referrer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "utm_source": {
+          "name": "utm_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "utm_medium": {
+          "name": "utm_medium",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "utm_campaign": {
+          "name": "utm_campaign",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "utm_term": {
+          "name": "utm_term",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "utm_content": {
+          "name": "utm_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signup_sent_at": {
+          "name": "signup_sent_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "purchase_sent_at": {
+          "name": "purchase_sent_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "reddit_attributions_user_idx": {
+          "name": "reddit_attributions_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        },
+        "reddit_attributions_organization_idx": {
+          "name": "reddit_attributions_organization_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reddit_attributions_user_id_user_id_fk": {
+          "name": "reddit_attributions_user_id_user_id_fk",
+          "tableFrom": "reddit_attributions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reddit_attributions_organization_id_organization_id_fk": {
+          "name": "reddit_attributions_organization_id_organization_id_fk",
+          "tableFrom": "reddit_attributions",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "telemetry_state": {
+      "name": "telemetry_state",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "install_id": {
+          "name": "install_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_version": {
+          "name": "last_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcp_tool_call_count": {
+          "name": "mcp_tool_call_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -260,6 +260,13 @@
       "when": 1784426967421,
       "tag": "0036_curvy_silk_fever",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "6",
+      "when": 1786277491182,
+      "tag": "0037_cultured_reptil",
+      "breakpoints": true
     }
   ]
 }

--- a/src/client/features/ga4/AnalyticsConnectionCard.tsx
+++ b/src/client/features/ga4/AnalyticsConnectionCard.tsx
@@ -1,0 +1,311 @@
+import * as React from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { isHostedClientAuthMode } from "@/lib/auth-mode";
+import { getStandardErrorMessage } from "@/client/lib/error-messages";
+import { captureClientEvent } from "@/client/lib/posthog";
+import { GoogleGlyph } from "@/client/features/gsc/GoogleGlyph";
+import { Ga4SelfHostedSetupWarning } from "@/client/features/ga4/Ga4SelfHostedSetupWarning";
+import {
+  PropertyPicker,
+  type Ga4PropertySelection,
+} from "@/client/features/ga4/PropertyPicker";
+import { startGa4Link } from "@/client/features/ga4/startGa4Link";
+import {
+  disconnectGa4,
+  getGa4Connection,
+  listGa4Properties,
+  setGa4Property,
+} from "@/serverFunctions/ga4";
+
+const GRANT_STATUS_KEY = ["ga4GrantStatus"];
+
+export function AnalyticsConnectionCard({
+  projectId,
+}: {
+  projectId: string;
+}) {
+  const hosted = isHostedClientAuthMode();
+  const queryClient = useQueryClient();
+  const [picking, setPicking] = React.useState(false);
+  const [selection, setSelection] = React.useState<Ga4PropertySelection | null>(
+    null,
+  );
+
+  const connectionKey = ["ga4Connection", projectId];
+  const connectionQuery = useQuery({
+    queryKey: connectionKey,
+    queryFn: () => getGa4Connection({ data: { projectId } }),
+  });
+  const connection = connectionQuery.data;
+  const connected = Boolean(connection?.connected);
+  const selfHostedNeedsSetup =
+    !hosted && connectionQuery.isSuccess && !connection?.googleOAuthConfigured;
+
+  const showPicker = picking || (connection?.currentUserHasGrant && !connected);
+  const propertiesQuery = useQuery({
+    queryKey: ["ga4Properties", projectId],
+    queryFn: () => listGa4Properties({ data: { projectId } }),
+    enabled: Boolean(showPicker && !selfHostedNeedsSetup),
+  });
+  const accounts = React.useMemo(
+    () => propertiesQuery.data?.accounts ?? [],
+    [propertiesQuery.data?.accounts],
+  );
+  const requiresReconnect = accounts.some(
+    (account) => account.requiresReconnect,
+  );
+
+  React.useEffect(() => {
+    if (!requiresReconnect) return;
+
+    void queryClient.invalidateQueries({
+      queryKey: ["ga4Connection", projectId],
+    });
+    void queryClient.invalidateQueries({ queryKey: GRANT_STATUS_KEY });
+  }, [requiresReconnect, queryClient, projectId]);
+
+  React.useEffect(() => {
+    if (selection) return;
+    for (const account of accounts) {
+      const selectedProperty = account.properties.find(
+        (property) => property.isSelected,
+      );
+      if (selectedProperty) {
+        setSelection({
+          accountId: account.accountId,
+          propertyId: selectedProperty.propertyId,
+        });
+        return;
+      }
+    }
+  }, [accounts, selection]);
+
+  const setPropertyMutation = useMutation({
+    mutationFn: (selected: Ga4PropertySelection) =>
+      setGa4Property({ data: { projectId, ...selected } }),
+    onSuccess: () => {
+      captureClientEvent("ga4:property_select");
+      toast.success("Analytics connected");
+      setPicking(false);
+      void queryClient.invalidateQueries({ queryKey: connectionKey });
+      void queryClient.invalidateQueries({ queryKey: GRANT_STATUS_KEY });
+    },
+    onError: (error) => toast.error(getStandardErrorMessage(error)),
+  });
+
+  const disconnectMutation = useMutation({
+    mutationFn: () => disconnectGa4({ data: { projectId } }),
+    onSuccess: () => {
+      toast.success("Analytics disconnected");
+      setPicking(false);
+      setSelection(null);
+      void queryClient.invalidateQueries({ queryKey: connectionKey });
+      // Disconnect can drop the account-level grant server-side; keep the
+      // shared grant-status cache (onboarding step + re-engagement nudge) honest.
+      void queryClient.invalidateQueries({ queryKey: GRANT_STATUS_KEY });
+    },
+    onError: (error) => toast.error(getStandardErrorMessage(error)),
+  });
+
+  const handleConnect = () => void startGa4Link(window.location.href);
+
+  return (
+    <IntegrationCard
+      status={
+        connectionQuery.isLoading
+          ? undefined
+          : selfHostedNeedsSetup
+            ? "setup_required"
+            : connected
+              ? "connected"
+              : "disconnected"
+      }
+    >
+      {connectionQuery.isLoading ? (
+        <div className="flex items-center gap-2 text-sm text-base-content/50">
+          <span className="loading loading-spinner loading-sm" />
+          Checking…
+        </div>
+      ) : selfHostedNeedsSetup ? (
+        <Ga4SelfHostedSetupWarning />
+      ) : connected && !picking ? (
+        <ConnectedState
+          propertyId={connection?.propertyId ?? ""}
+          propertyDisplayName={connection?.propertyDisplayName ?? null}
+          connectedByEmail={connection?.connectedByEmail ?? null}
+          onChange={() => {
+            setSelection(null);
+            setPicking(true);
+          }}
+          onDisconnect={() => disconnectMutation.mutate()}
+          disconnecting={disconnectMutation.isPending}
+        />
+      ) : showPicker ? (
+        <PropertyPicker
+          loading={propertiesQuery.isLoading}
+          error={propertiesQuery.isError}
+          accounts={accounts}
+          selection={selection}
+          onSelect={setSelection}
+          onSave={() => selection && setPropertyMutation.mutate(selection)}
+          saving={setPropertyMutation.isPending}
+          onRetry={() => void propertiesQuery.refetch()}
+          onReconnect={handleConnect}
+          secondaryAction={
+            connected
+              ? { label: "Cancel", onClick: () => setPicking(false) }
+              : {
+                  label: "Disconnect",
+                  destructive: true,
+                  disabled: disconnectMutation.isPending,
+                  onClick: () => disconnectMutation.mutate(),
+                }
+          }
+        />
+      ) : (
+        <div className="space-y-4">
+          <p className="text-sm text-base-content/70">
+            Connect Analytics to see total visits and channel mix (search,
+            direct, referral, email) — data Search Console can't provide.
+          </p>
+          <button
+            type="button"
+            onClick={handleConnect}
+            className="inline-flex items-center gap-2.5 rounded-lg border border-base-300 bg-base-100 px-4 py-2.5 text-sm font-semibold text-base-content shadow-sm transition hover:bg-base-200 hover:shadow focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          >
+            <GoogleGlyph className="size-[18px]" />
+            Connect with Google
+          </button>
+        </div>
+      )}
+    </IntegrationCard>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Card shell
+// ---------------------------------------------------------------------------
+
+function IntegrationCard({
+  status,
+  children,
+}: {
+  status?: "connected" | "disconnected" | "setup_required";
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="overflow-hidden rounded-xl border border-base-300 bg-base-100 shadow-sm">
+      <div className="flex items-start justify-between gap-4 p-5 sm:p-6">
+        <h2 className="text-base font-semibold leading-tight">
+          Google Analytics
+        </h2>
+        {status ? <StatusPill status={status} /> : null}
+      </div>
+      <div className="border-t border-base-300 p-5 sm:p-6">{children}</div>
+    </div>
+  );
+}
+
+function StatusPill({
+  status,
+}: {
+  status: "connected" | "disconnected" | "setup_required";
+}) {
+  const connected = status === "connected";
+  const setupRequired = status === "setup_required";
+  return (
+    <span
+      className={[
+        "inline-flex shrink-0 items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium",
+        connected
+          ? "border-success/30 bg-success/10 text-success"
+          : setupRequired
+            ? "border-warning/30 bg-warning/10 text-warning"
+            : "border-base-300 bg-base-200 text-base-content/60",
+      ].join(" ")}
+    >
+      <span
+        className={[
+          "size-1.5 rounded-full",
+          connected
+            ? "bg-success"
+            : setupRequired
+              ? "bg-warning"
+              : "bg-base-content/40",
+        ].join(" ")}
+      />
+      {connected
+        ? "Connected"
+        : setupRequired
+          ? "Setup required"
+          : "Not connected"}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Connected state
+// ---------------------------------------------------------------------------
+
+function ConnectedState({
+  propertyId,
+  propertyDisplayName,
+  connectedByEmail,
+  onChange,
+  onDisconnect,
+  disconnecting,
+}: {
+  propertyId: string;
+  propertyDisplayName: string | null;
+  connectedByEmail: string | null;
+  onChange: () => void;
+  onDisconnect: () => void;
+  disconnecting: boolean;
+}) {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-3 rounded-lg border border-base-300 bg-base-200/40 p-3.5">
+        <div className="grid size-9 shrink-0 place-items-center rounded-md border border-base-300 bg-base-100">
+          <GoogleGlyph className="size-[18px]" />
+        </div>
+        <div className="min-w-0">
+          <p className="truncate text-sm">
+            {propertyDisplayName ? (
+              <>
+                <span className="font-medium">{propertyDisplayName}</span>{" "}
+                <span className="font-mono text-base-content/60">
+                  ({propertyId})
+                </span>
+              </>
+            ) : (
+              <span className="font-mono">{propertyId}</span>
+            )}
+          </p>
+          {connectedByEmail ? (
+            <p className="truncate text-xs text-base-content/55">
+              Connected by {connectedByEmail}
+            </p>
+          ) : null}
+        </div>
+      </div>
+      <div className="flex items-center gap-1">
+        <button
+          type="button"
+          className="btn btn-ghost btn-sm"
+          onClick={onChange}
+        >
+          Change property
+        </button>
+        <button
+          type="button"
+          className="btn btn-ghost btn-sm text-error hover:bg-error/10"
+          onClick={onDisconnect}
+          disabled={disconnecting}
+        >
+          Disconnect
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/client/features/ga4/Ga4SelfHostedSetupWarning.tsx
+++ b/src/client/features/ga4/Ga4SelfHostedSetupWarning.tsx
@@ -1,0 +1,29 @@
+import { AlertTriangle } from "lucide-react";
+import { SafeExternalLink } from "@/client/components/SafeExternalLink";
+import { GA4_SELF_HOSTED_SETUP_DOCS_URL } from "@/shared/ga4";
+
+/**
+ * Shown in self-hosted deployments that haven't set GOOGLE_CLIENT_ID/SECRET yet
+ * — in the Integrations card. Same OAuth client as Search Console; this warns
+ * independently since a deployment could plausibly configure one connection
+ * before the other's docs are followed.
+ */
+export function Ga4SelfHostedSetupWarning() {
+  return (
+    <div className="alert alert-warning items-start text-sm">
+      <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+      <div className="space-y-1">
+        <p className="font-medium">Google OAuth client not configured</p>
+        <p className="text-base-content/70">
+          Add your Google client ID and secret to this OpenSEO deployment
+          before connecting Analytics.
+        </p>
+        <SafeExternalLink
+          url={GA4_SELF_HOSTED_SETUP_DOCS_URL}
+          label="Open setup guide"
+          className="inline-flex items-center gap-1 font-medium underline underline-offset-2"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/client/features/ga4/PropertyPicker.tsx
+++ b/src/client/features/ga4/PropertyPicker.tsx
@@ -1,0 +1,193 @@
+import { GoogleGlyph } from "@/client/features/gsc/GoogleGlyph";
+import { startGa4Link } from "@/client/features/ga4/startGa4Link";
+
+type PropertyOption = {
+  propertyId: string;
+  displayName: string;
+  isSelected: boolean;
+};
+
+type AccountOption = {
+  accountId: string;
+  email: string | null;
+  requiresReconnect: boolean;
+  properties: PropertyOption[];
+};
+
+export type Ga4PropertySelection = {
+  accountId: string;
+  propertyId: string;
+};
+
+type SecondaryAction = {
+  label: string;
+  onClick: () => void;
+  destructive?: boolean;
+  disabled?: boolean;
+};
+
+/**
+ * Property selector for connected Google accounts. `secondaryAction` is
+ * optional — omit it where there's nothing to cancel/disconnect.
+ */
+export function PropertyPicker({
+  loading,
+  error,
+  accounts,
+  selection,
+  onSelect,
+  onSave,
+  saving,
+  onRetry,
+  onReconnect,
+  secondaryAction,
+}: {
+  loading: boolean;
+  error: boolean;
+  accounts: AccountOption[];
+  selection: Ga4PropertySelection | null;
+  onSelect: (selection: Ga4PropertySelection) => void;
+  onSave: () => void;
+  saving: boolean;
+  onRetry: () => void;
+  onReconnect: () => void;
+  secondaryAction?: SecondaryAction;
+}) {
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-base-content/50">
+        <span className="loading loading-spinner loading-sm" />
+        Loading properties…
+      </div>
+    );
+  }
+  if (error) {
+    return (
+      <div className="space-y-3">
+        <p className="text-sm text-error">
+          Couldn't load your Analytics properties.
+        </p>
+        <button
+          type="button"
+          className="btn btn-ghost btn-sm"
+          onClick={onRetry}
+        >
+          Try again
+        </button>
+      </div>
+    );
+  }
+
+  const allAccountsRequireReconnect =
+    accounts.length > 0 &&
+    accounts.every((account) => account.requiresReconnect);
+  if (allAccountsRequireReconnect) {
+    return (
+      <div className="space-y-3">
+        <p className="text-sm text-error">
+          Connection expired. Reconnect to continue.
+        </p>
+        <button
+          type="button"
+          onClick={onReconnect}
+          className="inline-flex items-center gap-2.5 rounded-lg border border-base-300 bg-base-100 px-4 py-2.5 text-sm font-semibold shadow-sm transition hover:bg-base-200"
+        >
+          <GoogleGlyph className="size-[18px]" />
+          Reconnect with Google
+        </button>
+      </div>
+    );
+  }
+
+  const healthyAccounts = accounts.filter(
+    (account) => !account.requiresReconnect,
+  );
+  const options = healthyAccounts.flatMap((account) =>
+    account.properties.map((property) => ({
+      accountId: account.accountId,
+      propertyId: property.propertyId,
+    })),
+  );
+  const selectedIndex = selection
+    ? options.findIndex(
+        (option) =>
+          option.accountId === selection.accountId &&
+          option.propertyId === selection.propertyId,
+      )
+    : -1;
+
+  return (
+    <div className="space-y-4">
+      <label className="block">
+        <span className="mb-1.5 block text-sm font-medium text-base-content/80">
+          Property
+        </span>
+        <select
+          className="select select-bordered w-full max-w-md"
+          value={selectedIndex >= 0 ? String(selectedIndex) : ""}
+          onChange={(event) => {
+            const option = options[Number(event.target.value)];
+            if (option) onSelect(option);
+          }}
+        >
+          <option value="" disabled>
+            Select a property…
+          </option>
+          {healthyAccounts.map((account) => (
+            <optgroup
+              key={account.accountId}
+              label={account.email ?? "Google account"}
+            >
+              {account.properties.length === 0 ? (
+                <option disabled>No properties</option>
+              ) : (
+                account.properties.map((property) => {
+                  const index = options.findIndex(
+                    (option) =>
+                      option.accountId === account.accountId &&
+                      option.propertyId === property.propertyId,
+                  );
+                  return (
+                    <option key={property.propertyId} value={index}>
+                      {property.displayName} ({property.propertyId})
+                    </option>
+                  );
+                })
+              )}
+            </optgroup>
+          ))}
+        </select>
+      </label>
+      <div className="flex flex-wrap items-center gap-1">
+        <button
+          type="button"
+          className="btn btn-primary btn-sm"
+          onClick={onSave}
+          disabled={selectedIndex < 0 || saving}
+        >
+          {saving ? "Saving…" : "Save property"}
+        </button>
+        <button
+          type="button"
+          className="btn btn-ghost btn-sm"
+          onClick={() => void startGa4Link(window.location.href)}
+        >
+          Connect another Google account
+        </button>
+        {secondaryAction ? (
+          <button
+            type="button"
+            className={[
+              "btn btn-ghost btn-sm",
+              secondaryAction.destructive ? "text-error hover:bg-error/10" : "",
+            ].join(" ")}
+            onClick={secondaryAction.onClick}
+            disabled={secondaryAction.disabled}
+          >
+            {secondaryAction.label}
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/client/features/ga4/startGa4Link.ts
+++ b/src/client/features/ga4/startGa4Link.ts
@@ -1,0 +1,36 @@
+import { toast } from "sonner";
+import { getStandardErrorMessage } from "@/client/lib/error-messages";
+import { authClient } from "@/lib/auth-client";
+import { isHostedClientAuthMode } from "@/lib/auth-mode";
+import { startSelfHostedGa4Link } from "@/serverFunctions/ga4";
+import { GA4_OAUTH_PROVIDER_ID } from "@/shared/ga4";
+
+/**
+ * Kick off the incremental Google Analytics (GA4) OAuth grant. On success this
+ * redirects the whole page to Google's consent screen; `callbackURL` is where
+ * Google returns the user afterward. Independent of the Search Console grant —
+ * connecting one never requires re-consenting the other.
+ */
+export async function startGa4Link(callbackURL: string): Promise<void> {
+  try {
+    if (!isHostedClientAuthMode()) {
+      const res = await startSelfHostedGa4Link({ data: { callbackURL } });
+      window.location.href = res.url;
+      return;
+    }
+
+    const res = await authClient.oauth2.link({
+      providerId: GA4_OAUTH_PROVIDER_ID,
+      callbackURL,
+    });
+    if (res.error) {
+      toast.error(res.error.message ?? "Could not start Google sign-in");
+      return;
+    }
+    if (res.data?.url) {
+      window.location.href = res.data.url;
+    }
+  } catch (error) {
+    toast.error(getStandardErrorMessage(error));
+  }
+}

--- a/src/client/features/projects/ProjectSettings.tsx
+++ b/src/client/features/projects/ProjectSettings.tsx
@@ -4,6 +4,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ChevronLeft } from "lucide-react";
 import { toast } from "sonner";
 import { SearchConsoleConnectionCard } from "@/client/features/gsc/SearchConsoleConnectionCard";
+import { AnalyticsConnectionCard } from "@/client/features/ga4/AnalyticsConnectionCard";
 import { ProjectMarketFields } from "@/client/features/projects/ProjectMarketFields";
 import { getStandardErrorMessage } from "@/client/lib/error-messages";
 import {
@@ -59,6 +60,13 @@ export function ProjectSettings({ projectId }: { projectId: string }) {
           Search Console
         </h2>
         <SearchConsoleConnectionCard projectId={projectId} />
+      </section>
+
+      <section id="analytics" className="space-y-3 scroll-mt-6">
+        <h2 className="text-sm font-medium text-base-content/50">
+          Analytics
+        </h2>
+        <AnalyticsConnectionCard projectId={projectId} />
       </section>
 
       <DangerSection project={project} canArchive={projects.length > 1} />

--- a/src/db/d1/schema.ts
+++ b/src/db/d1/schema.ts
@@ -7,5 +7,6 @@ export * from "../sam.schema";
 export * from "../better-auth-schema";
 export * from "../billing.schema";
 export * from "../gsc.schema";
+export * from "../ga4.schema";
 export * from "../reddit-attribution.schema";
 export * from "../telemetry.schema";

--- a/src/db/ga4.schema.ts
+++ b/src/db/ga4.schema.ts
@@ -1,0 +1,42 @@
+import { sqliteTable, text, uniqueIndex, index } from "drizzle-orm/sqlite-core";
+import { sql } from "drizzle-orm";
+import { organization } from "./better-auth-schema";
+import { projects } from "./app.schema";
+
+// Connected Google Analytics (GA4) property per project.
+// OAuth tokens live in the better-auth `account` table under providerId
+// "google-analytics"; this row only records which property maps to a project
+// and whose grant to use when calling the Analytics APIs.
+export const ga4Connections = sqliteTable(
+  "ga4_connections",
+  {
+    id: text("id").primaryKey(),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    // Stored verbatim from accountSummaries.list — "properties/123456789".
+    // Never normalize; the Data API matches it byte-for-byte in the report path.
+    propertyId: text("property_id").notNull(),
+    // Human-readable label from accountSummaries.list, shown in the UI —
+    // GA4 properties have no URL-shaped identifier the way GSC sites do.
+    propertyDisplayName: text("property_display_name"),
+    // Whose google-analytics grant getAccessToken should use.
+    connectedByUserId: text("connected_by_user_id").notNull(),
+    ga4AccountId: text("ga4_account_id"),
+    connectedAccountEmail: text("connected_account_email"),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(current_timestamp)`),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(current_timestamp)`),
+  },
+  (table) => [
+    // One selected property per project in v1; switching replaces the row.
+    uniqueIndex("ga4_connections_project_idx").on(table.projectId),
+    index("ga4_connections_organization_idx").on(table.organizationId),
+  ],
+);

--- a/src/db/pg/ga4.schema.ts
+++ b/src/db/pg/ga4.schema.ts
@@ -1,0 +1,41 @@
+import { sql } from "drizzle-orm";
+import { index, pgTable, text, uniqueIndex } from "drizzle-orm/pg-core";
+import { organization } from "./better-auth-schema";
+import { projects } from "./app.schema";
+
+// See src/db/pg/app.schema.ts for why timestamps are ISO-8601 UTC text.
+const isoNow = sql`to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')`;
+
+// Connected Google Analytics (GA4) property per project.
+// OAuth tokens live in the better-auth `account` table under providerId
+// "google-analytics"; this row only records which property maps to a project
+// and whose grant to use when calling the Analytics APIs.
+export const ga4Connections = pgTable(
+  "ga4_connections",
+  {
+    id: text("id").primaryKey(),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    // Stored verbatim from accountSummaries.list — "properties/123456789".
+    // Never normalize; the Data API matches it byte-for-byte in the report path.
+    propertyId: text("property_id").notNull(),
+    // Human-readable label from accountSummaries.list, shown in the UI —
+    // GA4 properties have no URL-shaped identifier the way GSC sites do.
+    propertyDisplayName: text("property_display_name"),
+    // Whose google-analytics grant getAccessToken should use.
+    connectedByUserId: text("connected_by_user_id").notNull(),
+    ga4AccountId: text("ga4_account_id"),
+    connectedAccountEmail: text("connected_account_email"),
+    createdAt: text("created_at").notNull().default(isoNow),
+    updatedAt: text("updated_at").notNull().default(isoNow),
+  },
+  (table) => [
+    // One selected property per project in v1; switching replaces the row.
+    uniqueIndex("ga4_connections_project_idx").on(table.projectId),
+    index("ga4_connections_organization_idx").on(table.organizationId),
+  ],
+);

--- a/src/db/pg/schema.ts
+++ b/src/db/pg/schema.ts
@@ -4,5 +4,6 @@ export * from "./sam.schema";
 export * from "./better-auth-schema";
 export * from "./billing.schema";
 export * from "./gsc.schema";
+export * from "./ga4.schema";
 export * from "./reddit-attribution.schema";
 export * from "./telemetry.schema";

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -5,6 +5,7 @@ import * as sqliteSam from "./sam.schema";
 import * as sqliteAuth from "./better-auth-schema";
 import * as sqliteBilling from "./billing.schema";
 import * as sqliteGsc from "./gsc.schema";
+import * as sqliteGa4 from "./ga4.schema";
 import * as sqliteReddit from "./reddit-attribution.schema";
 import * as sqliteTelemetry from "./telemetry.schema";
 import * as pgApp from "./pg/app.schema";
@@ -13,6 +14,7 @@ import * as pgSam from "./pg/sam.schema";
 import * as pgAuth from "./pg/better-auth-schema";
 import * as pgBilling from "./pg/billing.schema";
 import * as pgGsc from "./pg/gsc.schema";
+import * as pgGa4 from "./pg/ga4.schema";
 import * as pgReddit from "./pg/reddit-attribution.schema";
 import * as pgTelemetry from "./pg/telemetry.schema";
 
@@ -32,6 +34,7 @@ type AppSchema = typeof sqliteApp &
   typeof sqliteAuth &
   typeof sqliteBilling &
   typeof sqliteGsc &
+  typeof sqliteGa4 &
   typeof sqliteReddit &
   typeof sqliteTelemetry;
 
@@ -44,6 +47,7 @@ const runtimeSchema =
         ...pgAuth,
         ...pgBilling,
         ...pgGsc,
+        ...pgGa4,
         ...pgReddit,
         ...pgTelemetry,
       }
@@ -54,6 +58,7 @@ const runtimeSchema =
         ...sqliteAuth,
         ...sqliteBilling,
         ...sqliteGsc,
+        ...sqliteGa4,
         ...sqliteReddit,
         ...sqliteTelemetry,
       };
@@ -91,6 +96,7 @@ export const {
   invitation,
   billingCustomerStatus,
   gscConnections,
+  ga4Connections,
   redditAttributions,
   telemetryState,
 } = schema;

--- a/src/lib/auth-config.ts
+++ b/src/lib/auth-config.ts
@@ -2,6 +2,7 @@ import { env } from "cloudflare:workers";
 import { genericOAuth, organization } from "better-auth/plugins";
 import { baseAuthOptions } from "@/lib/auth-options";
 import { GSC_OAUTH_PROVIDER_ID, GSC_OAUTH_SCOPES } from "@/shared/gsc";
+import { GA4_OAUTH_PROVIDER_ID, GA4_OAUTH_SCOPES } from "@/shared/ga4";
 
 export function createBaseAuthConfig() {
   return {
@@ -43,6 +44,20 @@ export function createBaseAuthConfig() {
             discoveryUrl:
               "https://accounts.google.com/.well-known/openid-configuration",
             scopes: [...GSC_OAUTH_SCOPES],
+            accessType: "offline", // request a refresh token
+            prompt: "select_account consent",
+            pkce: true,
+          },
+          {
+            // Independent connection from Search Console above: its own
+            // provider id, own scope, own grant — connecting one never
+            // touches the other's tokens or requires re-consenting it.
+            providerId: GA4_OAUTH_PROVIDER_ID,
+            clientId: env.GOOGLE_CLIENT_ID?.trim() ?? "",
+            clientSecret: env.GOOGLE_CLIENT_SECRET?.trim() ?? "",
+            discoveryUrl:
+              "https://accounts.google.com/.well-known/openid-configuration",
+            scopes: [...GA4_OAUTH_SCOPES],
             accessType: "offline", // request a refresh token
             prompt: "select_account consent",
             pkce: true,

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -37,6 +37,7 @@ import { Route as AppHelpDataforseoApiKeyRouteImport } from './routes/_app/help/
 import { Route as ProjectPProjectIdRouteRouteImport } from './routes/_project/p/$projectId/route'
 import { Route as ProjectPProjectIdIndexRouteImport } from './routes/_project/p/$projectId/index'
 import { Route as ApiGscOauthCallbackRouteImport } from './routes/api/gsc/oauth/callback'
+import { Route as ApiGa4OauthCallbackRouteImport } from './routes/api/ga4/oauth/callback'
 import { Route as ProjectPProjectIdSettingsRouteImport } from './routes/_project/p/$projectId/settings'
 import { Route as ProjectPProjectIdSearchPerformanceRouteImport } from './routes/_project/p/$projectId/search-performance'
 import { Route as ProjectPProjectIdSavedRouteImport } from './routes/_project/p/$projectId/saved'
@@ -193,6 +194,11 @@ const ApiGscOauthCallbackRoute = ApiGscOauthCallbackRouteImport.update({
   path: '/api/gsc/oauth/callback',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiGa4OauthCallbackRoute = ApiGa4OauthCallbackRouteImport.update({
+  id: '/api/ga4/oauth/callback',
+  path: '/api/ga4/oauth/callback',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ProjectPProjectIdSettingsRoute =
   ProjectPProjectIdSettingsRouteImport.update({
     id: '/settings',
@@ -314,6 +320,7 @@ export interface FileRoutesByFullPath {
   '/p/$projectId/saved': typeof ProjectPProjectIdSavedRoute
   '/p/$projectId/search-performance': typeof ProjectPProjectIdSearchPerformanceRoute
   '/p/$projectId/settings': typeof ProjectPProjectIdSettingsRoute
+  '/api/ga4/oauth/callback': typeof ApiGa4OauthCallbackRoute
   '/api/gsc/oauth/callback': typeof ApiGscOauthCallbackRoute
   '/p/$projectId/': typeof ProjectPProjectIdIndexRoute
   '/p/$projectId/rank-tracking/$configId': typeof ProjectPProjectIdRankTrackingConfigIdRoute
@@ -352,6 +359,7 @@ export interface FileRoutesByTo {
   '/p/$projectId/saved': typeof ProjectPProjectIdSavedRoute
   '/p/$projectId/search-performance': typeof ProjectPProjectIdSearchPerformanceRoute
   '/p/$projectId/settings': typeof ProjectPProjectIdSettingsRoute
+  '/api/ga4/oauth/callback': typeof ApiGa4OauthCallbackRoute
   '/api/gsc/oauth/callback': typeof ApiGscOauthCallbackRoute
   '/p/$projectId': typeof ProjectPProjectIdIndexRoute
   '/p/$projectId/rank-tracking/$configId': typeof ProjectPProjectIdRankTrackingConfigIdRoute
@@ -398,6 +406,7 @@ export interface FileRoutesById {
   '/_project/p/$projectId/saved': typeof ProjectPProjectIdSavedRoute
   '/_project/p/$projectId/search-performance': typeof ProjectPProjectIdSearchPerformanceRoute
   '/_project/p/$projectId/settings': typeof ProjectPProjectIdSettingsRoute
+  '/api/ga4/oauth/callback': typeof ApiGa4OauthCallbackRoute
   '/api/gsc/oauth/callback': typeof ApiGscOauthCallbackRoute
   '/_project/p/$projectId/': typeof ProjectPProjectIdIndexRoute
   '/_project/p/$projectId/rank-tracking/$configId': typeof ProjectPProjectIdRankTrackingConfigIdRoute
@@ -441,6 +450,7 @@ export interface FileRouteTypes {
     | '/p/$projectId/saved'
     | '/p/$projectId/search-performance'
     | '/p/$projectId/settings'
+    | '/api/ga4/oauth/callback'
     | '/api/gsc/oauth/callback'
     | '/p/$projectId/'
     | '/p/$projectId/rank-tracking/$configId'
@@ -479,6 +489,7 @@ export interface FileRouteTypes {
     | '/p/$projectId/saved'
     | '/p/$projectId/search-performance'
     | '/p/$projectId/settings'
+    | '/api/ga4/oauth/callback'
     | '/api/gsc/oauth/callback'
     | '/p/$projectId'
     | '/p/$projectId/rank-tracking/$configId'
@@ -524,6 +535,7 @@ export interface FileRouteTypes {
     | '/_project/p/$projectId/saved'
     | '/_project/p/$projectId/search-performance'
     | '/_project/p/$projectId/settings'
+    | '/api/ga4/oauth/callback'
     | '/api/gsc/oauth/callback'
     | '/_project/p/$projectId/'
     | '/_project/p/$projectId/rank-tracking/$configId'
@@ -544,6 +556,7 @@ export interface RootRouteChildren {
   ApiHealthRoute: typeof ApiHealthRoute
   ApiAuthSplatRoute: typeof ApiAuthSplatRoute
   ApiAutumnSplatRoute: typeof ApiAutumnSplatRoute
+  ApiGa4OauthCallbackRoute: typeof ApiGa4OauthCallbackRoute
   ApiGscOauthCallbackRoute: typeof ApiGscOauthCallbackRoute
 }
 
@@ -743,6 +756,13 @@ declare module '@tanstack/react-router' {
       path: '/api/gsc/oauth/callback'
       fullPath: '/api/gsc/oauth/callback'
       preLoaderRoute: typeof ApiGscOauthCallbackRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/ga4/oauth/callback': {
+      id: '/api/ga4/oauth/callback'
+      path: '/api/ga4/oauth/callback'
+      fullPath: '/api/ga4/oauth/callback'
+      preLoaderRoute: typeof ApiGa4OauthCallbackRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_project/p/$projectId/settings': {
@@ -1007,6 +1027,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiHealthRoute: ApiHealthRoute,
   ApiAuthSplatRoute: ApiAuthSplatRoute,
   ApiAutumnSplatRoute: ApiAutumnSplatRoute,
+  ApiGa4OauthCallbackRoute: ApiGa4OauthCallbackRoute,
   ApiGscOauthCallbackRoute: ApiGscOauthCallbackRoute,
 }
 export const routeTree = rootRouteImport

--- a/src/routes/api/ga4/oauth/callback.ts
+++ b/src/routes/api/ga4/oauth/callback.ts
@@ -1,0 +1,46 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { env } from "cloudflare:workers";
+import { getAuthMode, isHostedAuthMode } from "@/lib/auth-mode";
+import { resolveCloudflareAccessContext } from "@/middleware/ensure-user/cloudflareAccess";
+import { resolveLocalNoAuthContext } from "@/middleware/ensure-user/delegated";
+import { responseForAppError } from "@/server/lib/http-errors";
+import { handleSelfHostedGa4OAuthCallback } from "@/server/features/ga4/selfHostedOAuth";
+import { getPublicOrigin } from "@/server/mcp/public-origin";
+
+async function resolveSelfHostedContext(request: Request) {
+  const authMode = getAuthMode(env.AUTH_MODE);
+
+  if (isHostedAuthMode(authMode)) return null;
+
+  return authMode === "local_noauth"
+    ? resolveLocalNoAuthContext()
+    : resolveCloudflareAccessContext(request.headers);
+}
+
+async function handleCallbackRequest(request: Request) {
+  try {
+    const context = await resolveSelfHostedContext(request);
+    if (!context) return new Response("Not found", { status: 404 });
+
+    return await handleSelfHostedGa4OAuthCallback({
+      request,
+      user: {
+        userId: context.userId,
+        userEmail: context.userEmail,
+      },
+      publicOrigin: getPublicOrigin(request),
+    });
+  } catch (error) {
+    return responseForAppError(error, "Analytics OAuth failed");
+  }
+}
+
+export const Route = createFileRoute("/api/ga4/oauth/callback")({
+  server: {
+    handlers: {
+      GET: async ({ request }: { request: Request }) => {
+        return handleCallbackRequest(request);
+      },
+    },
+  },
+});

--- a/src/server/features/ga4/analyticsReport.test.ts
+++ b/src/server/features/ga4/analyticsReport.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildRunReportRequest,
+  resolveDateRange,
+} from "@/server/features/ga4/analyticsReport";
+
+const TODAY = new Date("2026-05-28T00:00:00Z");
+
+describe("resolveDateRange", () => {
+  it("ends convenience ranges 1 day back for GA4's processing lag", () => {
+    const { endDate } = resolveDateRange({ dateRange: "last_28_days" }, TODAY);
+    expect(endDate).toBe("2026-05-27");
+  });
+
+  it("computes a 28-day window from the lagged end", () => {
+    const { startDate, endDate } = resolveDateRange(
+      { dateRange: "last_28_days" },
+      TODAY,
+    );
+    expect(startDate).toBe("2026-04-29");
+    expect(endDate).toBe("2026-05-27");
+  });
+
+  it("does not clamp a far-in-the-past explicit start — unlike Search Console, GA4 has no fixed lookback ceiling", () => {
+    const { startDate, endDate } = resolveDateRange(
+      { startDate: "2020-01-01", endDate: "2026-05-01" },
+      TODAY,
+    );
+    expect(startDate).toBe("2020-01-01");
+    expect(endDate).toBe("2026-05-01");
+  });
+
+  it("passes explicit dates through untouched", () => {
+    const { startDate, endDate } = resolveDateRange(
+      { startDate: "2026-01-01", endDate: "2026-05-01" },
+      TODAY,
+    );
+    expect(startDate).toBe("2026-01-01");
+    expect(endDate).toBe("2026-05-01");
+  });
+});
+
+describe("buildRunReportRequest", () => {
+  it("defaults dimensions to ['date'] and wraps metrics/dateRanges", () => {
+    const request = buildRunReportRequest(
+      { projectId: "p1", metrics: ["sessions"] },
+      TODAY,
+    );
+    expect(request.dimensions).toEqual([{ name: "date" }]);
+    expect(request.metrics).toEqual([{ name: "sessions" }]);
+    expect(request.dateRanges).toEqual([
+      { startDate: "2026-04-29", endDate: "2026-05-27" },
+    ]);
+  });
+
+  it("maps requested dimensions and metrics in order", () => {
+    const request = buildRunReportRequest(
+      {
+        projectId: "p1",
+        dimensions: ["sessionDefaultChannelGroup", "pagePath"],
+        metrics: ["sessions", "totalUsers"],
+      },
+      TODAY,
+    );
+    expect(request.dimensions).toEqual([
+      { name: "sessionDefaultChannelGroup" },
+      { name: "pagePath" },
+    ]);
+    expect(request.metrics).toEqual([
+      { name: "sessions" },
+      { name: "totalUsers" },
+    ]);
+  });
+
+  it("clamps limit to the 1000 ceiling", () => {
+    expect(
+      buildRunReportRequest(
+        { projectId: "p1", metrics: ["sessions"], rowLimit: 99999 },
+        TODAY,
+      ).limit,
+    ).toBe(1000);
+    expect(
+      buildRunReportRequest(
+        { projectId: "p1", metrics: ["sessions"], rowLimit: 0 },
+        TODAY,
+      ).limit,
+    ).toBe(1);
+  });
+
+  it("only includes offset when startRow is positive", () => {
+    expect(
+      buildRunReportRequest({ projectId: "p1", metrics: ["sessions"] }, TODAY)
+        .offset,
+    ).toBeUndefined();
+    expect(
+      buildRunReportRequest(
+        { projectId: "p1", metrics: ["sessions"], startRow: 500 },
+        TODAY,
+      ).offset,
+    ).toBe(500);
+  });
+
+  it("omits dimensionFilter when no filters are given", () => {
+    const request = buildRunReportRequest(
+      { projectId: "p1", metrics: ["sessions"] },
+      TODAY,
+    );
+    expect(request.dimensionFilter).toBeUndefined();
+  });
+
+  it("builds a single string filter directly, without a group wrapper", () => {
+    const request = buildRunReportRequest(
+      {
+        projectId: "p1",
+        metrics: ["sessions"],
+        filters: [
+          {
+            dimension: "sessionDefaultChannelGroup",
+            operator: "equals",
+            expression: "Organic Search",
+          },
+        ],
+      },
+      TODAY,
+    );
+    expect(request.dimensionFilter).toEqual({
+      filter: {
+        fieldName: "sessionDefaultChannelGroup",
+        stringFilter: {
+          matchType: "EXACT",
+          value: "Organic Search",
+          caseSensitive: false,
+        },
+      },
+    });
+  });
+
+  it("wraps a negated operator in notExpression", () => {
+    const request = buildRunReportRequest(
+      {
+        projectId: "p1",
+        metrics: ["sessions"],
+        filters: [
+          {
+            dimension: "country",
+            operator: "notEquals",
+            expression: "Spain",
+          },
+        ],
+      },
+      TODAY,
+    );
+    expect(request.dimensionFilter).toEqual({
+      notExpression: {
+        filter: {
+          fieldName: "country",
+          stringFilter: {
+            matchType: "EXACT",
+            value: "Spain",
+            caseSensitive: false,
+          },
+        },
+      },
+    });
+  });
+
+  it("uses CONTAINS matchType for contains/notContains operators", () => {
+    const request = buildRunReportRequest(
+      {
+        projectId: "p1",
+        metrics: ["sessions"],
+        filters: [
+          { dimension: "pagePath", operator: "contains", expression: "/blog/" },
+        ],
+      },
+      TODAY,
+    );
+    expect(request.dimensionFilter).toEqual({
+      filter: {
+        fieldName: "pagePath",
+        stringFilter: {
+          matchType: "CONTAINS",
+          value: "/blog/",
+          caseSensitive: false,
+        },
+      },
+    });
+  });
+
+  it("AND-combines more than one filter into andGroup", () => {
+    const request = buildRunReportRequest(
+      {
+        projectId: "p1",
+        metrics: ["sessions"],
+        filters: [
+          {
+            dimension: "sessionDefaultChannelGroup",
+            operator: "equals",
+            expression: "Organic Search",
+          },
+          { dimension: "deviceCategory", operator: "equals", expression: "mobile" },
+        ],
+      },
+      TODAY,
+    );
+    expect(request.dimensionFilter).toEqual({
+      andGroup: {
+        expressions: [
+          {
+            filter: {
+              fieldName: "sessionDefaultChannelGroup",
+              stringFilter: {
+                matchType: "EXACT",
+                value: "Organic Search",
+                caseSensitive: false,
+              },
+            },
+          },
+          {
+            filter: {
+              fieldName: "deviceCategory",
+              stringFilter: {
+                matchType: "EXACT",
+                value: "mobile",
+                caseSensitive: false,
+              },
+            },
+          },
+        ],
+      },
+    });
+  });
+});

--- a/src/server/features/ga4/analyticsReport.ts
+++ b/src/server/features/ga4/analyticsReport.ts
@@ -1,0 +1,203 @@
+import type {
+  Ga4FilterExpression,
+  Ga4RunReportRequest,
+} from "@/server/lib/ga4Client";
+
+// Curated option sets — also drive the MCP tool Zod schemas so the two stay in
+// sync. GA4 exposes far more dimensions/metrics than this; these are the ones
+// that answer this project's actual reporting questions (channel mix, top
+// pages, growth over time) without overwhelming the tool surface.
+export const GA4_DIMENSIONS = [
+  "date",
+  "sessionDefaultChannelGroup",
+  "pagePath",
+  "landingPage",
+  "country",
+  "deviceCategory",
+  "sessionSource",
+  "sessionMedium",
+] as const;
+
+export const GA4_METRICS = [
+  "sessions",
+  "totalUsers",
+  "newUsers",
+  "activeUsers",
+  "screenPageViews",
+  "engagementRate",
+  "averageSessionDuration",
+  "eventCount",
+  "conversions",
+  "bounceRate",
+] as const;
+
+export const GA4_FILTER_OPERATORS = [
+  "equals",
+  "notEquals",
+  "contains",
+  "notContains",
+] as const;
+
+export const GA4_DATE_RANGES = [
+  "last_7_days",
+  "last_28_days",
+  "last_3_months",
+  "last_6_months",
+  "last_12_months",
+  "last_16_months",
+] as const;
+
+export const GA4_DEFAULT_ROW_LIMIT = 1000;
+// v1 caps rows-per-call at 1000, matching the Search Console tool's cap, to
+// protect the MCP context window. The Data API supports far more; the agent
+// paginates with `startRow` for more, same convention as GSC.
+export const GA4_MAX_ROW_LIMIT = 1000;
+// GA4's own processing lag: end the default window a day before "today" so
+// the last row isn't a partial, still-accumulating day.
+const GA4_DATA_LAG_DAYS = 1;
+
+export type Ga4Dimension = (typeof GA4_DIMENSIONS)[number];
+export type Ga4Metric = (typeof GA4_METRICS)[number];
+type Ga4FilterOperator = (typeof GA4_FILTER_OPERATORS)[number];
+export type Ga4DateRange = (typeof GA4_DATE_RANGES)[number];
+
+export type Ga4PerformanceFilter = {
+  dimension: Ga4Dimension;
+  operator: Ga4FilterOperator;
+  expression: string;
+};
+
+export type Ga4PerformanceInput = {
+  projectId: string;
+  dimensions?: Ga4Dimension[];
+  metrics: Ga4Metric[];
+  dateRange?: Ga4DateRange;
+  startDate?: string;
+  endDate?: string;
+  filters?: Ga4PerformanceFilter[];
+  rowLimit?: number;
+  startRow?: number;
+};
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function formatDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+// Subtract calendar months in UTC, clamping the day to the target month's
+// length — matches the Search Console tool's date math (naive setUTCMonth
+// rolls e.g. March 31 minus 1 month into March 3, not February 28).
+function subtractUtcMonths(date: Date, months: number): Date {
+  const day = date.getUTCDate();
+  const d = new Date(date);
+  d.setUTCDate(1);
+  d.setUTCMonth(d.getUTCMonth() - months);
+  const daysInTargetMonth = new Date(
+    Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + 1, 0),
+  ).getUTCDate();
+  d.setUTCDate(Math.min(day, daysInTargetMonth));
+  return d;
+}
+
+function subtractRange(end: Date, range: Ga4DateRange): Date {
+  const d = new Date(end);
+  switch (range) {
+    case "last_7_days":
+      d.setUTCDate(d.getUTCDate() - 7);
+      return d;
+    case "last_28_days":
+      d.setUTCDate(d.getUTCDate() - 28);
+      return d;
+    case "last_3_months":
+      return subtractUtcMonths(d, 3);
+    case "last_6_months":
+      return subtractUtcMonths(d, 6);
+    case "last_12_months":
+      return subtractUtcMonths(d, 12);
+    case "last_16_months":
+      return subtractUtcMonths(d, 16);
+  }
+}
+
+/** Resolve a convenience `dateRange` or explicit start/end into GA4 dates.
+ *  Unlike Search Console, GA4 has no fixed API-enforced lookback ceiling — how
+ *  far back real data exists depends on the property's own configured
+ *  data-retention setting, so there is no floor to clamp to here.
+ *  `today` is injectable for deterministic tests. */
+export function resolveDateRange(
+  input: Pick<Ga4PerformanceInput, "dateRange" | "startDate" | "endDate">,
+  today: Date = new Date(),
+): { startDate: string; endDate: string } {
+  if (input.startDate && input.endDate) {
+    return { startDate: input.startDate, endDate: input.endDate };
+  }
+
+  const end = new Date(today);
+  end.setUTCDate(end.getUTCDate() - GA4_DATA_LAG_DAYS);
+  const start = subtractRange(end, input.dateRange ?? "last_28_days");
+  return { startDate: formatDate(start), endDate: formatDate(end) };
+}
+
+function toFilterExpression(filter: Ga4PerformanceFilter): Ga4FilterExpression {
+  const matchType: "EXACT" | "CONTAINS" =
+    filter.operator === "contains" || filter.operator === "notContains"
+      ? "CONTAINS"
+      : "EXACT";
+  const stringFilter = {
+    filter: {
+      fieldName: filter.dimension,
+      stringFilter: {
+        matchType,
+        value: filter.expression,
+        caseSensitive: false,
+      },
+    },
+  };
+  if (filter.operator === "notEquals" || filter.operator === "notContains") {
+    return { notExpression: stringFilter };
+  }
+  return stringFilter;
+}
+
+/** Wrap flat `filters` into a GA4 `FilterExpression`. A single filter maps
+ *  directly to `filter`/`notExpression`; more than one is AND-combined —
+ *  matching how the Search Console tool always ANDs its flat filter list. */
+function buildDimensionFilter(
+  filters: Ga4PerformanceFilter[],
+): Ga4FilterExpression {
+  const expressions = filters.map(toFilterExpression);
+  return expressions.length === 1
+    ? expressions[0]
+    : { andGroup: { expressions } };
+}
+
+/** Build the GA4 `runReport` body from validated tool input. */
+export function buildRunReportRequest(
+  input: Ga4PerformanceInput,
+  today: Date = new Date(),
+): Ga4RunReportRequest {
+  const { startDate, endDate } = resolveDateRange(input, today);
+  const request: Ga4RunReportRequest = {
+    dateRanges: [{ startDate, endDate }],
+    dimensions:
+      input.dimensions && input.dimensions.length > 0
+        ? input.dimensions.map((name) => ({ name }))
+        : [{ name: "date" }],
+    metrics: input.metrics.map((name) => ({ name })),
+    limit: clamp(
+      input.rowLimit ?? GA4_DEFAULT_ROW_LIMIT,
+      1,
+      GA4_MAX_ROW_LIMIT,
+    ),
+  };
+  if (input.startRow && input.startRow > 0) {
+    request.offset = input.startRow;
+  }
+  if (input.filters && input.filters.length > 0) {
+    request.dimensionFilter = buildDimensionFilter(input.filters);
+  }
+  return request;
+}

--- a/src/server/features/ga4/oauth-config.ts
+++ b/src/server/features/ga4/oauth-config.ts
@@ -1,0 +1,32 @@
+import { getOptionalEnvValue } from "@/server/lib/runtime-env";
+import { MIN_BETTER_AUTH_SECRET_LENGTH } from "@/shared/selfhost-checks";
+
+type Ga4OAuthClientConfig = {
+  clientId: string;
+  clientSecret: string;
+};
+
+// Reuses the same Google OAuth client already configured for Search Console —
+// GOOGLE_CLIENT_ID/SECRET are generic, not GSC-specific. What differs is the
+// scope requested (see GA4_OAUTH_SCOPES) and the connection this grant feeds.
+export async function getGa4OAuthClientConfig(): Promise<Ga4OAuthClientConfig | null> {
+  const clientId = (await getOptionalEnvValue("GOOGLE_CLIENT_ID"))?.trim();
+  const clientSecret = (
+    await getOptionalEnvValue("GOOGLE_CLIENT_SECRET")
+  )?.trim();
+
+  if (!clientId || !clientSecret) return null;
+
+  return { clientId, clientSecret };
+}
+
+// Self-hosted Analytics needs the Google OAuth client AND BETTER_AUTH_SECRET
+// (>=32 chars): the secret keys OAuth-token encryption and lets us build the
+// Better Auth instance that mints/refreshes tokens. Both must be set before we
+// surface the connect flow.
+export async function hasSelfHostedGa4Config(): Promise<boolean> {
+  if (!(await getGa4OAuthClientConfig())) return false;
+
+  const secret = (await getOptionalEnvValue("BETTER_AUTH_SECRET"))?.trim();
+  return Boolean(secret && secret.length >= MIN_BETTER_AUTH_SECRET_LENGTH);
+}

--- a/src/server/features/ga4/repositories/Ga4ConnectionRepository.ts
+++ b/src/server/features/ga4/repositories/Ga4ConnectionRepository.ts
@@ -1,0 +1,77 @@
+import { and, eq, sql } from "drizzle-orm";
+import { db } from "@/db";
+import { ga4Connections } from "@/db/schema";
+
+export type Ga4Connection = typeof ga4Connections.$inferSelect;
+
+async function getByProjectId(
+  projectId: string,
+): Promise<Ga4Connection | null> {
+  const rows = await db
+    .select()
+    .from(ga4Connections)
+    .where(eq(ga4Connections.projectId, projectId))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+async function upsert(input: {
+  projectId: string;
+  organizationId: string;
+  propertyId: string;
+  propertyDisplayName: string | null;
+  connectedByUserId: string;
+  ga4AccountId: string;
+  connectedAccountEmail: string | null;
+}): Promise<Ga4Connection> {
+  const [row] = await db
+    .insert(ga4Connections)
+    .values({ id: crypto.randomUUID(), ...input })
+    .onConflictDoUpdate({
+      target: ga4Connections.projectId,
+      set: {
+        propertyId: input.propertyId,
+        propertyDisplayName: input.propertyDisplayName,
+        organizationId: input.organizationId,
+        connectedByUserId: input.connectedByUserId,
+        ga4AccountId: input.ga4AccountId,
+        connectedAccountEmail: sql`coalesce(${input.connectedAccountEmail}, ${ga4Connections.connectedAccountEmail})`,
+        updatedAt: sql`(current_timestamp)`,
+      },
+    })
+    .returning();
+  if (!row) {
+    throw new Error("Failed to upsert ga4_connection");
+  }
+  return row;
+}
+
+async function deleteByProjectId(projectId: string): Promise<void> {
+  await db
+    .delete(ga4Connections)
+    .where(eq(ga4Connections.projectId, projectId));
+}
+
+async function existsForConnectorAccount(
+  userId: string,
+  ga4AccountId: string,
+): Promise<boolean> {
+  const rows = await db
+    .select({ id: ga4Connections.id })
+    .from(ga4Connections)
+    .where(
+      and(
+        eq(ga4Connections.connectedByUserId, userId),
+        eq(ga4Connections.ga4AccountId, ga4AccountId),
+      ),
+    )
+    .limit(1);
+  return rows.length > 0;
+}
+
+export const Ga4ConnectionRepository = {
+  getByProjectId,
+  upsert,
+  deleteByProjectId,
+  existsForConnectorAccount,
+};

--- a/src/server/features/ga4/selfHostedOAuth.ts
+++ b/src/server/features/ga4/selfHostedOAuth.ts
@@ -1,0 +1,336 @@
+import { symmetricEncrypt } from "better-auth/crypto";
+import { and, eq } from "drizzle-orm";
+import { decodeJwt } from "jose";
+import { z } from "zod";
+import { db } from "@/db";
+import { account } from "@/db/schema";
+import { getAuth } from "@/lib/auth";
+import { AppError } from "@/server/lib/errors";
+import { GA4_OAUTH_PROVIDER_ID, GA4_OAUTH_SCOPES } from "@/shared/ga4";
+import {
+  getGa4OAuthClientConfig,
+  hasSelfHostedGa4Config,
+} from "./oauth-config";
+
+const GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
+const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+
+type SelfHostedGa4User = {
+  userId: string;
+  userEmail: string;
+};
+
+const oauthStateSchema = z.object({
+  userId: z.string().min(1),
+  callbackPath: z.string().min(1),
+  exp: z.number().int(),
+});
+
+const googleTokenResponseSchema = z.object({
+  access_token: z.string().min(1),
+  expires_in: z.number().optional(),
+  refresh_token: z.string().optional(),
+  scope: z.string().optional(),
+  id_token: z.string().optional(),
+  token_type: z.string().optional(),
+});
+
+const googleIdTokenSchema = z.object({
+  sub: z.string().min(1),
+});
+
+type GoogleTokenResponse = z.infer<typeof googleTokenResponseSchema>;
+
+function bytesToBase64Url(bytes: Uint8Array) {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary)
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replaceAll("=", "");
+}
+
+function base64UrlToBytes(value: string) {
+  const padded = `${value}${"=".repeat((4 - (value.length % 4)) % 4)}`;
+  const binary = atob(padded.replaceAll("-", "+").replaceAll("_", "/"));
+  return Uint8Array.from(binary, (char) => char.charCodeAt(0));
+}
+
+async function getStateKey(clientSecret: string) {
+  return crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(`openseo:ga4:${clientSecret}`),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign", "verify"],
+  );
+}
+
+async function signState(payload: string, clientSecret: string) {
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    await getStateKey(clientSecret),
+    new TextEncoder().encode(payload),
+  );
+  return bytesToBase64Url(new Uint8Array(signature));
+}
+
+function getSafeCallbackPath(callbackURL: string, publicOrigin: string) {
+  try {
+    const url = new URL(callbackURL, publicOrigin);
+    if (url.origin !== publicOrigin) return "/";
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    return "/";
+  }
+}
+
+async function createState(input: {
+  clientSecret: string;
+  userId: string;
+  callbackURL: string;
+  publicOrigin: string;
+}) {
+  const payload = bytesToBase64Url(
+    new TextEncoder().encode(
+      JSON.stringify({
+        userId: input.userId,
+        callbackPath: getSafeCallbackPath(
+          input.callbackURL,
+          input.publicOrigin,
+        ),
+        exp: Date.now() + 10 * 60 * 1_000,
+      }),
+    ),
+  );
+  const signature = await signState(payload, input.clientSecret);
+  return `${payload}.${signature}`;
+}
+
+async function verifyState(state: string, clientSecret: string) {
+  const [payload, signature] = state.split(".");
+  if (!payload || !signature) {
+    throw new AppError("VALIDATION_ERROR", "Invalid Analytics state");
+  }
+
+  const ok = await crypto.subtle.verify(
+    "HMAC",
+    await getStateKey(clientSecret),
+    base64UrlToBytes(signature),
+    new TextEncoder().encode(payload),
+  );
+  if (!ok) {
+    throw new AppError("VALIDATION_ERROR", "Invalid Analytics state");
+  }
+
+  const parsed = oauthStateSchema.parse(
+    JSON.parse(new TextDecoder().decode(base64UrlToBytes(payload))),
+  );
+  if (parsed.exp < Date.now()) {
+    throw new AppError("VALIDATION_ERROR", "Expired Analytics state");
+  }
+
+  return parsed;
+}
+
+function getRedirectUri(publicOrigin: string) {
+  return `${publicOrigin}/api/ga4/oauth/callback`;
+}
+
+function accessTokenExpiresAt(tokens: GoogleTokenResponse) {
+  return new Date(Date.now() + (tokens.expires_in ?? 3600) * 1_000);
+}
+
+function storedScope(tokens: GoogleTokenResponse) {
+  return tokens.scope
+    ? tokens.scope.trim().split(/\s+/).join(",")
+    : GA4_OAUTH_SCOPES.join(",");
+}
+
+function getGoogleAccountId(tokens: GoogleTokenResponse) {
+  if (!tokens.id_token) {
+    throw new AppError(
+      "VALIDATION_ERROR",
+      "Google did not return an ID token for Analytics.",
+    );
+  }
+
+  return googleIdTokenSchema.parse(decodeJwt(tokens.id_token)).sub;
+}
+
+async function upsertGrant(input: {
+  user: SelfHostedGa4User;
+  tokens: GoogleTokenResponse;
+}) {
+  // Encrypt tokens at rest exactly the way Better Auth's setTokenUtil does
+  // (same key from BETTER_AUTH_SECRET, same crypto, same encryptOAuthTokens
+  // gate), so getAccessToken decrypts them on read — and so flipping the flag
+  // can never desync the write and read paths.
+  const ctx = await getAuth().$context;
+  const encrypt = (value: string) =>
+    ctx.options.account?.encryptOAuthTokens
+      ? symmetricEncrypt({ key: ctx.secretConfig, data: value })
+      : value;
+  const googleAccountId = getGoogleAccountId(input.tokens);
+
+  const existing = await db
+    .select({ id: account.id, refreshToken: account.refreshToken })
+    .from(account)
+    .where(
+      and(
+        eq(account.userId, input.user.userId),
+        eq(account.providerId, GA4_OAUTH_PROVIDER_ID),
+        eq(account.accountId, googleAccountId),
+      ),
+    )
+    .limit(1);
+
+  const accountValues = {
+    accountId: googleAccountId,
+    providerId: GA4_OAUTH_PROVIDER_ID,
+    userId: input.user.userId,
+    accessToken: await encrypt(input.tokens.access_token),
+    // A fresh refresh token is encrypted here; an absent one falls back to the
+    // already-encrypted value stored on the existing grant.
+    refreshToken: input.tokens.refresh_token
+      ? await encrypt(input.tokens.refresh_token)
+      : (existing[0]?.refreshToken ?? null),
+    idToken: input.tokens.id_token
+      ? await encrypt(input.tokens.id_token)
+      : null,
+    accessTokenExpiresAt: accessTokenExpiresAt(input.tokens),
+    refreshTokenExpiresAt: null,
+    scope: storedScope(input.tokens),
+    password: null,
+  };
+
+  if (existing[0]) {
+    await db
+      .update(account)
+      .set({ ...accountValues, updatedAt: new Date() })
+      .where(eq(account.id, existing[0].id));
+    return;
+  }
+
+  await db.insert(account).values({
+    id: crypto.randomUUID(),
+    ...accountValues,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+}
+
+async function exchangeCode(input: {
+  code: string;
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+}) {
+  const response = await fetch(GOOGLE_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      code: input.code,
+      client_id: input.clientId,
+      client_secret: input.clientSecret,
+      redirect_uri: input.redirectUri,
+      grant_type: "authorization_code",
+    }),
+  });
+
+  if (!response.ok) {
+    throw new AppError(
+      "VALIDATION_ERROR",
+      "Google rejected the Analytics authorization code.",
+    );
+  }
+
+  return googleTokenResponseSchema.parse(await response.json());
+}
+
+export async function createSelfHostedGa4AuthorizationUrl(input: {
+  user: SelfHostedGa4User;
+  callbackURL: string;
+  publicOrigin: string;
+}) {
+  const config = await getGa4OAuthClientConfig();
+  if (!config || !(await hasSelfHostedGa4Config())) {
+    throw new AppError(
+      "AUTH_CONFIG_MISSING",
+      "Analytics is not configured. Set GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, and BETTER_AUTH_SECRET.",
+    );
+  }
+
+  const redirectUri = getRedirectUri(input.publicOrigin);
+  const state = await createState({
+    clientSecret: config.clientSecret,
+    userId: input.user.userId,
+    callbackURL: input.callbackURL,
+    publicOrigin: input.publicOrigin,
+  });
+  const url = new URL(GOOGLE_AUTH_URL);
+  url.searchParams.set("client_id", config.clientId);
+  url.searchParams.set("redirect_uri", redirectUri);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("scope", GA4_OAUTH_SCOPES.join(" "));
+  url.searchParams.set("access_type", "offline");
+  url.searchParams.set("prompt", "select_account consent");
+  url.searchParams.set("state", state);
+
+  return url.toString();
+}
+
+export async function handleSelfHostedGa4OAuthCallback(input: {
+  request: Request;
+  user: SelfHostedGa4User;
+  publicOrigin: string;
+}) {
+  const config = await getGa4OAuthClientConfig();
+  if (!config) {
+    return new Response("Missing Google Analytics OAuth configuration", {
+      status: 500,
+    });
+  }
+
+  const url = new URL(input.request.url);
+  const stateParam = url.searchParams.get("state");
+  if (!stateParam) {
+    return new Response("Missing Analytics OAuth state", { status: 400 });
+  }
+
+  const state = await verifyState(stateParam, config.clientSecret);
+  if (state.userId !== input.user.userId) {
+    return new Response("Analytics OAuth user mismatch", { status: 403 });
+  }
+
+  // state.callbackPath is a validated same-origin relative path
+  // (getSafeCallbackPath). Redirect with a *relative* Location so the browser
+  // resolves it against the real request origin — this avoids trusting
+  // x-forwarded-host for the final hop.
+  const redirectToCallback = () =>
+    new Response(null, {
+      status: 303,
+      headers: { Location: state.callbackPath },
+    });
+
+  if (url.searchParams.get("error")) {
+    return redirectToCallback();
+  }
+
+  const code = url.searchParams.get("code");
+  if (!code) {
+    return new Response("Missing Analytics OAuth code", { status: 400 });
+  }
+
+  const tokens = await exchangeCode({
+    code,
+    clientId: config.clientId,
+    clientSecret: config.clientSecret,
+    redirectUri: getRedirectUri(input.publicOrigin),
+  });
+  await upsertGrant({ user: input.user, tokens });
+
+  return redirectToCallback();
+}

--- a/src/server/features/ga4/services/Ga4Service.test.ts
+++ b/src/server/features/ga4/services/Ga4Service.test.ts
@@ -1,0 +1,580 @@
+/* eslint-disable max-lines */
+import type { SQL } from "drizzle-orm";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  class Ga4ApiError extends Error {
+    constructor(
+      public readonly status: number,
+      message: string,
+    ) {
+      super(message);
+      this.name = "Ga4ApiError";
+    }
+  }
+
+  class Ga4TokenError extends Error {
+    constructor(message = "token unavailable") {
+      super(message);
+      this.name = "Ga4TokenError";
+    }
+  }
+
+  const state: { selectRows: Array<{ id: string; accountId: string }> } = {
+    selectRows: [],
+  };
+  type Ga4ClientOptions = { userId: string; ga4AccountId?: string };
+  type Ga4AccountSummary = {
+    account: string;
+    displayName: string;
+    propertySummaries: Array<{
+      property: string;
+      displayName: string;
+      parent: string;
+    }>;
+  };
+  const listAccountSummaries =
+    vi.fn<(opts: Ga4ClientOptions) => Promise<Ga4AccountSummary[]>>();
+  const getUserInfoEmail =
+    vi.fn<(opts: Ga4ClientOptions) => Promise<string | null>>();
+  const runReport = vi.fn<(opts: Ga4ClientOptions) => Promise<unknown>>();
+  const deleteWhere = vi
+    .fn<(condition: SQL) => Promise<void>>()
+    .mockResolvedValue(undefined);
+  const dbSelect = vi.fn(() => ({
+    from: vi.fn(() => ({
+      where: vi.fn(() => {
+        const rows = state.selectRows;
+        return Object.assign(Promise.resolve(rows), {
+          limit: vi.fn().mockResolvedValue(rows),
+        });
+      }),
+    })),
+  }));
+
+  return {
+    state,
+    dbSelect,
+    deleteWhere,
+    dbDelete: vi.fn(() => ({ where: deleteWhere })),
+    listAccountSummaries,
+    getUserInfoEmail,
+    runReport,
+    createGa4Client: vi.fn((opts: Ga4ClientOptions) => ({
+      listAccountSummaries: () => listAccountSummaries(opts),
+      getUserInfoEmail: () => getUserInfoEmail(opts),
+      runReport: () => runReport(opts),
+    })),
+    upsert: vi.fn(),
+    getByProjectId: vi.fn(),
+    deleteByProjectId: vi.fn(),
+    existsForConnectorAccount: vi.fn(),
+    Ga4ApiError,
+    Ga4TokenError,
+  };
+});
+
+vi.mock("cloudflare:workers", () => ({ env: {} }));
+vi.mock("@/db", () => ({
+  db: { select: mocks.dbSelect, delete: mocks.dbDelete },
+}));
+vi.mock("@/server/lib/ga4Client", () => ({
+  createGa4Client: mocks.createGa4Client,
+  Ga4ApiError: mocks.Ga4ApiError,
+  Ga4TokenError: mocks.Ga4TokenError,
+}));
+vi.mock("@/server/features/ga4/repositories/Ga4ConnectionRepository", () => ({
+  Ga4ConnectionRepository: {
+    upsert: mocks.upsert,
+    getByProjectId: mocks.getByProjectId,
+    deleteByProjectId: mocks.deleteByProjectId,
+    existsForConnectorAccount: mocks.existsForConnectorAccount,
+  },
+}));
+
+const baseInput = {
+  projectId: "p1",
+  organizationId: "org1",
+  accountId: "sub-a",
+  userId: "u1",
+};
+
+function collectSqlParams(value: unknown): unknown[] {
+  if (!value || typeof value !== "object") return [];
+  if ("value" in value && "encoder" in value) {
+    return [value.value];
+  }
+  if (!("queryChunks" in value) || !Array.isArray(value.queryChunks)) return [];
+  return value.queryChunks.flatMap(collectSqlParams);
+}
+
+describe("Ga4Service.setProperty", () => {
+  beforeEach(() => {
+    mocks.state.selectRows = [{ id: "grant-a", accountId: "sub-a" }];
+    mocks.listAccountSummaries.mockReset();
+    mocks.getUserInfoEmail.mockReset();
+    mocks.createGa4Client.mockClear();
+    mocks.upsert.mockReset();
+  });
+
+  it("upserts the selected property with the selected grant and userinfo email", async () => {
+    mocks.listAccountSummaries.mockResolvedValue([
+      {
+        account: "accounts/1",
+        displayName: "My Org",
+        propertySummaries: [
+          {
+            property: "properties/123",
+            displayName: "example.com",
+            parent: "accounts/1",
+          },
+        ],
+      },
+    ]);
+    mocks.getUserInfoEmail.mockResolvedValue("client@example.com");
+    mocks.upsert.mockResolvedValue({ propertyId: "properties/123" });
+    const { Ga4Service } = await import("./Ga4Service");
+
+    await Ga4Service.setProperty({ ...baseInput, propertyId: "properties/123" });
+
+    expect(mocks.createGa4Client).toHaveBeenCalledWith({
+      userId: "u1",
+      ga4AccountId: "sub-a",
+    });
+    expect(mocks.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "p1",
+        propertyId: "properties/123",
+        propertyDisplayName: "example.com",
+        connectedByUserId: "u1",
+        ga4AccountId: "sub-a",
+        connectedAccountEmail: "client@example.com",
+      }),
+    );
+  });
+
+  it("re-saves with a null email when userinfo is unavailable", async () => {
+    mocks.listAccountSummaries.mockResolvedValue([
+      {
+        account: "accounts/1",
+        displayName: "My Org",
+        propertySummaries: [
+          {
+            property: "properties/123",
+            displayName: "example.com",
+            parent: "accounts/1",
+          },
+        ],
+      },
+    ]);
+    mocks.getUserInfoEmail.mockRejectedValue(new Error("userinfo unavailable"));
+    mocks.upsert.mockResolvedValue({
+      propertyId: "properties/123",
+      connectedAccountEmail: "previous@example.com",
+    });
+    const { Ga4Service } = await import("./Ga4Service");
+
+    const result = await Ga4Service.setProperty({
+      ...baseInput,
+      propertyId: "properties/123",
+    });
+
+    expect(mocks.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ connectedAccountEmail: null }),
+    );
+    expect(result).toMatchObject({
+      connectedAccountEmail: "previous@example.com",
+    });
+  });
+
+  it("rejects a Google sub that is not one of the caller's grants", async () => {
+    const { Ga4Service } = await import("./Ga4Service");
+
+    await expect(
+      Ga4Service.setProperty({
+        ...baseInput,
+        accountId: "foreign-sub",
+        propertyId: "properties/123",
+      }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    expect(mocks.createGa4Client).not.toHaveBeenCalled();
+    expect(mocks.upsert).not.toHaveBeenCalled();
+  });
+
+  it("rejects a property not on the selected grant with NOT_FOUND", async () => {
+    mocks.listAccountSummaries.mockResolvedValue([
+      {
+        account: "accounts/1",
+        displayName: "My Org",
+        propertySummaries: [
+          {
+            property: "properties/123",
+            displayName: "example.com",
+            parent: "accounts/1",
+          },
+        ],
+      },
+    ]);
+    const { Ga4Service } = await import("./Ga4Service");
+
+    await expect(
+      Ga4Service.setProperty({ ...baseInput, propertyId: "properties/999" }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    expect(mocks.upsert).not.toHaveBeenCalled();
+  });
+});
+
+describe("Ga4Service.listPropertiesForUserWithGrantStatus", () => {
+  beforeEach(() => {
+    mocks.state.selectRows = [
+      { id: "grant-a", accountId: "sub-a" },
+      { id: "grant-b", accountId: "sub-b" },
+    ];
+    mocks.listAccountSummaries.mockReset();
+    mocks.getUserInfoEmail.mockReset();
+    mocks.createGa4Client.mockClear();
+    mocks.dbDelete.mockClear();
+    mocks.getByProjectId.mockReset().mockResolvedValue(null);
+  });
+
+  it("lists grants independently and never deletes a dead grant", async () => {
+    mocks.getUserInfoEmail.mockImplementation(
+      async ({ ga4AccountId }: { ga4AccountId?: string }) =>
+        `${ga4AccountId}@example.com`,
+    );
+    mocks.listAccountSummaries.mockImplementation(
+      async ({ ga4AccountId }: { ga4AccountId?: string }) => {
+        if (ga4AccountId === "sub-b")
+          throw new mocks.Ga4TokenError();
+        return [
+          {
+            account: "accounts/1",
+            displayName: "My Org",
+            propertySummaries: [
+              {
+                property: "properties/123",
+                displayName: "example.com",
+                parent: "accounts/1",
+              },
+            ],
+          },
+        ];
+      },
+    );
+    const { Ga4Service } = await import("./Ga4Service");
+
+    await expect(
+      Ga4Service.listPropertiesForUserWithGrantStatus("u1", "p1"),
+    ).resolves.toEqual({
+      accounts: [
+        {
+          accountId: "sub-a",
+          email: "sub-a@example.com",
+          requiresReconnect: false,
+          properties: [
+            {
+              propertyId: "properties/123",
+              displayName: "example.com",
+              isSelected: false,
+            },
+          ],
+        },
+        {
+          accountId: "sub-b",
+          email: null,
+          requiresReconnect: true,
+          properties: [],
+        },
+      ],
+    });
+    expect(mocks.createGa4Client).toHaveBeenCalledTimes(2);
+    expect(mocks.getUserInfoEmail).not.toHaveBeenCalledWith(
+      expect.objectContaining({ ga4AccountId: "sub-b" }),
+    );
+    expect(mocks.dbDelete).not.toHaveBeenCalled();
+  });
+
+  it("marks the connected property as selected", async () => {
+    mocks.state.selectRows = [{ id: "grant-a", accountId: "sub-a" }];
+    mocks.getByProjectId.mockResolvedValue({ propertyId: "properties/123" });
+    mocks.getUserInfoEmail.mockResolvedValue("a@example.com");
+    mocks.listAccountSummaries.mockResolvedValue([
+      {
+        account: "accounts/1",
+        displayName: "My Org",
+        propertySummaries: [
+          {
+            property: "properties/123",
+            displayName: "example.com",
+            parent: "accounts/1",
+          },
+        ],
+      },
+    ]);
+    const { Ga4Service } = await import("./Ga4Service");
+
+    const result = await Ga4Service.listPropertiesForUserWithGrantStatus(
+      "u1",
+      "p1",
+    );
+
+    expect(result.accounts[0]?.properties[0]?.isSelected).toBe(true);
+  });
+
+  it("keeps userinfo failures non-fatal", async () => {
+    mocks.state.selectRows = [{ id: "grant-a", accountId: "sub-a" }];
+    mocks.getUserInfoEmail.mockRejectedValue(new Error("userinfo unavailable"));
+    mocks.listAccountSummaries.mockResolvedValue([
+      {
+        account: "accounts/1",
+        displayName: "My Org",
+        propertySummaries: [
+          {
+            property: "properties/123",
+            displayName: "example.com",
+            parent: "accounts/1",
+          },
+        ],
+      },
+    ]);
+    const { Ga4Service } = await import("./Ga4Service");
+
+    await expect(
+      Ga4Service.listPropertiesForUserWithGrantStatus("u1", "p1"),
+    ).resolves.toEqual({
+      accounts: [
+        {
+          accountId: "sub-a",
+          email: null,
+          requiresReconnect: false,
+          properties: [
+            {
+              propertyId: "properties/123",
+              displayName: "example.com",
+              isSelected: false,
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("marks a grant for reconnect on a GA4 403 without deleting it", async () => {
+    mocks.state.selectRows = [{ id: "grant-a", accountId: "sub-a" }];
+    mocks.getUserInfoEmail.mockResolvedValue("a@example.com");
+    mocks.listAccountSummaries.mockRejectedValue(
+      new mocks.Ga4ApiError(403, "Analytics denied access"),
+    );
+    const { Ga4Service } = await import("./Ga4Service");
+
+    await expect(
+      Ga4Service.listPropertiesForUserWithGrantStatus("u1", "p1"),
+    ).resolves.toEqual({
+      accounts: [
+        {
+          accountId: "sub-a",
+          email: null,
+          requiresReconnect: true,
+          properties: [],
+        },
+      ],
+    });
+    expect(mocks.getUserInfoEmail).not.toHaveBeenCalled();
+    expect(mocks.dbDelete).not.toHaveBeenCalled();
+  });
+
+  it("keeps non-auth GA4 API errors reportable", async () => {
+    mocks.getUserInfoEmail.mockImplementation(
+      async ({ ga4AccountId }: { ga4AccountId?: string }) =>
+        `${ga4AccountId}@example.com`,
+    );
+    const rateLimit = new mocks.Ga4ApiError(429, "slow down");
+    mocks.listAccountSummaries.mockImplementation(
+      async ({ ga4AccountId }: { ga4AccountId?: string }) => {
+        if (ga4AccountId === "sub-b") throw rateLimit;
+        return [
+          {
+            account: "accounts/1",
+            displayName: "My Org",
+            propertySummaries: [
+              {
+                property: "properties/123",
+                displayName: "example.com",
+                parent: "accounts/1",
+              },
+            ],
+          },
+        ];
+      },
+    );
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const { Ga4Service } = await import("./Ga4Service");
+
+    await expect(
+      Ga4Service.listPropertiesForUserWithGrantStatus("u1", "p1"),
+    ).resolves.toEqual({
+      accounts: [
+        {
+          accountId: "sub-a",
+          email: "sub-a@example.com",
+          requiresReconnect: false,
+          properties: [
+            {
+              propertyId: "properties/123",
+              displayName: "example.com",
+              isSelected: false,
+            },
+          ],
+        },
+        {
+          accountId: "sub-b",
+          email: null,
+          requiresReconnect: true,
+          properties: [],
+        },
+      ],
+    });
+    expect(consoleError).toHaveBeenCalledWith(
+      "Failed to list Analytics properties for account",
+      "sub-b",
+      rateLimit,
+    );
+    expect(mocks.dbDelete).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+});
+
+describe("Ga4Service.getPerformance", () => {
+  beforeEach(() => {
+    mocks.getByProjectId.mockReset();
+    mocks.runReport.mockReset().mockResolvedValue({ rows: [] });
+    mocks.createGa4Client.mockClear();
+  });
+
+  it("uses the grant stored on the project connection", async () => {
+    mocks.getByProjectId.mockResolvedValue({
+      connectedByUserId: "u1",
+      connectedAccountEmail: "a@example.com",
+      ga4AccountId: "sub-a",
+      propertyId: "properties/123",
+      propertyDisplayName: "example.com",
+    });
+    const { Ga4Service } = await import("./Ga4Service");
+
+    await Ga4Service.getPerformance({
+      projectId: "p1",
+      metrics: ["sessions"],
+      startDate: "2026-01-01",
+      endDate: "2026-01-31",
+    });
+
+    expect(mocks.createGa4Client).toHaveBeenCalledWith({
+      userId: "u1",
+      ga4AccountId: "sub-a",
+    });
+  });
+
+  it("passes undefined for the legacy null-account fallback", async () => {
+    mocks.getByProjectId.mockResolvedValue({
+      connectedByUserId: "u1",
+      connectedAccountEmail: null,
+      ga4AccountId: null,
+      propertyId: "properties/123",
+      propertyDisplayName: null,
+    });
+    const { Ga4Service } = await import("./Ga4Service");
+
+    await Ga4Service.getPerformance({
+      projectId: "p1",
+      metrics: ["sessions"],
+      startDate: "2026-01-01",
+      endDate: "2026-01-31",
+    });
+
+    expect(mocks.createGa4Client).toHaveBeenCalledWith({
+      userId: "u1",
+      ga4AccountId: undefined,
+    });
+  });
+});
+
+describe("Ga4Service.disconnect", () => {
+  beforeEach(() => {
+    mocks.getByProjectId.mockReset();
+    mocks.deleteByProjectId.mockReset().mockResolvedValue(undefined);
+    mocks.existsForConnectorAccount.mockReset();
+    mocks.dbDelete.mockClear();
+    mocks.deleteWhere.mockClear();
+  });
+
+  it("unlinks only the disconnected account when it is no longer used", async () => {
+    mocks.getByProjectId.mockResolvedValue({
+      connectedByUserId: "u1",
+      ga4AccountId: "sub-b",
+    });
+    mocks.existsForConnectorAccount.mockResolvedValue(false);
+    const { Ga4Service } = await import("./Ga4Service");
+
+    await Ga4Service.disconnect({ projectId: "p1", userId: "u1" });
+
+    expect(mocks.deleteByProjectId).toHaveBeenCalledWith("p1");
+    expect(mocks.existsForConnectorAccount).toHaveBeenCalledWith("u1", "sub-b");
+    expect(mocks.dbDelete).toHaveBeenCalledTimes(1);
+    const whereCondition = mocks.deleteWhere.mock.calls[0]?.[0];
+    expect(collectSqlParams(whereCondition)).toEqual(
+      expect.arrayContaining(["u1", "google-analytics", "sub-b"]),
+    );
+  });
+
+  it("keeps the grant when the same account powers another project", async () => {
+    mocks.getByProjectId.mockResolvedValue({
+      connectedByUserId: "u1",
+      ga4AccountId: "sub-b",
+    });
+    mocks.existsForConnectorAccount.mockResolvedValue(true);
+    const { Ga4Service } = await import("./Ga4Service");
+
+    await Ga4Service.disconnect({ projectId: "p1", userId: "u1" });
+
+    expect(mocks.dbDelete).not.toHaveBeenCalled();
+  });
+
+  it("never revokes a grant when another member disconnects", async () => {
+    mocks.getByProjectId.mockResolvedValue({
+      connectedByUserId: "owner",
+      ga4AccountId: "sub-b",
+    });
+    const { Ga4Service } = await import("./Ga4Service");
+
+    await Ga4Service.disconnect({ projectId: "p1", userId: "other-member" });
+
+    expect(mocks.existsForConnectorAccount).not.toHaveBeenCalled();
+    expect(mocks.dbDelete).not.toHaveBeenCalled();
+  });
+
+  it("deletes no grants for a legacy null-account connection", async () => {
+    mocks.getByProjectId.mockResolvedValue({
+      connectedByUserId: "u1",
+      ga4AccountId: null,
+    });
+    const { Ga4Service } = await import("./Ga4Service");
+
+    await Ga4Service.disconnect({ projectId: "p1", userId: "u1" });
+
+    expect(mocks.deleteByProjectId).toHaveBeenCalledWith("p1");
+    expect(mocks.existsForConnectorAccount).not.toHaveBeenCalled();
+    expect(mocks.dbDelete).not.toHaveBeenCalled();
+  });
+
+  it("deletes no grants when no property was bound", async () => {
+    mocks.getByProjectId.mockResolvedValue(null);
+    const { Ga4Service } = await import("./Ga4Service");
+
+    await Ga4Service.disconnect({ projectId: "p1", userId: "u1" });
+
+    expect(mocks.existsForConnectorAccount).not.toHaveBeenCalled();
+    expect(mocks.dbDelete).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/features/ga4/services/Ga4Service.test.ts
+++ b/src/server/features/ga4/services/Ga4Service.test.ts
@@ -321,6 +321,59 @@ describe("Ga4Service.listPropertiesForUserWithGrantStatus", () => {
     expect(result.accounts[0]?.properties[0]?.isSelected).toBe(true);
   });
 
+  it("merges properties from multiple GA4 accounts under one grant into a single entry", async () => {
+    mocks.state.selectRows = [{ id: "grant-a", accountId: "sub-a" }];
+    mocks.getUserInfoEmail.mockResolvedValue("a@example.com");
+    mocks.listAccountSummaries.mockResolvedValue([
+      {
+        account: "accounts/1",
+        displayName: "Personal",
+        propertySummaries: [
+          {
+            property: "properties/111",
+            displayName: "personal-site.com",
+            parent: "accounts/1",
+          },
+        ],
+      },
+      {
+        account: "accounts/2",
+        displayName: "Work",
+        propertySummaries: [
+          {
+            property: "properties/222",
+            displayName: "work-site.com",
+            parent: "accounts/2",
+          },
+        ],
+      },
+    ]);
+    const { Ga4Service } = await import("./Ga4Service");
+
+    const result = await Ga4Service.listPropertiesForUserWithGrantStatus(
+      "u1",
+      "p1",
+    );
+
+    // One entry per grant, not per GA4 account — otherwise both entries would
+    // share the same accountId (the grant's OAuth sub) and collide as
+    // duplicate React keys in the property picker.
+    expect(result.accounts).toHaveLength(1);
+    expect(result.accounts[0]?.accountId).toBe("sub-a");
+    expect(result.accounts[0]?.properties).toEqual([
+      {
+        propertyId: "properties/111",
+        displayName: "personal-site.com",
+        isSelected: false,
+      },
+      {
+        propertyId: "properties/222",
+        displayName: "work-site.com",
+        isSelected: false,
+      },
+    ]);
+  });
+
   it("keeps userinfo failures non-fatal", async () => {
     mocks.state.selectRows = [{ id: "grant-a", accountId: "sub-a" }];
     mocks.getUserInfoEmail.mockRejectedValue(new Error("userinfo unavailable"));

--- a/src/server/features/ga4/services/Ga4Service.ts
+++ b/src/server/features/ga4/services/Ga4Service.ts
@@ -98,18 +98,24 @@ export function isExpectedGrantFailure(error: unknown): boolean {
   );
 }
 
+// A single Google grant can see more than one GA4 Admin "account" (e.g. a
+// personal account and a work account under the same login) — each becomes
+// its own accountSummary. Flatten all of them into one property list per
+// grant rather than one entry per summary: the grant's OAuth sub is what
+// setProperty/createGa4Client actually key on, so per-summary entries would
+// share that same id and collide (duplicate React keys in the picker, with
+// later summaries' properties dropped).
 function flattenProperties(
   summaries: Ga4AccountSummary[],
   connection: Ga4Connection | null,
-): Array<{ accountId: string; properties: Ga4PropertyOption[] }> {
-  return summaries.map((summary) => ({
-    accountId: summary.account,
-    properties: (summary.propertySummaries ?? []).map((property) => ({
+): Ga4PropertyOption[] {
+  return summaries.flatMap((summary) =>
+    (summary.propertySummaries ?? []).map((property) => ({
       propertyId: property.property,
       displayName: property.displayName,
       isSelected: connection?.propertyId === property.property,
     })),
-  }));
+  );
 }
 
 async function listPropertiesForUserWithGrantStatus(
@@ -135,13 +141,12 @@ async function listPropertiesForUserWithGrantStatus(
         } catch {
           email = null;
         }
-        const byAccount = flattenProperties(summaries, connection);
-        return byAccount.map((entry) => ({
+        return {
           accountId: grant.accountId,
           email,
           requiresReconnect: false,
-          properties: entry.properties,
-        }));
+          properties: flattenProperties(summaries, connection),
+        };
       } catch (error) {
         if (!isExpectedGrantFailure(error)) {
           console.error(
@@ -150,18 +155,16 @@ async function listPropertiesForUserWithGrantStatus(
             error,
           );
         }
-        return [
-          {
-            accountId: grant.accountId,
-            email: null,
-            requiresReconnect: true,
-            properties: [],
-          },
-        ];
+        return {
+          accountId: grant.accountId,
+          email: null,
+          requiresReconnect: true,
+          properties: [],
+        };
       }
     }),
   );
-  return { accounts: accounts.flat() };
+  return { accounts };
 }
 
 /** Map a property to a project. Rejects properties not present on the

--- a/src/server/features/ga4/services/Ga4Service.ts
+++ b/src/server/features/ga4/services/Ga4Service.ts
@@ -1,0 +1,284 @@
+import { and, eq } from "drizzle-orm";
+import { db } from "@/db";
+import { account } from "@/db/schema";
+import { GA4_OAUTH_PROVIDER_ID } from "@/shared/ga4";
+import { AppError } from "@/server/lib/errors";
+import {
+  createGa4Client,
+  Ga4ApiError,
+  Ga4TokenError,
+  type Ga4AccountSummary,
+} from "@/server/lib/ga4Client";
+import {
+  buildRunReportRequest,
+  type Ga4PerformanceInput,
+} from "@/server/features/ga4/analyticsReport";
+import {
+  Ga4ConnectionRepository,
+  type Ga4Connection,
+} from "@/server/features/ga4/repositories/Ga4ConnectionRepository";
+import type {
+  Ga4RunReportRequest,
+  Ga4RunReportResponse,
+} from "@/server/lib/ga4Client";
+
+type Ga4PerformanceResult = {
+  propertyId: string;
+  propertyDisplayName: string | null;
+  connectedBy: string | null;
+  request: Ga4RunReportRequest;
+  report: Ga4RunReportResponse;
+};
+
+type Ga4PropertyOption = {
+  propertyId: string;
+  displayName: string;
+  isSelected: boolean;
+};
+
+type Ga4PropertyListResult = {
+  accounts: Array<{
+    accountId: string;
+    email: string | null;
+    requiresReconnect: boolean;
+    properties: Ga4PropertyOption[];
+  }>;
+};
+
+/** Thrown when a project has no connected GA4 property. */
+export class Ga4NotConnectedError extends Error {
+  constructor(public readonly projectId: string) {
+    super("Analytics is not connected for this project");
+    this.name = "Ga4NotConnectedError";
+  }
+}
+
+async function getConnection(
+  projectId: string,
+): Promise<Ga4Connection | null> {
+  return Ga4ConnectionRepository.getByProjectId(projectId);
+}
+
+/** Whether this user has linked a google-analytics grant (regardless of
+ *  whether they've picked a property yet). Drives the connect-vs-pick UI. */
+async function userHasGrant(userId: string): Promise<boolean> {
+  const rows = await db
+    .select({ id: account.id })
+    .from(account)
+    .where(
+      and(
+        eq(account.userId, userId),
+        eq(account.providerId, GA4_OAUTH_PROVIDER_ID),
+      ),
+    )
+    .limit(1);
+  return rows.length > 0;
+}
+
+async function listGrantsForUser(userId: string) {
+  return db
+    .select({ id: account.id, accountId: account.accountId })
+    .from(account)
+    .where(
+      and(
+        eq(account.userId, userId),
+        eq(account.providerId, GA4_OAUTH_PROVIDER_ID),
+      ),
+    );
+}
+
+/** Expected ways a stored grant fails to reach Analytics: no token could be
+ *  minted (refresh token revoked or expired), or Google rejected the call
+ *  (401/403). These surface a reconnect prompt without fault logging. */
+export function isExpectedGrantFailure(error: unknown): boolean {
+  if (error instanceof Ga4TokenError) return true;
+  return (
+    error instanceof Ga4ApiError &&
+    (error.status === 401 || error.status === 403)
+  );
+}
+
+function flattenProperties(
+  summaries: Ga4AccountSummary[],
+  connection: Ga4Connection | null,
+): Array<{ accountId: string; properties: Ga4PropertyOption[] }> {
+  return summaries.map((summary) => ({
+    accountId: summary.account,
+    properties: (summary.propertySummaries ?? []).map((property) => ({
+      propertyId: property.property,
+      displayName: property.displayName,
+      isSelected: connection?.propertyId === property.property,
+    })),
+  }));
+}
+
+async function listPropertiesForUserWithGrantStatus(
+  userId: string,
+  projectId: string,
+): Promise<Ga4PropertyListResult> {
+  const [grants, connection] = await Promise.all([
+    listGrantsForUser(userId),
+    Ga4ConnectionRepository.getByProjectId(projectId),
+  ]);
+  const accounts = await Promise.all(
+    grants.map(async (grant) => {
+      const client = createGa4Client({
+        userId,
+        ga4AccountId: grant.accountId,
+      });
+
+      try {
+        const summaries = await client.listAccountSummaries();
+        let email: string | null = null;
+        try {
+          email = await client.getUserInfoEmail();
+        } catch {
+          email = null;
+        }
+        const byAccount = flattenProperties(summaries, connection);
+        return byAccount.map((entry) => ({
+          accountId: grant.accountId,
+          email,
+          requiresReconnect: false,
+          properties: entry.properties,
+        }));
+      } catch (error) {
+        if (!isExpectedGrantFailure(error)) {
+          console.error(
+            "Failed to list Analytics properties for account",
+            grant.accountId,
+            error,
+          );
+        }
+        return [
+          {
+            accountId: grant.accountId,
+            email: null,
+            requiresReconnect: true,
+            properties: [],
+          },
+        ];
+      }
+    }),
+  );
+  return { accounts: accounts.flat() };
+}
+
+/** Map a property to a project. Rejects properties not present on the
+ *  connector's grant. */
+async function setProperty(input: {
+  projectId: string;
+  organizationId: string;
+  propertyId: string;
+  accountId: string;
+  userId: string;
+}): Promise<Ga4Connection> {
+  const grants = await listGrantsForUser(input.userId);
+  if (!grants.some((grant) => grant.accountId === input.accountId)) {
+    throw new AppError(
+      "NOT_FOUND",
+      "That Google account isn't connected to your OpenSEO account.",
+    );
+  }
+
+  const client = createGa4Client({
+    userId: input.userId,
+    ga4AccountId: input.accountId,
+  });
+  const summaries = await client.listAccountSummaries();
+  const match = summaries
+    .flatMap((summary) => summary.propertySummaries ?? [])
+    .find((property) => property.property === input.propertyId);
+  if (!match) {
+    throw new AppError(
+      "NOT_FOUND",
+      "That Analytics property isn't available on your connected Google account.",
+    );
+  }
+  let connectedAccountEmail: string | null = null;
+  try {
+    connectedAccountEmail = await client.getUserInfoEmail();
+  } catch {
+    connectedAccountEmail = null;
+  }
+  return Ga4ConnectionRepository.upsert({
+    projectId: input.projectId,
+    organizationId: input.organizationId,
+    propertyId: input.propertyId,
+    propertyDisplayName: match.displayName ?? null,
+    connectedByUserId: input.userId,
+    ga4AccountId: input.accountId,
+    connectedAccountEmail,
+  });
+}
+
+async function unlinkUserGrant(
+  userId: string,
+  ga4AccountId: string,
+): Promise<void> {
+  await db
+    .delete(account)
+    .where(
+      and(
+        eq(account.userId, userId),
+        eq(account.providerId, GA4_OAUTH_PROVIDER_ID),
+        eq(account.accountId, ga4AccountId),
+      ),
+    );
+}
+
+async function disconnect(input: {
+  projectId: string;
+  userId: string;
+}): Promise<void> {
+  const connection = await Ga4ConnectionRepository.getByProjectId(
+    input.projectId,
+  );
+  await Ga4ConnectionRepository.deleteByProjectId(input.projectId);
+  if (
+    connection?.ga4AccountId &&
+    connection.connectedByUserId === input.userId
+  ) {
+    const stillUsed = await Ga4ConnectionRepository.existsForConnectorAccount(
+      input.userId,
+      connection.ga4AccountId,
+    );
+    if (!stillUsed) {
+      await unlinkUserGrant(input.userId, connection.ga4AccountId);
+    }
+  }
+}
+
+/** Pass-through of GA4 `runReport` for a project's connected property. */
+async function getPerformance(
+  input: Ga4PerformanceInput,
+): Promise<Ga4PerformanceResult> {
+  const connection = await Ga4ConnectionRepository.getByProjectId(
+    input.projectId,
+  );
+  if (!connection) {
+    throw new Ga4NotConnectedError(input.projectId);
+  }
+  const request = buildRunReportRequest(input);
+  const client = createGa4Client({
+    userId: connection.connectedByUserId,
+    ga4AccountId: connection.ga4AccountId ?? undefined,
+  });
+  const report = await client.runReport(connection.propertyId, request);
+  return {
+    propertyId: connection.propertyId,
+    propertyDisplayName: connection.propertyDisplayName,
+    connectedBy: connection.connectedAccountEmail,
+    request,
+    report,
+  };
+}
+
+export const Ga4Service = {
+  getConnection,
+  userHasGrant,
+  listPropertiesForUserWithGrantStatus,
+  setProperty,
+  disconnect,
+  getPerformance,
+};

--- a/src/server/lib/ga4Client.test.ts
+++ b/src/server/lib/ga4Client.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getAccessToken: vi.fn(),
+  // ga4Client always calls fetch with a plain string URL (it stringifies any
+  // URL object itself before calling), so the mock is typed to match that
+  // real call shape rather than fetch's broader RequestInfo|URL signature.
+  fetch: vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  getAuth: () => ({ api: { getAccessToken: mocks.getAccessToken } }),
+}));
+
+function jsonResponse(body: unknown, status = 200) {
+  return Response.json(body, { status });
+}
+
+describe("ga4Client", () => {
+  beforeEach(() => {
+    mocks.getAccessToken.mockReset();
+    mocks.getAccessToken.mockResolvedValue({ accessToken: "tok_123" });
+    mocks.fetch.mockReset();
+    vi.stubGlobal("fetch", mocks.fetch);
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("lists account summaries with a bearer token", async () => {
+    mocks.fetch.mockResolvedValue(
+      jsonResponse({
+        accountSummaries: [
+          {
+            account: "accounts/1",
+            displayName: "My Org",
+            propertySummaries: [
+              { property: "properties/123", displayName: "example.com" },
+            ],
+          },
+        ],
+      }),
+    );
+    const { createGa4Client } = await import("./ga4Client");
+    const summaries = await createGa4Client({
+      userId: "u1",
+    }).listAccountSummaries();
+
+    expect(summaries).toHaveLength(1);
+    const [url, init] = mocks.fetch.mock.calls[0];
+    expect(url).toContain(
+      "https://analyticsadmin.googleapis.com/v1beta/accountSummaries",
+    );
+    expect(init?.headers).toMatchObject({ Authorization: "Bearer tok_123" });
+  });
+
+  it("follows pageToken until every account summary page is fetched", async () => {
+    mocks.fetch
+      .mockResolvedValueOnce(
+        jsonResponse({
+          accountSummaries: [{ account: "accounts/1", displayName: "A" }],
+          nextPageToken: "page2",
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          accountSummaries: [{ account: "accounts/2", displayName: "B" }],
+        }),
+      );
+    const { createGa4Client } = await import("./ga4Client");
+    const summaries = await createGa4Client({
+      userId: "u1",
+    }).listAccountSummaries();
+
+    expect(summaries).toHaveLength(2);
+    expect(mocks.fetch).toHaveBeenCalledTimes(2);
+    expect(mocks.fetch.mock.calls[1][0]).toContain(
+      "pageToken=page2",
+    );
+  });
+
+  it("targets the selected Better Auth grant by Google sub", async () => {
+    mocks.fetch.mockResolvedValue(jsonResponse({ accountSummaries: [] }));
+    const { createGa4Client } = await import("./ga4Client");
+
+    await createGa4Client({
+      userId: "u1",
+      ga4AccountId: "google-sub-a",
+    }).listAccountSummaries();
+
+    expect(mocks.getAccessToken).toHaveBeenCalledWith({
+      body: {
+        providerId: "google-analytics",
+        userId: "u1",
+        accountId: "google-sub-a",
+      },
+    });
+  });
+
+  it("omits accountId for the legacy null-account fallback", async () => {
+    mocks.fetch.mockResolvedValue(jsonResponse({ accountSummaries: [] }));
+    const { createGa4Client } = await import("./ga4Client");
+
+    await createGa4Client({ userId: "u1" }).listAccountSummaries();
+
+    expect(mocks.getAccessToken).toHaveBeenCalledWith({
+      body: { providerId: "google-analytics", userId: "u1" },
+    });
+  });
+
+  it("fetches the Google account email from userinfo", async () => {
+    mocks.fetch.mockResolvedValue(
+      jsonResponse({ email: "client@example.com" }),
+    );
+    const { createGa4Client } = await import("./ga4Client");
+
+    const email = await createGa4Client({
+      userId: "u1",
+      ga4AccountId: "google-sub-a",
+    }).getUserInfoEmail();
+
+    expect(email).toBe("client@example.com");
+    const [url, init] = mocks.fetch.mock.calls[0];
+    expect(url).toBe("https://openidconnect.googleapis.com/v1/userinfo");
+    expect(init?.headers).toMatchObject({ Authorization: "Bearer tok_123" });
+  });
+
+  it("posts runReport to the property's resource name verbatim", async () => {
+    mocks.fetch.mockImplementation(async () => jsonResponse({ rows: [] }));
+    const { createGa4Client } = await import("./ga4Client");
+    const client = createGa4Client({ userId: "u1" });
+
+    await client.runReport("properties/123456789", {
+      dateRanges: [{ startDate: "2026-01-01", endDate: "2026-01-28" }],
+      metrics: [{ name: "sessions" }],
+    });
+
+    const [url, init] = mocks.fetch.mock.calls[0];
+    expect(url).toBe(
+      "https://analyticsdata.googleapis.com/v1beta/properties/123456789:runReport",
+    );
+    expect(init?.method).toBe("POST");
+    const body = init?.body;
+    const payload =
+      typeof body === "string" ? (JSON.parse(body) as unknown) : null;
+    expect(payload).toEqual({
+      dateRanges: [{ startDate: "2026-01-01", endDate: "2026-01-28" }],
+      metrics: [{ name: "sessions" }],
+    });
+  });
+
+  it("maps 403 to a no-access Ga4ApiError", async () => {
+    mocks.fetch.mockImplementation(async () =>
+      jsonResponse({ error: "forbidden" }, 403),
+    );
+    const { createGa4Client, Ga4ApiError } = await import("./ga4Client");
+    await expect(
+      createGa4Client({ userId: "u1" }).listAccountSummaries(),
+    ).rejects.toMatchObject({ status: 403 });
+    await expect(
+      createGa4Client({ userId: "u1" }).listAccountSummaries(),
+    ).rejects.toBeInstanceOf(Ga4ApiError);
+  });
+
+  it("maps 429 to a rate-limit Ga4ApiError", async () => {
+    mocks.fetch.mockResolvedValue(jsonResponse({ error: "slow down" }, 429));
+    const { createGa4Client } = await import("./ga4Client");
+    await expect(
+      createGa4Client({ userId: "u1" }).listAccountSummaries(),
+    ).rejects.toMatchObject({ status: 429 });
+  });
+
+  it("throws Ga4TokenError when no access token can be minted", async () => {
+    mocks.getAccessToken.mockRejectedValue(new Error("revoked"));
+    const { createGa4Client, Ga4TokenError } = await import("./ga4Client");
+    await expect(
+      createGa4Client({ userId: "u1" }).listAccountSummaries(),
+    ).rejects.toBeInstanceOf(Ga4TokenError);
+  });
+});

--- a/src/server/lib/ga4Client.ts
+++ b/src/server/lib/ga4Client.ts
@@ -1,0 +1,202 @@
+import { getAuth } from "@/lib/auth";
+import { GA4_OAUTH_PROVIDER_ID } from "@/shared/ga4";
+
+const GA4_ADMIN_API_BASE = "https://analyticsadmin.googleapis.com/v1beta";
+const GA4_DATA_API_BASE = "https://analyticsdata.googleapis.com/v1beta";
+const GOOGLE_USERINFO_URL = "https://openidconnect.googleapis.com/v1/userinfo";
+
+/** A GA4 REST call returned a non-2xx status. `status` drives user-facing messaging. */
+export class Ga4ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+    public readonly body?: string,
+  ) {
+    super(message);
+    this.name = "Ga4ApiError";
+  }
+}
+
+/** No fresh access token could be minted — the user revoked the grant, or the
+ *  refresh token expired (e.g. weekly in Google's OAuth "Testing" mode). */
+export class Ga4TokenError extends Error {
+  constructor(
+    message: string,
+    public readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = "Ga4TokenError";
+  }
+}
+
+export type Ga4Property = {
+  /** Resource name, e.g. "properties/123456789". Stored and matched verbatim. */
+  property: string;
+  displayName: string;
+  parent: string;
+};
+
+export type Ga4AccountSummary = {
+  account: string;
+  displayName: string;
+  propertySummaries: Ga4Property[];
+};
+
+export type Ga4DimensionFilter = {
+  dimension: string;
+  operator: string;
+  expression: string;
+};
+
+/** Minimal shape of GA4's recursive `FilterExpression` — only what this
+ *  project's tool actually constructs (single string-match filters, negated,
+ *  or AND-combined). The real API type is broader (orGroup, numeric/in-list
+ *  filters); extend here if a future dimension needs them. */
+export type Ga4FilterExpression =
+  | {
+      filter: {
+        fieldName: string;
+        stringFilter: {
+          matchType: "EXACT" | "CONTAINS";
+          value: string;
+          caseSensitive: boolean;
+        };
+      };
+    }
+  | { notExpression: Ga4FilterExpression }
+  | { andGroup: { expressions: Ga4FilterExpression[] } };
+
+export type Ga4RunReportRequest = {
+  dateRanges: Array<{ startDate: string; endDate: string }>;
+  dimensions?: Array<{ name: string }>;
+  metrics: Array<{ name: string }>;
+  dimensionFilter?: Ga4FilterExpression;
+  limit?: number;
+  offset?: number;
+};
+
+export type Ga4RunReportRow = {
+  dimensionValues?: Array<{ value: string }>;
+  metricValues?: Array<{ value: string }>;
+};
+
+export type Ga4RunReportResponse = {
+  dimensionHeaders?: Array<{ name: string }>;
+  metricHeaders?: Array<{ name: string; type?: string }>;
+  rows?: Ga4RunReportRow[];
+  rowCount?: number;
+};
+
+function messageForStatus(status: number, body: string): string {
+  if (status === 401 || status === 403) {
+    return "Analytics denied access to this property (no verified permission, or the connection was revoked).";
+  }
+  if (status === 429) {
+    return "Analytics rate limit reached. Retry shortly.";
+  }
+  if (status === 404) {
+    return "Analytics property not found. It may have been removed in Google Analytics.";
+  }
+  return `Analytics API error (${status}): ${body.slice(0, 300)}`;
+}
+
+/** Free Google Analytics (GA4) client. Unlike the DataForSEO client it does NOT
+ *  meter credits — GA4 is first-party data with no per-call cost. Access tokens
+ *  are minted (and auto-refreshed) by Better Auth from the connector's stored
+ *  google-analytics grant. */
+export function createGa4Client(opts: {
+  userId: string;
+  ga4AccountId?: string;
+}) {
+  async function getToken(): Promise<string> {
+    let result: { accessToken?: string } | undefined;
+    try {
+      // Headerless call: getAccessToken trusts body.userId when no request
+      // session is present, and auto-refreshes via the genericOAuth provider.
+      // Works in every auth mode — self-hosted builds the same Better Auth
+      // instance once BETTER_AUTH_SECRET is set.
+      result = await getAuth().api.getAccessToken({
+        body: {
+          providerId: GA4_OAUTH_PROVIDER_ID,
+          userId: opts.userId,
+          ...(opts.ga4AccountId ? { accountId: opts.ga4AccountId } : {}),
+        },
+      });
+    } catch (error) {
+      throw new Ga4TokenError(
+        "Could not mint an Analytics access token (grant revoked or expired).",
+        error,
+      );
+    }
+    if (!result?.accessToken) {
+      throw new Ga4TokenError(
+        "Analytics returned no access token (grant revoked or expired).",
+      );
+    }
+    return result.accessToken;
+  }
+
+  async function request<T>(
+    url: string,
+    init?: { method?: string; body?: unknown },
+  ): Promise<T> {
+    const token = await getToken();
+    const hasBody = init?.body !== undefined;
+    const response = await fetch(url, {
+      method: init?.method ?? "GET",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        ...(hasBody ? { "Content-Type": "application/json" } : {}),
+      },
+      body: hasBody ? JSON.stringify(init?.body) : undefined,
+    });
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      throw new Ga4ApiError(
+        response.status,
+        messageForStatus(response.status, body),
+        body,
+      );
+    }
+    return (await response.json()) as T;
+  }
+
+  return {
+    async getUserInfoEmail(): Promise<string | null> {
+      const data = await request<{ email?: unknown }>(GOOGLE_USERINFO_URL);
+      return typeof data.email === "string" ? data.email : null;
+    },
+
+    /** Admin API `accountSummaries.list` — every account/property the grant can
+     *  see. Paginated by Google; followed to completion so a multi-page
+     *  account never silently truncates the property picker. */
+    async listAccountSummaries(): Promise<Ga4AccountSummary[]> {
+      const summaries: Ga4AccountSummary[] = [];
+      let pageToken: string | undefined;
+      do {
+        const url = new URL(`${GA4_ADMIN_API_BASE}/accountSummaries`);
+        url.searchParams.set("pageSize", "200");
+        if (pageToken) url.searchParams.set("pageToken", pageToken);
+        const data = await request<{
+          accountSummaries?: Ga4AccountSummary[];
+          nextPageToken?: string;
+        }>(url.toString());
+        summaries.push(...(data.accountSummaries ?? []));
+        pageToken = data.nextPageToken;
+      } while (pageToken);
+      return summaries;
+    },
+
+    /** Data API `properties.runReport`. propertyId is used verbatim — it's the
+     *  full resource name, e.g. "properties/123456789". */
+    async runReport(
+      propertyId: string,
+      body: Ga4RunReportRequest,
+    ): Promise<Ga4RunReportResponse> {
+      return request<Ga4RunReportResponse>(
+        `${GA4_DATA_API_BASE}/${propertyId}:runReport`,
+        { method: "POST", body },
+      );
+    },
+  };
+}

--- a/src/server/mcp/server.ts
+++ b/src/server/mcp/server.ts
@@ -23,6 +23,7 @@ import {
   getSearchConsolePerformanceTool,
   inspectUrlsTool,
 } from "@/server/mcp/tools/search-console-tools";
+import { getAnalyticsPerformanceTool } from "@/server/mcp/tools/analytics-tools";
 import {
   getAuditIssuesTool,
   getAuditPagesTool,
@@ -215,6 +216,15 @@ export function registerOpenSeoMcpTools(server: McpServer) {
       inspectUrlsTool.name,
       inspectUrlsTool.config.outputSchema,
       inspectUrlsTool.handler,
+    ),
+  );
+  server.registerTool(
+    getAnalyticsPerformanceTool.name,
+    getAnalyticsPerformanceTool.config,
+    instrumentMcpToolHandler(
+      getAnalyticsPerformanceTool.name,
+      getAnalyticsPerformanceTool.config.outputSchema,
+      getAnalyticsPerformanceTool.handler,
     ),
   );
   server.registerTool(

--- a/src/server/mcp/tools/analytics-tools.test.ts
+++ b/src/server/mcp/tools/analytics-tools.test.ts
@@ -140,6 +140,112 @@ describe("analytics MCP tools", () => {
     expect(text?.type === "text" && text.text).toContain("Organic Search");
   });
 
+  it("reports hasMore:false on an exact-multiple-of-limit last page, using rowCount", async () => {
+    mocks.Ga4Service.getPerformance.mockResolvedValue({
+      propertyId: "properties/123",
+      propertyDisplayName: null,
+      connectedBy: "alice@example.com",
+      request: {
+        dateRanges: [{ startDate: "2026-04-29", endDate: "2026-05-27" }],
+        dimensions: [{ name: "date" }],
+        metrics: [{ name: "sessions" }],
+        limit: 2,
+        offset: 0,
+      },
+      report: {
+        rowCount: 2,
+        rows: [
+          { dimensionValues: [{ value: "2026-05-26" }], metricValues: [{ value: "10" }] },
+          { dimensionValues: [{ value: "2026-05-27" }], metricValues: [{ value: "12" }] },
+        ],
+      },
+    });
+    const { getAnalyticsPerformanceTool } = await import(
+      "./analytics-tools"
+    );
+
+    const result = await getAnalyticsPerformanceTool.handler(
+      { projectId: "project_1", metrics: ["sessions"], rowLimit: 2 },
+      toolExtra,
+    );
+
+    // Naive length->=limit heuristic would say hasMore:true here (2 >= 2);
+    // rowCount says the 2 rows returned are the whole result set.
+    expect(result.structuredContent).toMatchObject({
+      hasMore: false,
+      nextStartRow: undefined,
+    });
+  });
+
+  it("reports hasMore:true when rowCount says more rows remain", async () => {
+    mocks.Ga4Service.getPerformance.mockResolvedValue({
+      propertyId: "properties/123",
+      propertyDisplayName: null,
+      connectedBy: "alice@example.com",
+      request: {
+        dateRanges: [{ startDate: "2026-04-29", endDate: "2026-05-27" }],
+        dimensions: [{ name: "date" }],
+        metrics: [{ name: "sessions" }],
+        limit: 2,
+        offset: 0,
+      },
+      report: {
+        rowCount: 5,
+        rows: [
+          { dimensionValues: [{ value: "2026-05-26" }], metricValues: [{ value: "10" }] },
+          { dimensionValues: [{ value: "2026-05-27" }], metricValues: [{ value: "12" }] },
+        ],
+      },
+    });
+    const { getAnalyticsPerformanceTool } = await import(
+      "./analytics-tools"
+    );
+
+    const result = await getAnalyticsPerformanceTool.handler(
+      { projectId: "project_1", metrics: ["sessions"], rowLimit: 2 },
+      toolExtra,
+    );
+
+    expect(result.structuredContent).toMatchObject({
+      hasMore: true,
+      nextStartRow: 2,
+    });
+  });
+
+  it("falls back to the length-vs-limit heuristic when rowCount is absent", async () => {
+    mocks.Ga4Service.getPerformance.mockResolvedValue({
+      propertyId: "properties/123",
+      propertyDisplayName: null,
+      connectedBy: "alice@example.com",
+      request: {
+        dateRanges: [{ startDate: "2026-04-29", endDate: "2026-05-27" }],
+        dimensions: [{ name: "date" }],
+        metrics: [{ name: "sessions" }],
+        limit: 2,
+        offset: 0,
+      },
+      report: {
+        rows: [
+          { dimensionValues: [{ value: "2026-05-26" }], metricValues: [{ value: "10" }] },
+          { dimensionValues: [{ value: "2026-05-27" }], metricValues: [{ value: "12" }] },
+        ],
+      },
+    });
+    const { getAnalyticsPerformanceTool } = await import(
+      "./analytics-tools"
+    );
+
+    const result = await getAnalyticsPerformanceTool.handler(
+      { projectId: "project_1", metrics: ["sessions"], rowLimit: 2 },
+      toolExtra,
+    );
+
+    expect(result.structuredContent).toMatchObject({
+      hasMore: true,
+      nextStartRow: 2,
+    });
+  });
+
   it("surfaces a not-connected message with a connect URL", async () => {
     mocks.Ga4Service.getPerformance.mockRejectedValue(
       new Ga4NotConnectedError("project_1"),

--- a/src/server/mcp/tools/analytics-tools.test.ts
+++ b/src/server/mcp/tools/analytics-tools.test.ts
@@ -1,0 +1,257 @@
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ToolExtra } from "@/server/mcp/context";
+import { MCP_AUTH_CONTEXT_PROP } from "@/server/mcp/context";
+
+const mocks = vi.hoisted(() => ({
+  getProjectForOrganization: vi.fn(),
+  isHostedServerAuthMode: vi.fn(),
+  hasSelfHostedGa4Config: vi.fn(),
+  Ga4Service: {
+    getPerformance: vi.fn(),
+  },
+}));
+
+class Ga4NotConnectedError extends Error {
+  constructor(public readonly projectId: string) {
+    super("not connected");
+    this.name = "Ga4NotConnectedError";
+  }
+}
+class Ga4ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "Ga4ApiError";
+  }
+}
+class Ga4TokenError extends Error {}
+
+vi.mock("cloudflare:workers", () => ({ env: {} }));
+vi.mock("@/server/lib/runtime-env", () => ({
+  isHostedServerAuthMode: mocks.isHostedServerAuthMode,
+}));
+vi.mock("@/server/features/ga4/oauth-config", () => ({
+  hasSelfHostedGa4Config: mocks.hasSelfHostedGa4Config,
+}));
+vi.mock("@/server/features/projects/services/ProjectService", () => ({
+  ProjectService: {
+    getProjectForOrganization: mocks.getProjectForOrganization,
+  },
+}));
+vi.mock("@/server/features/ga4/services/Ga4Service", () => ({
+  Ga4Service: mocks.Ga4Service,
+  Ga4NotConnectedError,
+}));
+vi.mock("@/server/lib/ga4Client", () => ({ Ga4ApiError, Ga4TokenError }));
+
+const authContext = {
+  userId: "user_123",
+  userEmail: "alice@example.com",
+  organizationId: "org_123",
+  clientId: "client_123",
+  scopes: ["mcp"],
+  audience: "https://open-seo.test/mcp",
+  subject: "user_123",
+  baseUrl: "https://open-seo.test",
+};
+
+const toolExtra: ToolExtra = {
+  signal: new AbortController().signal,
+  requestId: 1,
+  sendNotification: vi.fn(),
+  sendRequest: vi.fn(),
+  authInfo: {
+    token: "token",
+    clientId: "client_123",
+    scopes: ["mcp"],
+    resource: new URL("https://open-seo.test/mcp"),
+    extra: { [MCP_AUTH_CONTEXT_PROP]: authContext },
+  } satisfies AuthInfo,
+};
+
+describe("analytics MCP tools", () => {
+  beforeEach(() => {
+    mocks.getProjectForOrganization.mockReset();
+    mocks.getProjectForOrganization.mockResolvedValue({
+      id: "project_1",
+      locationCode: 2840,
+      languageCode: "en",
+    });
+    mocks.isHostedServerAuthMode.mockReset();
+    mocks.isHostedServerAuthMode.mockResolvedValue(true);
+    mocks.hasSelfHostedGa4Config.mockReset();
+    mocks.hasSelfHostedGa4Config.mockResolvedValue(false);
+    mocks.Ga4Service.getPerformance.mockReset();
+  });
+
+  it("returns flattened rows on success", async () => {
+    mocks.Ga4Service.getPerformance.mockResolvedValue({
+      propertyId: "properties/123",
+      propertyDisplayName: "example.com",
+      connectedBy: "alice@example.com",
+      request: {
+        dateRanges: [{ startDate: "2026-04-29", endDate: "2026-05-27" }],
+        dimensions: [{ name: "sessionDefaultChannelGroup" }],
+        metrics: [{ name: "sessions" }],
+        limit: 1000,
+      },
+      report: {
+        rows: [
+          {
+            dimensionValues: [{ value: "Organic Search" }],
+            metricValues: [{ value: "42" }],
+          },
+        ],
+      },
+    });
+    const { getAnalyticsPerformanceTool } = await import(
+      "./analytics-tools"
+    );
+
+    const result = await getAnalyticsPerformanceTool.handler(
+      {
+        projectId: "project_1",
+        dimensions: ["sessionDefaultChannelGroup"],
+        metrics: ["sessions"],
+      },
+      toolExtra,
+    );
+
+    expect(mocks.Ga4Service.getPerformance).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "project_1",
+        dimensions: ["sessionDefaultChannelGroup"],
+        metrics: ["sessions"],
+      }),
+    );
+    expect(result.structuredContent).toMatchObject({
+      ok: true,
+      propertyId: "properties/123",
+      rowCount: 1,
+      rows: [{ sessionDefaultChannelGroup: "Organic Search", sessions: "42" }],
+    });
+    const text = result.content?.[0];
+    expect(text?.type === "text" && text.text).toContain(
+      "sessionDefaultChannelGroup | sessions",
+    );
+    expect(text?.type === "text" && text.text).toContain("Organic Search");
+  });
+
+  it("surfaces a not-connected message with a connect URL", async () => {
+    mocks.Ga4Service.getPerformance.mockRejectedValue(
+      new Ga4NotConnectedError("project_1"),
+    );
+    const { getAnalyticsPerformanceTool } = await import(
+      "./analytics-tools"
+    );
+
+    const result = await getAnalyticsPerformanceTool.handler(
+      { projectId: "project_1", metrics: ["sessions"] },
+      toolExtra,
+    );
+
+    expect(result.structuredContent).toMatchObject({
+      ok: false,
+      reason: "not_connected",
+    });
+    const first = result.content[0];
+    expect(first.type).toBe("text");
+    expect(first.type === "text" && first.text).toContain(
+      "/p/project_1/settings",
+    );
+  });
+
+  it("renders an api_error with a reconnect URL on a GA4 API failure", async () => {
+    mocks.Ga4Service.getPerformance.mockRejectedValue(
+      new Ga4ApiError(403, "no access"),
+    );
+    const { getAnalyticsPerformanceTool } = await import(
+      "./analytics-tools"
+    );
+
+    const result = await getAnalyticsPerformanceTool.handler(
+      { projectId: "project_1", metrics: ["sessions"] },
+      toolExtra,
+    );
+
+    expect(result.structuredContent).toMatchObject({
+      ok: false,
+      reason: "api_error",
+    });
+    const first = result.content[0];
+    expect(first.type === "text" && first.text).toContain(
+      "/p/project_1/settings",
+    );
+  });
+
+  it("rejects a half-specified explicit date range", async () => {
+    const { getAnalyticsPerformanceTool } = await import(
+      "./analytics-tools"
+    );
+
+    const result = await getAnalyticsPerformanceTool.handler(
+      {
+        projectId: "project_1",
+        metrics: ["sessions"],
+        startDate: "2026-01-01",
+      },
+      toolExtra,
+    );
+
+    expect(result.structuredContent).toMatchObject({
+      reason: "invalid_request",
+    });
+    expect(mocks.Ga4Service.getPerformance).not.toHaveBeenCalled();
+  });
+
+  it("returns a setup message in self-hosted mode without a Google client", async () => {
+    mocks.isHostedServerAuthMode.mockResolvedValue(false);
+    mocks.hasSelfHostedGa4Config.mockResolvedValue(false);
+    const { getAnalyticsPerformanceTool } = await import(
+      "./analytics-tools"
+    );
+
+    const result = await getAnalyticsPerformanceTool.handler(
+      { projectId: "project_1", metrics: ["sessions"] },
+      toolExtra,
+    );
+
+    expect(result.structuredContent).toMatchObject({
+      reason: "ga4_oauth_not_configured",
+    });
+    expect(mocks.Ga4Service.getPerformance).not.toHaveBeenCalled();
+  });
+
+  it("allows performance queries in self-hosted mode with a Google client", async () => {
+    mocks.isHostedServerAuthMode.mockResolvedValue(false);
+    mocks.hasSelfHostedGa4Config.mockResolvedValue(true);
+    mocks.Ga4Service.getPerformance.mockResolvedValue({
+      propertyId: "properties/123",
+      propertyDisplayName: null,
+      connectedBy: "alice@example.com",
+      request: {
+        dateRanges: [{ startDate: "2026-04-29", endDate: "2026-05-27" }],
+        dimensions: [{ name: "date" }],
+        metrics: [{ name: "sessions" }],
+        limit: 1000,
+      },
+      report: { rows: [] },
+    });
+    const { getAnalyticsPerformanceTool } = await import(
+      "./analytics-tools"
+    );
+
+    const result = await getAnalyticsPerformanceTool.handler(
+      { projectId: "project_1", metrics: ["sessions"] },
+      toolExtra,
+    );
+
+    expect(mocks.Ga4Service.getPerformance).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: "project_1" }),
+    );
+    expect(result.structuredContent).toMatchObject({ ok: true });
+  });
+});

--- a/src/server/mcp/tools/analytics-tools.ts
+++ b/src/server/mcp/tools/analytics-tools.ts
@@ -228,8 +228,15 @@ export const getAnalyticsPerformanceTool = {
       const rawRows = result.report.rows ?? [];
       const rows = flattenRows(dimensions, metrics, rawRows);
       const requestedLimit = result.request.limit ?? GA4_DEFAULT_ROW_LIMIT;
-      const hasMore = rows.length >= requestedLimit;
-      const nextStartRow = (result.request.offset ?? 0) + rows.length;
+      const offset = result.request.offset ?? 0;
+      // GA4 reports the true total in rowCount, unlike Search Console — prefer
+      // it so the last exact-multiple-of-limit page doesn't misreport hasMore.
+      // Fall back to the length-vs-limit heuristic only if it's ever absent.
+      const hasMore =
+        result.report.rowCount !== undefined
+          ? offset + rows.length < result.report.rowCount
+          : rows.length >= requestedLimit;
+      const nextStartRow = offset + rows.length;
 
       const columns: McpTableColumn<Record<string, string>>[] = [
         ...dimensions.map((name) => ({

--- a/src/server/mcp/tools/analytics-tools.ts
+++ b/src/server/mcp/tools/analytics-tools.ts
@@ -1,0 +1,286 @@
+import { z } from "zod";
+import { buildProjectMeta } from "@/server/mcp/context";
+import { mcpResponse } from "@/server/mcp/formatters";
+import { optionalMetaOutputSchema } from "@/server/mcp/output-schemas";
+import { withMcpProjectAuth } from "@/server/mcp/project-auth";
+import { formatMcpTable, type McpTableColumn } from "@/server/mcp/table";
+import { projectIdSchema } from "@/server/mcp/schemas";
+import { buildDashboardUrl } from "@/server/mcp/urls";
+import { hasSelfHostedGa4Config } from "@/server/features/ga4/oauth-config";
+import { isHostedServerAuthMode } from "@/server/lib/runtime-env";
+import {
+  Ga4NotConnectedError,
+  Ga4Service,
+} from "@/server/features/ga4/services/Ga4Service";
+import {
+  GA4_DATE_RANGES,
+  GA4_DIMENSIONS,
+  GA4_DEFAULT_ROW_LIMIT,
+  GA4_FILTER_OPERATORS,
+  GA4_MAX_ROW_LIMIT,
+  GA4_METRICS,
+  type Ga4PerformanceInput,
+} from "@/server/features/ga4/analyticsReport";
+import { Ga4ApiError, Ga4TokenError } from "@/server/lib/ga4Client";
+import { GA4_SELF_HOSTED_SETUP_DOCS_URL } from "@/shared/ga4";
+
+type ProjectAuthContext = {
+  auth: { organizationId: string };
+  baseUrl: string;
+};
+
+function connectGa4Url(baseUrl: string, projectId: string): string {
+  return buildDashboardUrl(baseUrl, `/p/${projectId}/settings`);
+}
+
+/** Self-hosted GA4 requires the operator to provide a Google OAuth client and
+ *  BETTER_AUTH_SECRET. Hosted mode always has both; self-hosted tools return
+ *  this setup nudge before attempting a token lookup when either is missing. */
+async function missingSelfHostedGoogleClientResponse(
+  context: ProjectAuthContext,
+  projectId: string,
+) {
+  const [hosted, configured] = await Promise.all([
+    isHostedServerAuthMode(),
+    hasSelfHostedGa4Config(),
+  ]);
+  if (hosted || configured) return null;
+
+  return mcpResponse({
+    text: `This self-hosted OpenSEO deployment is not configured for Analytics yet. Set GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, and BETTER_AUTH_SECRET, then connect Analytics from the project's settings page. Setup docs: ${GA4_SELF_HOSTED_SETUP_DOCS_URL}`,
+    meta: buildProjectMeta(context, projectId),
+    structuredContent: {
+      ok: false,
+      connected: false,
+      reason: "ga4_oauth_not_configured",
+      setupDocsUrl: GA4_SELF_HOSTED_SETUP_DOCS_URL,
+    },
+  });
+}
+
+function invalidRequest(
+  meta: ReturnType<typeof buildProjectMeta>,
+  message: string,
+) {
+  return mcpResponse({
+    text: message,
+    meta,
+    structuredContent: { ok: false, reason: "invalid_request" },
+  });
+}
+
+function describeGa4Error(error: unknown): string {
+  if (error instanceof Ga4NotConnectedError) {
+    return "Analytics is not connected for this project.";
+  }
+  if (error instanceof Ga4TokenError) {
+    return "The Analytics connection has expired or was revoked. Reconnect it to continue.";
+  }
+  if (error instanceof Ga4ApiError) {
+    return error.message;
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
+/** A GA4 report row is dimensionValues[]/metricValues[] in header order — flatten
+ *  each row into a plain {name: value} object keyed by the requested field
+ *  names, which is what both the text table and structuredContent want. */
+function flattenRows(
+  dimensions: string[],
+  metrics: string[],
+  rows: Array<{
+    dimensionValues?: Array<{ value: string }>;
+    metricValues?: Array<{ value: string }>;
+  }>,
+): Array<Record<string, string>> {
+  return rows.map((row) => {
+    const flat: Record<string, string> = {};
+    dimensions.forEach((name, i) => {
+      flat[name] = row.dimensionValues?.[i]?.value ?? "";
+    });
+    metrics.forEach((name, i) => {
+      flat[name] = row.metricValues?.[i]?.value ?? "";
+    });
+    return flat;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// get_analytics_performance
+// ---------------------------------------------------------------------------
+
+const filterSchema = z.object({
+  dimension: z.enum(GA4_DIMENSIONS),
+  operator: z.enum(GA4_FILTER_OPERATORS).default("equals"),
+  expression: z.string().min(1),
+});
+
+const perfInputSchema = {
+  projectId: projectIdSchema,
+  dimensions: z
+    .array(z.enum(GA4_DIMENSIONS))
+    .min(1)
+    .max(4)
+    .optional()
+    .describe(
+      "Group rows by these dimensions. Default ['date']. Use ['sessionDefaultChannelGroup'] for the channel-mix question Search Console can't answer (organic search vs. direct vs. referral vs. email vs. paid); ['pagePath'] for top pages by real visits, not just search clicks.",
+    ),
+  metrics: z
+    .array(z.enum(GA4_METRICS))
+    .min(1)
+    .max(10)
+    .describe(
+      "Metrics to return, e.g. ['sessions','totalUsers']. At least one is required — GA4 has no implicit default metric set the way Search Console has clicks/impressions.",
+    ),
+  dateRange: z
+    .enum(GA4_DATE_RANGES)
+    .optional()
+    .describe(
+      "Convenience window (default last_28_days). Ignored if startDate+endDate are given. Unlike Search Console, GA4 has no fixed lookback ceiling — how far back real data exists depends on the property's own data-retention setting.",
+    ),
+  startDate: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .optional()
+    .describe("Explicit start (YYYY-MM-DD). Use with endDate."),
+  endDate: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .optional()
+    .describe("Explicit end (YYYY-MM-DD). Use with startDate."),
+  filters: z
+    .array(filterSchema)
+    .max(5)
+    .optional()
+    .describe(
+      "AND-combined filters on dimension values, e.g. [{dimension:'sessionDefaultChannelGroup',operator:'equals',expression:'Organic Search'}].",
+    ),
+  rowLimit: z
+    .number()
+    .int()
+    .min(1)
+    .max(GA4_MAX_ROW_LIMIT)
+    .optional()
+    .describe("Rows per call (default 1000, max 1000)."),
+  startRow: z.number().int().min(0).optional().describe("Pagination offset."),
+} as const;
+
+type PerfArgs = z.infer<z.ZodObject<typeof perfInputSchema>>;
+
+export const getAnalyticsPerformanceTool = {
+  name: "get_analytics_performance",
+  config: {
+    title: "Get Google Analytics (GA4) performance",
+    description:
+      "Query the connected GA4 property's report data (sessions, users, engagement, and more) by date, channel, page, country or device. Use this for questions Search Console can't answer: total visits across every channel, and the channel mix (organic search vs. direct vs. referral vs. email vs. paid) — 'email' only appears if the visited link carried UTM tags. Read-only; uses no credits.",
+    inputSchema: perfInputSchema,
+    outputSchema: {
+      ok: z.boolean(),
+      reason: z.string().optional(),
+      connectUrl: z.string().optional(),
+      setupDocsUrl: z.string().optional(),
+      propertyId: z.string().optional(),
+      propertyDisplayName: z.string().nullable().optional(),
+      startDate: z.string().optional(),
+      endDate: z.string().optional(),
+      dimensions: z.array(z.string()).optional(),
+      metrics: z.array(z.string()).optional(),
+      rowCount: z.number().optional(),
+      rows: z.array(z.record(z.string(), z.string())).optional(),
+      hasMore: z.boolean().optional(),
+      nextStartRow: z.number().optional(),
+      ...optionalMetaOutputSchema,
+    },
+    annotations: {
+      readOnlyHint: true,
+      openWorldHint: true,
+      destructiveHint: false,
+    },
+  },
+  handler: withMcpProjectAuth(async (args: PerfArgs, context) => {
+    const blocked = await missingSelfHostedGoogleClientResponse(
+      context,
+      args.projectId,
+    );
+    if (blocked) return blocked;
+
+    const connectUrl = connectGa4Url(context.baseUrl, args.projectId);
+    const meta = buildProjectMeta(
+      context,
+      args.projectId,
+      `/p/${args.projectId}/settings`,
+    );
+
+    if (Boolean(args.startDate) !== Boolean(args.endDate)) {
+      return invalidRequest(
+        meta,
+        "Provide both startDate and endDate, or neither (use dateRange instead).",
+      );
+    }
+
+    try {
+      const result = await Ga4Service.getPerformance(
+        args satisfies Ga4PerformanceInput,
+      );
+      const dimensions =
+        result.request.dimensions?.map((d) => d.name) ?? [];
+      const metrics = result.request.metrics.map((m) => m.name);
+      const rawRows = result.report.rows ?? [];
+      const rows = flattenRows(dimensions, metrics, rawRows);
+      const requestedLimit = result.request.limit ?? GA4_DEFAULT_ROW_LIMIT;
+      const hasMore = rows.length >= requestedLimit;
+      const nextStartRow = (result.request.offset ?? 0) + rows.length;
+
+      const columns: McpTableColumn<Record<string, string>>[] = [
+        ...dimensions.map((name) => ({
+          header: name,
+          value: (row: Record<string, string>) => row[name] ?? "",
+        })),
+        ...metrics.map((name) => ({
+          header: name,
+          value: (row: Record<string, string>) => row[name] ?? "",
+        })),
+      ];
+
+      const propertyLabel = result.propertyDisplayName
+        ? `${result.propertyId} (${result.propertyDisplayName})`
+        : result.propertyId;
+      const header =
+        `${propertyLabel} · ${dimensions.join("+")} · ${result.request.dateRanges[0].startDate}→${result.request.dateRanges[0].endDate} · ` +
+        `${rows.length} row${rows.length === 1 ? "" : "s"}${hasMore ? " (more available — paginate with startRow)" : ""}`;
+      const text =
+        rows.length > 0
+          ? `${header}\n${formatMcpTable(rows, columns)}`
+          : `${header}\nNo rows for this query/date range.`;
+
+      return mcpResponse({
+        text,
+        meta,
+        structuredContent: {
+          ok: true,
+          propertyId: result.propertyId,
+          propertyDisplayName: result.propertyDisplayName,
+          startDate: result.request.dateRanges[0].startDate,
+          endDate: result.request.dateRanges[0].endDate,
+          dimensions,
+          metrics,
+          rowCount: rows.length,
+          rows,
+          hasMore,
+          nextStartRow: hasMore ? nextStartRow : undefined,
+        },
+      });
+    } catch (error) {
+      const isNotConnected = error instanceof Ga4NotConnectedError;
+      return mcpResponse({
+        text: `${describeGa4Error(error)}${isNotConnected ? ` Connect it here: ${connectUrl}` : ` (reconnect at ${connectUrl})`}`,
+        meta,
+        structuredContent: {
+          ok: false,
+          reason: isNotConnected ? "not_connected" : "api_error",
+          connectUrl,
+        },
+      });
+    }
+  }),
+};

--- a/src/serverFunctions/ga4.ts
+++ b/src/serverFunctions/ga4.ts
@@ -1,0 +1,126 @@
+import { createServerFn } from "@tanstack/react-start";
+import { getRequest } from "@tanstack/react-start/server";
+import { waitUntil } from "cloudflare:workers";
+import { z } from "zod";
+import { Ga4Service } from "@/server/features/ga4/services/Ga4Service";
+import { hasSelfHostedGa4Config } from "@/server/features/ga4/oauth-config";
+import { createSelfHostedGa4AuthorizationUrl } from "@/server/features/ga4/selfHostedOAuth";
+import { captureServerEvent } from "@/server/lib/posthog";
+import { getPublicOrigin } from "@/server/mcp/public-origin";
+import { isHostedServerAuthMode } from "@/server/lib/runtime-env";
+import {
+  requireAuthenticatedContext,
+  requireProjectContext,
+} from "@/serverFunctions/middleware";
+
+const projectScopedSchema = z.object({ projectId: z.string().min(1) });
+const setPropertySchema = projectScopedSchema.extend({
+  accountId: z.string().min(1),
+  propertyId: z.string().min(1),
+});
+const startSelfHostedLinkSchema = z.object({
+  callbackURL: z.string().min(1),
+});
+
+// Account-level grant check (no project needed) for surfaces like onboarding
+// where the user hasn't picked a project yet. The OAuth grant is per-account;
+// binding a property to a project happens later in Integrations.
+export const getGa4GrantStatus = createServerFn({ method: "GET" })
+  .middleware(requireAuthenticatedContext)
+  .handler(async ({ context }) => {
+    return { connected: await Ga4Service.userHasGrant(context.userId) };
+  });
+
+export const getGa4Connection = createServerFn({ method: "POST" })
+  .middleware(requireProjectContext)
+  .validator(projectScopedSchema)
+  .handler(async ({ context }) => {
+    const [connection, currentUserHasGrant, hosted, ga4Configured] =
+      await Promise.all([
+        Ga4Service.getConnection(context.projectId),
+        Ga4Service.userHasGrant(context.userId),
+        isHostedServerAuthMode(),
+        hasSelfHostedGa4Config(),
+      ]);
+    return {
+      connected: Boolean(connection),
+      currentUserHasGrant,
+      googleOAuthConfigured: hosted || ga4Configured,
+      propertyId: connection?.propertyId ?? null,
+      propertyDisplayName: connection?.propertyDisplayName ?? null,
+      connectedByEmail: connection?.connectedAccountEmail ?? null,
+      connectedAt: connection?.createdAt ?? null,
+    };
+  });
+
+export const listGa4Properties = createServerFn({ method: "POST" })
+  .middleware(requireProjectContext)
+  .validator(projectScopedSchema)
+  .handler(async ({ context }) => {
+    const { accounts } = await Ga4Service.listPropertiesForUserWithGrantStatus(
+      context.userId,
+      context.projectId,
+    );
+    return { accounts };
+  });
+
+export const setGa4Property = createServerFn({ method: "POST" })
+  .middleware(requireProjectContext)
+  .validator(setPropertySchema)
+  .handler(async ({ data, context }) => {
+    const connection = await Ga4Service.setProperty({
+      projectId: context.projectId,
+      organizationId: context.organizationId,
+      accountId: data.accountId,
+      propertyId: data.propertyId,
+      userId: context.userId,
+    });
+    waitUntil(
+      captureServerEvent({
+        distinctId: context.userId,
+        event: "ga4:property_select",
+        organizationId: context.organizationId,
+        properties: {
+          project_id: context.projectId,
+          property_id: data.propertyId,
+        },
+      }),
+    );
+    return { connected: true as const, propertyId: connection.propertyId };
+  });
+
+export const disconnectGa4 = createServerFn({ method: "POST" })
+  .middleware(requireProjectContext)
+  .validator(projectScopedSchema)
+  .handler(async ({ context }) => {
+    await Ga4Service.disconnect({
+      projectId: context.projectId,
+      userId: context.userId,
+    });
+    waitUntil(
+      captureServerEvent({
+        distinctId: context.userId,
+        event: "ga4:disconnect",
+        organizationId: context.organizationId,
+        properties: { project_id: context.projectId },
+      }),
+    );
+    return { connected: false as const };
+  });
+
+export const startSelfHostedGa4Link = createServerFn({ method: "POST" })
+  .middleware(requireAuthenticatedContext)
+  .validator(startSelfHostedLinkSchema)
+  .handler(async ({ data, context }) => {
+    const publicOrigin = getPublicOrigin(getRequest());
+    const url = await createSelfHostedGa4AuthorizationUrl({
+      user: {
+        userId: context.userId,
+        userEmail: context.userEmail,
+      },
+      callbackURL: data.callbackURL,
+      publicOrigin,
+    });
+
+    return { url };
+  });

--- a/src/shared/ga4.ts
+++ b/src/shared/ga4.ts
@@ -1,0 +1,14 @@
+/** Better Auth providerId for the incremental Google Analytics (GA4) connection.
+ *  Kept in `shared` so both server (auth config, GA4 client) and client (connect
+ *  button) can reference it without importing the server-only auth config. */
+export const GA4_OAUTH_PROVIDER_ID = "google-analytics";
+
+export const GA4_OAUTH_SCOPES = [
+  "openid",
+  "email",
+  "profile",
+  "https://www.googleapis.com/auth/analytics.readonly",
+] as const;
+
+export const GA4_SELF_HOSTED_SETUP_DOCS_URL =
+  "https://github.com/every-app/open-seo/blob/main/docs/SELF_HOSTING_GOOGLE_ANALYTICS.md";


### PR DESCRIPTION
## Summary

Adds a full self-hosted GA4 integration, mirroring the existing Search Console feature end to end — same architecture, same conventions, independent connection.

- `shared/ga4.ts`: its own OAuth provider id (`google-analytics`) and scope (`analytics.readonly`) — connecting/disconnecting GA4 never touches the Search Console grant or requires re-consenting it, even though both reuse the same `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET`.
- DB schema (sqlite + pg): `ga4_connections`, one property per project — same shape as `gsc_connections`. OAuth tokens live in the existing better-auth `account` table under the new provider id, same as every other generic-OAuth connection here.
- `server/lib/ga4Client.ts`: thin client over the Analytics Admin API (`accountSummaries.list`, paginated to completion — GSC's `sites.list` doesn't need this, GA4 accounts can span pages) and the Analytics Data API (`runReport`), with the same token-refresh/error-mapping pattern as `gscClient`.
- `server/features/ga4/`: OAuth flow (authorization URL, callback, HMAC-signed state), connection repository, service layer, and `analyticsReport.ts` (date-range resolution — no fixed lookback floor, unlike GSC's 16-month cap, since GA4's real retention is per-property configuration; `dimensionFilter` building from the same flat-filter shape the Search Console tool uses).
- New MCP tool `get_analytics_performance`: sessions/users/engagement by date, channel (`sessionDefaultChannelGroup` — the channel-mix question Search Console structurally cannot answer), page, country, or device.
- Client: `AnalyticsConnectionCard` + `PropertyPicker` (mirrors `SearchConsoleConnectionCard`/`SitePicker`), wired into Project Settings under a new "Analytics" section next to Search Console.
- `docs/SELF_HOSTING_GOOGLE_ANALYTICS.md`: setup guide — reuses the same OAuth client as Search Console, just one more redirect URI and two more APIs (`analyticsdata`, `analyticsadmin`) to enable.

Adopted two upstream fixes that landed on `main` after this branch was started, rather than reintroducing the bugs they fixed: `MIN_BETTER_AUTH_SECRET_LENGTH` from `shared/selfhost-checks` instead of a magic `32`, and the `subtractUtcMonths` month-rollover fix (naive `setUTCMonth` mis-handles e.g. March 31 minus 1 month) in `analyticsReport.ts`'s date-range math, matching `searchAnalytics.ts`'s.

## Test plan

- [x] `pnpm run types:check` — clean.
- [x] `pnpm run lint` — clean, 0 warnings/errors.
- [x] Full test suite: 98 files / 812 tests pass, including the existing `schema-parity.test.ts` (now 120 assertions, covering the new table).
- [x] `pnpm run db:migrate:local` applies the new migration (`0037_cultured_reptil.sql` / `drizzle-pg/0014_futuristic_shadow_king.sql`) cleanly against a real local D1.
- [x] `pnpm run build` succeeds for both client and server bundles.
- [ ] Not done: a live OAuth round-trip against a real GA4 property (would need a redirect URI registered on a real Google Cloud OAuth client, which isn't available in this environment) — the request/response shapes are covered by mocked unit tests instead. Worth a manual smoke test before merging: connect, pick a property, run `get_analytics_performance`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)