### PR TITLE
feat(audit): AEO checks — schemamap and JSON-LD linked graph (part 2 of #99)

### DIFF
--- a/badseo/scripts/run-audit.ts
+++ b/badseo/scripts/run-audit.ts
@@ -17,6 +17,7 @@ import {
   discoverUrls,
   parseRobotsTxt,
 } from "../../src/server/lib/audit/discovery";
+import { runSiteChecks } from "../../src/server/lib/audit/issues/site-checks";
 import {
   normalizeUrl,
   isSameOrigin,
@@ -68,6 +69,7 @@ async function crawl(origin: string): Promise<{
   pages: CrawledPageResult[];
   links: CrawlLink[];
   completed: boolean;
+  robotsText: string | null;
 }> {
   const { urls: sitemapUrls, robotsText } = await discoverUrls(
     origin,
@@ -146,7 +148,7 @@ async function crawl(origin: string): Promise<{
   }
 
   const completed = linkQueue.length === 0 && sitemapQueue.length === 0;
-  return { pages, links, completed };
+  return { pages, links, completed, robotsText };
 }
 
 /** In-memory equivalents of the two D1-backed multipage checks. */
@@ -243,7 +245,7 @@ async function main() {
   await warmup();
   const origin = new URL(BASE).origin;
   const startUrl = normalizeUrl(`${origin}/`) ?? `${origin}/`;
-  const { pages, links, completed } = await crawl(origin);
+  const { pages, links, completed, robotsText } = await crawl(origin);
 
   if (process.env.DEBUG_DEPTH) {
     for (const p of pages) {
@@ -382,6 +384,25 @@ async function main() {
     });
   }
 
+  // Site-level checks run once over the whole origin rather than per page, so
+  // they can't be expressed as a fixture's expectedIssues. badseo serves no
+  // /schemamap.xml and names none in robots.txt, so the check must fire.
+  {
+    const siteIssues = await runSiteChecks({ origin, robotsText });
+    const found = siteIssues.some(
+      (issue) => issue.issueType === "schemamap-missing",
+    );
+    if (!found) failures++;
+    rows.push({
+      name: "Site: no schemamap declared",
+      url: origin,
+      ok: found,
+      detail: found
+        ? c.green("schemamap-missing reported")
+        : c.red("schemamap-missing NOT reported"),
+    });
+  }
+
   // ---- report ----
   const pad = Math.max(...rows.map((r) => r.name.length));
   for (const r of rows) {
@@ -398,7 +419,13 @@ async function main() {
   );
 
   // Coverage: every audit issue type should be exercised by at least one page.
-  const exercised = new Set(allFixtures.flatMap((f) => f.expectedIssues));
+  // Site-level issues have no fixture to hang off — they're asserted directly
+  // above, so list them here rather than reporting them as forever-uncovered.
+  const SITE_LEVEL_ISSUES: IssueId[] = ["schemamap-missing"];
+  const exercised = new Set([
+    ...allFixtures.flatMap((f) => f.expectedIssues),
+    ...SITE_LEVEL_ISSUES,
+  ]);
   const allTypes = Object.keys(AUDIT_ISSUE_TYPES) as IssueId[];
   const uncovered = allTypes.filter((id) => !exercised.has(id));
   console.log(

--- a/badseo/src/fixtures/registry.ts
+++ b/badseo/src/fixtures/registry.ts
@@ -6,6 +6,7 @@ import { httpStatusFixtures } from "./http-status";
 import { redirectFixtures } from "./redirects";
 import { performanceFixtures } from "./performance";
 import { structureFixtures } from "./structure";
+import { structuredDataFixtures } from "./structured-data";
 import { kitchenSinkFixtures } from "./kitchen-sink";
 
 /** Every fixture on the site, in catalog order. */
@@ -17,6 +18,7 @@ export const allFixtures: Fixture[] = [
   ...redirectFixtures,
   ...performanceFixtures,
   ...structureFixtures,
+  ...structuredDataFixtures,
   ...kitchenSinkFixtures,
 ];
 

--- a/badseo/src/fixtures/structured-data.ts
+++ b/badseo/src/fixtures/structured-data.ts
@@ -1,0 +1,120 @@
+import type { Fixture } from "./types";
+import { htmlResponse, renderPage } from "../lib";
+import { article } from "./helpers";
+
+const CAT = "Structured data";
+
+function ldJson(payload: unknown): string {
+  return `<script type="application/ld+json">${JSON.stringify(payload)}</script>`;
+}
+
+// 33 — several JSON-LD entities that never reference each other ------------
+const unlinkedGraph: Fixture = {
+  path: "/structured-data/unlinked-graph",
+  category: CAT,
+  name: "Structured data is not a linked graph",
+  summary:
+    "Three separate JSON-LD blocks. Each is valid. None of them reference each other.",
+  lesson:
+    "Structured data is read as one graph of entities. Emitting an Article, an Organization and a Person as three islands says nothing about how they relate, so no consumer can tell who wrote the article or who published it. Wrap them in a single @graph, or give each one an @id and point at it from the others.",
+  expectedIssues: ["jsonld-not-linked-graph"],
+  handler: () =>
+    htmlResponse(
+      renderPage({
+        fixture: unlinkedGraph,
+        title: "Three islands of structured data",
+        metaDescription:
+          "This page emits an Article, an Organization and a Person as three unconnected JSON-LD blocks, so nothing ties the entities together.",
+        headExtra: [
+          ldJson({
+            "@context": "https://schema.org",
+            "@type": "Article",
+            headline: "Three islands of structured data",
+          }),
+          ldJson({
+            "@context": "https://schema.org",
+            "@type": "Organization",
+            name: "Bad SEO Industries",
+          }),
+          ldJson({
+            "@context": "https://schema.org",
+            "@type": "Person",
+            name: "Dana Marks",
+          }),
+        ].join(""),
+        bodyHtml: article({
+          h1: "Three islands of structured data",
+          lede: "The markup on this page is valid. It is also disconnected, which throws away most of its value.",
+          sections: [
+            {
+              h2: "Why linking the entities matters",
+              body: "Search engines and AI assistants do not read your structured data block by block. They merge it into a single graph of entities and then ask questions of that graph: who wrote this, who published it, what does this organisation do. When each block stands alone, none of those questions have answers. You have described three things and stated no relationship between them, so the markup adds far less than it looks like it does.",
+            },
+            {
+              h2: "Two ways to connect them",
+              body: "The simplest fix is a single script holding a @graph array with every entity inside it. The other way, useful when blocks are emitted by different templates or components, is to give each entity a stable @id such as https://example.com/#organisation and then reference that id from the other entities. Either way a consumer can walk from the article to its author and its publisher instead of guessing.",
+            },
+          ],
+        }),
+      }),
+    ),
+};
+
+// 34 — the same entities, correctly linked (regression guard) --------------
+const linkedGraph: Fixture = {
+  path: "/structured-data/linked-graph",
+  category: CAT,
+  name: "Structured data as a linked graph",
+  summary:
+    "The same three entities, connected through @id references across blocks.",
+  lesson:
+    "This page is the counter-example: separate blocks are fine as long as the entities reference each other by @id. It exists so the linked-graph check cannot start firing on correct markup.",
+  expectedIssues: [],
+  handler: () =>
+    htmlResponse(
+      renderPage({
+        fixture: linkedGraph,
+        title: "Structured data done as one graph",
+        metaDescription:
+          "The same Article, Organization and Person, this time connected by @id references so consumers can walk from the article to its author and publisher.",
+        headExtra: [
+          ldJson({
+            "@context": "https://schema.org",
+            "@type": "Article",
+            "@id": "https://badseo.dev/structured-data/linked-graph#article",
+            headline: "Structured data done as one graph",
+            author: { "@id": "https://badseo.dev/#person" },
+            publisher: { "@id": "https://badseo.dev/#organization" },
+          }),
+          ldJson({
+            "@context": "https://schema.org",
+            "@type": "Organization",
+            "@id": "https://badseo.dev/#organization",
+            name: "Bad SEO Industries",
+          }),
+          ldJson({
+            "@context": "https://schema.org",
+            "@type": "Person",
+            "@id": "https://badseo.dev/#person",
+            name: "Dana Marks",
+          }),
+        ].join(""),
+        bodyHtml: article({
+          h1: "Structured data done as one graph",
+          lede: "Same three entities as the previous page, this time joined up.",
+          sections: [
+            {
+              h2: "What changed",
+              body: "Every entity now carries an @id, and the article points at the other two through those ids. The blocks are still separate scripts, which is realistic: a header component emits the organisation, an author component emits the person, the page template emits the article. Because they agree on identifiers, a consumer merges them into one graph anyway and can answer who wrote and who published the piece.",
+            },
+            {
+              h2: "Choosing identifiers",
+              body: "Use absolute URLs with a fragment, and keep them stable over time. A good identifier names the thing rather than the page it happened to appear on, which is why the organisation here is site-wide rather than scoped to this URL. Reusing the same id everywhere the entity appears is what lets a crawler recognise it as one organisation across your whole site instead of a new one per page.",
+            },
+          ],
+        }),
+      }),
+    ),
+};
+
+export const structuredDataFixtures: Fixture[] = [unlinkedGraph, linkedGraph];

--- a/src/server/lib/audit/crawl-window.test.ts
+++ b/src/server/lib/audit/crawl-window.test.ts
@@ -1,3 +1,4 @@
+import { EMPTY_JSON_LD_SUMMARY } from "@/server/lib/audit/jsonld";
 import { describe, expect, it } from "vitest";
 import { adjustCrawlWindow } from "@/server/lib/audit/crawl-window";
 import type {
@@ -41,6 +42,7 @@ function page(
     images: [],
     links: [],
     hasStructuredData: false,
+    jsonLd: EMPTY_JSON_LD_SUMMARY,
     hreflangTags: [],
     isIndexable: true,
     responseTimeMs,

--- a/src/server/lib/audit/issues/page-reporters.test.ts
+++ b/src/server/lib/audit/issues/page-reporters.test.ts
@@ -1,3 +1,4 @@
+import { EMPTY_JSON_LD_SUMMARY } from "@/server/lib/audit/jsonld";
 import { describe, expect, it } from "vitest";
 import { runPageReporters } from "@/server/lib/audit/issues/page-reporters";
 import {
@@ -47,6 +48,7 @@ function makePage(overrides: Partial<CrawledPageResult>): CrawledPageResult {
     images: [],
     links: [HEALTHY_LINK],
     hasStructuredData: false,
+    jsonLd: EMPTY_JSON_LD_SUMMARY,
     hreflangTags: [],
     isIndexable: true,
     responseTimeMs: 200,
@@ -200,6 +202,50 @@ describe("runPageReporters", () => {
     expect(issueTypes(makePage({ links: [HEALTHY_LINK] }))).not.toContain(
       "no-outgoing-links",
     );
+  });
+
+  it("checks structured-data linkage", () => {
+    // Linkage itself is exercised in jsonld.test.ts; this pins the wiring —
+    // the reporter reads the page's summary and attaches the counts.
+    const unlinked = makePage({
+      jsonLd: {
+        ...EMPTY_JSON_LD_SUMMARY,
+        blocks: 2,
+        nodes: 2,
+      },
+    });
+    expect(issueTypes(unlinked)).toContain("jsonld-not-linked-graph");
+    expect(
+      runPageReporters(unlinked).find(
+        (issue) => issue.issueType === "jsonld-not-linked-graph",
+      )?.details,
+    ).toEqual({ blocks: 2, nodes: 2 });
+
+    expect(issueTypes(makePage({}))).not.toContain("jsonld-not-linked-graph");
+    expect(
+      issueTypes(
+        makePage({
+          jsonLd: {
+            ...EMPTY_JSON_LD_SUMMARY,
+            blocks: 1,
+            nodes: 2,
+            hasGraph: true,
+          },
+        }),
+      ),
+    ).not.toContain("jsonld-not-linked-graph");
+  });
+
+  it("does not run content checks on non-HTML responses", () => {
+    // A PDF has no structured data to be unlinked.
+    expect(
+      issueTypes(
+        makePage({
+          isHtml: false,
+          jsonLd: { ...EMPTY_JSON_LD_SUMMARY, blocks: 2, nodes: 2 },
+        }),
+      ),
+    ).not.toContain("jsonld-not-linked-graph");
   });
 });
 

--- a/src/server/lib/audit/issues/page-reporters.ts
+++ b/src/server/lib/audit/issues/page-reporters.ts
@@ -9,6 +9,7 @@
  * live in multipage.ts and run over D1 after the crawl.
  */
 import type { AuditIssueType } from "@/shared/audit-issues";
+import { isUnlinkedJsonLdGraph } from "@/server/lib/audit/jsonld";
 import type { CrawledPageResult } from "@/server/lib/audit/types";
 
 export interface DetectedIssue {
@@ -148,6 +149,15 @@ export function runPageReporters(page: CrawledPageResult): DetectedIssue[] {
   }
   if (page.crawlDepth !== null && page.crawlDepth >= DEEP_PAGE_DEPTH) {
     report("deep-page", { crawlDepth: page.crawlDepth });
+  }
+
+  // Structured data: several entities that never reference each other read as
+  // unrelated fragments rather than one graph.
+  if (isUnlinkedJsonLdGraph(page.jsonLd)) {
+    report("jsonld-not-linked-graph", {
+      blocks: page.jsonLd.blocks,
+      nodes: page.jsonLd.nodes,
+    });
   }
 
   return issues;

--- a/src/server/lib/audit/issues/site-checks.test.ts
+++ b/src/server/lib/audit/issues/site-checks.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { detectSchemamapMissing, robotsDeclaresSchemamap } from "./site-checks";
+
+const ORIGIN = "https://example.com";
+
+function detect(input: { robotsText?: string | null; served?: boolean }) {
+  return detectSchemamapMissing({
+    origin: ORIGIN,
+    robotsText: input.robotsText ?? null,
+    schemamapServed: input.served ?? false,
+  });
+}
+
+describe("robotsDeclaresSchemamap", () => {
+  it("finds the directive regardless of case or leading space", () => {
+    expect(
+      robotsDeclaresSchemamap("Schemamap: https://example.com/schemamap.xml"),
+    ).toBe(true);
+    expect(robotsDeclaresSchemamap("  schemamap:/schemamap.xml")).toBe(true);
+    expect(
+      robotsDeclaresSchemamap(
+        "User-agent: *\nAllow: /\n\nSCHEMAMAP: /schemamap.xml\n",
+      ),
+    ).toBe(true);
+  });
+
+  it("ignores missing robots.txt and unrelated directives", () => {
+    expect(robotsDeclaresSchemamap(null)).toBe(false);
+    expect(robotsDeclaresSchemamap("")).toBe(false);
+    expect(
+      robotsDeclaresSchemamap("User-agent: *\nSitemap: /sitemap.xml"),
+    ).toBe(false);
+  });
+
+  it("does not match the word mid-line", () => {
+    expect(
+      robotsDeclaresSchemamap("# we should add a schemamap: one day"),
+    ).toBe(false);
+  });
+});
+
+describe("detectSchemamapMissing", () => {
+  it("reports when neither the file nor the directive is present", () => {
+    const issues = detect({});
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({
+      issueType: "schemamap-missing",
+      pageId: null,
+      pageUrl: ORIGIN,
+    });
+  });
+
+  it("stays quiet when /schemamap.xml is served", () => {
+    expect(detect({ served: true })).toEqual([]);
+  });
+
+  it("stays quiet when robots.txt declares one", () => {
+    expect(
+      detect({ robotsText: "Schemamap: https://example.com/schemamap.xml" }),
+    ).toEqual([]);
+  });
+});

--- a/src/server/lib/audit/issues/site-checks.ts
+++ b/src/server/lib/audit/issues/site-checks.ts
@@ -1,0 +1,74 @@
+/**
+ * Site-level issue checks — findings about the site as a whole rather than any
+ * one page. Unlike the per-page reporters these may perform one extra fetch for
+ * a well-known root resource, so the impure entry point is kept thin and every
+ * decision lives in a pure predicate that tests can drive without a network.
+ *
+ * Site-level issues carry `pageId: null` and the site origin as `pageUrl`
+ * (the issues table allows a null page reference but requires a URL).
+ */
+import type { DetectedIssue } from "@/server/lib/audit/issues/page-reporters";
+
+const FETCH_HEADERS = { "User-Agent": "OpenSEO-Audit/1.0" } as const;
+const FETCH_TIMEOUT_MS = 10_000;
+
+/**
+ * robots-parser only exposes the directives it knows about, so an emerging
+ * one like `Schemamap:` has to be read off the raw text. Matches a directive
+ * at the start of a line, which is where robots.txt directives live.
+ */
+export function robotsDeclaresSchemamap(robotsText: string | null): boolean {
+  if (!robotsText) return false;
+  return /^[^\S\r\n]*schemamap[^\S\r\n]*:/im.test(robotsText);
+}
+
+/**
+ * A site advertises a schemamap either by serving /schemamap.xml or by
+ * pointing at one from robots.txt. Absence is an opportunity, not a defect —
+ * the convention is young — so this only reports when neither signal is there.
+ */
+export function detectSchemamapMissing(input: {
+  origin: string;
+  robotsText: string | null;
+  schemamapServed: boolean;
+}): DetectedIssue[] {
+  if (input.schemamapServed || robotsDeclaresSchemamap(input.robotsText)) {
+    return [];
+  }
+  return [
+    {
+      issueType: "schemamap-missing",
+      pageId: null,
+      pageUrl: input.origin,
+    },
+  ];
+}
+
+/**
+ * True only for a definite 2xx. A network error or timeout returns false, which
+ * would surface the issue on a site that does serve one — acceptable for an
+ * info-level finding, and the alternative (suppressing on error) hides it for
+ * every site whose root is briefly unreachable.
+ */
+async function fetchServesSchemamap(origin: string): Promise<boolean> {
+  try {
+    const response = await fetch(`${origin}/schemamap.xml`, {
+      headers: FETCH_HEADERS,
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    // Drain so the connection can be reused; we only care about the status.
+    await response.body?.cancel();
+    return response.ok;
+  } catch (error) {
+    console.warn("Failed to fetch schemamap.xml:", error);
+    return false;
+  }
+}
+
+export async function runSiteChecks(input: {
+  origin: string;
+  robotsText: string | null;
+}): Promise<DetectedIssue[]> {
+  const schemamapServed = await fetchServesSchemamap(input.origin);
+  return detectSchemamapMissing({ ...input, schemamapServed });
+}

--- a/src/server/lib/audit/jsonld.test.ts
+++ b/src/server/lib/audit/jsonld.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+import {
+  addJsonLdBlock,
+  createJsonLdAccumulator,
+  isUnlinkedJsonLdGraph,
+  summarizeJsonLd,
+} from "./jsonld";
+
+function summarize(...blocks: string[]) {
+  const acc = createJsonLdAccumulator();
+  for (const block of blocks) addJsonLdBlock(acc, block);
+  return summarizeJsonLd(acc);
+}
+
+function isUnlinked(...blocks: string[]) {
+  return isUnlinkedJsonLdGraph(summarize(...blocks));
+}
+
+const ARTICLE = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "Article",
+  headline: "Hello",
+});
+const ORGANIZATION = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  name: "Acme",
+});
+
+describe("summarizeJsonLd", () => {
+  it("counts top-level entities across blocks", () => {
+    expect(summarize(ARTICLE, ORGANIZATION)).toMatchObject({
+      blocks: 2,
+      nodes: 2,
+      hasGraph: false,
+      crossReferenced: false,
+      invalidBlocks: 0,
+    });
+  });
+
+  it("expands @graph and a top-level array into their entities", () => {
+    expect(
+      summarize(
+        JSON.stringify({
+          "@context": "https://schema.org",
+          "@graph": [{ "@type": "Article" }, { "@type": "Organization" }],
+        }),
+      ),
+    ).toMatchObject({ blocks: 1, nodes: 2, hasGraph: true });
+
+    expect(
+      summarize(
+        JSON.stringify([{ "@type": "Article" }, { "@type": "Person" }]),
+      ),
+    ).toMatchObject({ blocks: 1, nodes: 2, hasGraph: false });
+  });
+
+  it("separates declared @ids from references to them", () => {
+    expect(
+      summarize(
+        JSON.stringify({
+          "@type": "Article",
+          "@id": "https://example.com/#article",
+          author: { "@id": "https://example.com/#person" },
+        }),
+        JSON.stringify({
+          "@type": "Person",
+          "@id": "https://example.com/#person",
+        }),
+      ),
+    ).toMatchObject({ nodes: 2, crossReferenced: true });
+  });
+
+  it("does not treat a dangling reference as a link", () => {
+    expect(
+      summarize(
+        JSON.stringify({
+          "@type": "Article",
+          author: { "@id": "https://example.com/#nobody" },
+        }),
+        ORGANIZATION,
+      ),
+    ).toMatchObject({ crossReferenced: false });
+  });
+
+  it("counts malformed blocks without throwing", () => {
+    expect(summarize("{ not json", ARTICLE)).toMatchObject({
+      blocks: 2,
+      invalidBlocks: 1,
+      nodes: 1,
+    });
+  });
+
+  it("marks oversized input as truncated instead of guessing", () => {
+    const huge = JSON.stringify({
+      "@type": "Product",
+      description: "x".repeat(70_000),
+    });
+    expect(summarize(huge, ARTICLE)).toMatchObject({ truncated: true });
+  });
+});
+
+describe("isUnlinkedJsonLdGraph", () => {
+  it("does not fire on a page with no structured data", () => {
+    expect(isUnlinked()).toBe(false);
+  });
+
+  it("does not fire on a single entity", () => {
+    expect(isUnlinked(ARTICLE)).toBe(false);
+  });
+
+  it("fires on two independent entities in separate blocks", () => {
+    expect(isUnlinked(ARTICLE, ORGANIZATION)).toBe(true);
+  });
+
+  it("fires on two independent entities in one array block", () => {
+    expect(
+      isUnlinked(
+        JSON.stringify([{ "@type": "Article" }, { "@type": "Organization" }]),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not fire when the entities share a @graph", () => {
+    expect(
+      isUnlinked(
+        JSON.stringify({
+          "@graph": [{ "@type": "Article" }, { "@type": "Organization" }],
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not fire when a resolvable @id links the blocks", () => {
+    expect(
+      isUnlinked(
+        JSON.stringify({
+          "@type": "Article",
+          publisher: { "@id": "https://example.com/#org" },
+        }),
+        JSON.stringify({
+          "@type": "Organization",
+          "@id": "https://example.com/#org",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("stays quiet when a cap hid part of the data", () => {
+    const huge = JSON.stringify({
+      "@type": "Product",
+      description: "x".repeat(70_000),
+    });
+    expect(isUnlinked(huge, ARTICLE, ORGANIZATION)).toBe(false);
+  });
+});

--- a/src/server/lib/audit/jsonld.ts
+++ b/src/server/lib/audit/jsonld.ts
@@ -1,0 +1,188 @@
+/**
+ * JSON-LD graph summarization for the audit engine.
+ *
+ * Search engines and AI assistants read a page's structured data as one graph
+ * of entities. When a page ships several `<script type="application/ld+json">`
+ * blocks that never reference each other, consumers see a pile of unrelated
+ * nodes instead of "this Article, by this Person, published by this
+ * Organization" — the relationships that make the data worth emitting are
+ * simply absent.
+ *
+ * Blocks are folded in one at a time and only a handful of counters survive,
+ * because page-analyzer.ts runs ~25 parses concurrently on a 128MB isolate and
+ * buffering raw JSON-LD would reintroduce the OOM class that file exists to
+ * avoid. Everything here is pure, so the check is unit-testable without a DOM
+ * or a network.
+ */
+
+/** Blocks past this are counted but not parsed — pages this deep are pathological. */
+const MAX_PARSED_BLOCKS = 25;
+/** Longer blocks are counted as present but not parsed (see memory note above). */
+const MAX_BLOCK_CHARS = 64_000;
+/** Cap on tracked @id values, so a huge catalog can't grow the accumulator without bound. */
+const MAX_TRACKED_IDS = 200;
+/** Guards against deeply nested or cyclic structures while walking a block. */
+const MAX_WALK_DEPTH = 12;
+
+export interface JsonLdAccumulator {
+  /** Every ld+json block seen, including ones too large or malformed to parse. */
+  blocks: number;
+  /** Blocks that failed JSON.parse (malformed structured data). */
+  invalidBlocks: number;
+  /** Blocks skipped by the size/count caps — treated as unknown, never as unlinked. */
+  skippedBlocks: number;
+  /** Top-level entity nodes across all blocks, expanding @graph and arrays. */
+  nodes: number;
+  /** True when any block uses the @graph container. */
+  hasGraph: boolean;
+  declaredIds: Set<string>;
+  referencedIds: Set<string>;
+}
+
+export interface JsonLdSummary {
+  blocks: number;
+  invalidBlocks: number;
+  nodes: number;
+  hasGraph: boolean;
+  /** True when a node references an @id that another node declares. */
+  crossReferenced: boolean;
+  /** True when a cap kept us from seeing the whole picture; suppresses the check. */
+  truncated: boolean;
+}
+
+export function createJsonLdAccumulator(): JsonLdAccumulator {
+  return {
+    blocks: 0,
+    invalidBlocks: 0,
+    skippedBlocks: 0,
+    nodes: 0,
+    hasGraph: false,
+    declaredIds: new Set(),
+    referencedIds: new Set(),
+  };
+}
+
+function track(set: Set<string>, value: string) {
+  if (set.size < MAX_TRACKED_IDS) set.add(value);
+}
+
+/**
+ * Walk one parsed node. `topLevel` nodes are the entities a consumer sees;
+ * nested objects still contribute @id references (that's how a linked graph
+ * expresses "this Article's author is that Person").
+ */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function walk(
+  value: unknown,
+  acc: JsonLdAccumulator,
+  depth: number,
+  topLevel: boolean,
+) {
+  if (depth > MAX_WALK_DEPTH) return;
+
+  if (Array.isArray(value)) {
+    for (const item of value) walk(item, acc, depth + 1, topLevel);
+    return;
+  }
+
+  if (!isRecord(value)) return;
+  const node = value;
+
+  const graph = node["@graph"];
+  if (graph !== undefined) {
+    acc.hasGraph = true;
+    walk(graph, acc, depth + 1, true);
+    // A @graph wrapper is a container, not an entity of its own.
+    if (!("@type" in node)) return;
+  }
+
+  const id = node["@id"];
+  if (typeof id === "string" && id) {
+    // A bare {"@id": "..."} with no other meaningful key is a reference to
+    // another node; anything carrying a @type is declaring its own identity.
+    if ("@type" in node) {
+      track(acc.declaredIds, id);
+    } else {
+      track(acc.referencedIds, id);
+    }
+  }
+
+  if (topLevel && "@type" in node) acc.nodes += 1;
+
+  for (const [key, child] of Object.entries(node)) {
+    if (key === "@graph" || key === "@id" || key === "@context") continue;
+    walk(child, acc, depth + 1, false);
+  }
+}
+
+export function addJsonLdBlock(acc: JsonLdAccumulator, text: string) {
+  acc.blocks += 1;
+
+  if (acc.blocks > MAX_PARSED_BLOCKS || text.length > MAX_BLOCK_CHARS) {
+    acc.skippedBlocks += 1;
+    return;
+  }
+
+  const trimmed = text.trim();
+  if (!trimmed) {
+    acc.invalidBlocks += 1;
+    return;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    acc.invalidBlocks += 1;
+    return;
+  }
+
+  walk(parsed, acc, 0, true);
+}
+
+export function summarizeJsonLd(acc: JsonLdAccumulator): JsonLdSummary {
+  let crossReferenced = false;
+  for (const ref of acc.referencedIds) {
+    if (acc.declaredIds.has(ref)) {
+      crossReferenced = true;
+      break;
+    }
+  }
+
+  return {
+    blocks: acc.blocks,
+    invalidBlocks: acc.invalidBlocks,
+    nodes: acc.nodes,
+    hasGraph: acc.hasGraph,
+    crossReferenced,
+    truncated:
+      acc.skippedBlocks > 0 ||
+      acc.declaredIds.size >= MAX_TRACKED_IDS ||
+      acc.referencedIds.size >= MAX_TRACKED_IDS,
+  };
+}
+
+export const EMPTY_JSON_LD_SUMMARY: JsonLdSummary = {
+  blocks: 0,
+  invalidBlocks: 0,
+  nodes: 0,
+  hasGraph: false,
+  crossReferenced: false,
+  truncated: false,
+};
+
+/**
+ * A page fails the "linked graph" bar when it publishes several independent
+ * entities with nothing tying them together. One entity needs no links, a
+ * @graph container is linked by construction, and a resolvable @id reference
+ * is the explicit way to connect nodes across separate blocks. Anything we
+ * couldn't fully inspect is given the benefit of the doubt.
+ */
+export function isUnlinkedJsonLdGraph(summary: JsonLdSummary): boolean {
+  if (summary.truncated) return false;
+  if (summary.hasGraph || summary.crossReferenced) return false;
+  return summary.nodes >= 2;
+}

--- a/src/server/lib/audit/page-analyzer.test.ts
+++ b/src/server/lib/audit/page-analyzer.test.ts
@@ -3,6 +3,11 @@
  * cheerio/DOM reference implementation — the exact logic the analyzer
  * replaced. Cheerio stays as a devDependency for this test only.
  */
+import {
+  addJsonLdBlock,
+  createJsonLdAccumulator,
+  summarizeJsonLd,
+} from "@/server/lib/audit/jsonld";
 import * as cheerio from "cheerio";
 import { describe, expect, it } from "vitest";
 import { analyzeHtml } from "@/server/lib/audit/page-analyzer";
@@ -74,8 +79,13 @@ function analyzeHtmlWithCheerio(html: string, pageUrl: string): PageAnalysis {
   });
 
   let hasStructuredData = false;
-  $('script[type="application/ld+json"]').each(() => {
+  // The reference folds JSON-LD through the same pure accumulator as the
+  // streaming analyzer; only the block extraction differs (DOM vs tokenizer),
+  // which is exactly what the parity assertion is meant to compare.
+  const referenceJsonLd = createJsonLdAccumulator();
+  $('script[type="application/ld+json"]').each((_, el) => {
     hasStructuredData = true;
+    addJsonLdBlock(referenceJsonLd, $(el).text());
   });
 
   const hreflangTags: string[] = [];
@@ -103,6 +113,7 @@ function analyzeHtmlWithCheerio(html: string, pageUrl: string): PageAnalysis {
     images,
     links: Array.from(linksByTarget.values()),
     hasStructuredData,
+    jsonLd: summarizeJsonLd(referenceJsonLd),
     hreflangTags,
   };
 }

--- a/src/server/lib/audit/page-analyzer.ts
+++ b/src/server/lib/audit/page-analyzer.ts
@@ -12,6 +12,11 @@
  */
 import { Parser } from "htmlparser2";
 import { normalizeUrl, isSameOrigin } from "./url-utils";
+import {
+  addJsonLdBlock,
+  createJsonLdAccumulator,
+  summarizeJsonLd,
+} from "./jsonld";
 import type { PageAnalysis, PageLink } from "./types";
 
 const SKIPPED_LINK_PROTOCOLS = /^(javascript:|mailto:|tel:|#)/;
@@ -56,6 +61,11 @@ export function analyzeHtml(
   let ogDescription: string | null = null;
   let ogImage: string | null = null;
   let hasStructuredData = false;
+  // JSON-LD is folded into counters one block at a time (see jsonld.ts): the
+  // raw text of at most one block is ever held, keeping this parse allocation-
+  // flat like every other buffer in this file.
+  const jsonLd = createJsonLdAccumulator();
+  let openLdJson: string[] | null = null;
   const hreflangTags: string[] = [];
 
   const h1s: string[] = [];
@@ -156,6 +166,7 @@ export function analyzeHtml(
           case "script":
             if (attribs["type"] === "application/ld+json") {
               hasStructuredData = true;
+              openLdJson = [];
             }
             break;
           case "a": {
@@ -180,6 +191,8 @@ export function analyzeHtml(
         }
       },
       ontext(text) {
+        // <script> is a suppressed tag, so capture before the guard below.
+        if (openLdJson) openLdJson.push(text);
         if (suppressDepth > 0) return;
         if (titleDepth > 0) {
           if (title !== null) title += text;
@@ -196,6 +209,10 @@ export function analyzeHtml(
       onclosetag(name) {
         if (NON_CONTENT_TAGS.has(name) && suppressDepth > 0) {
           suppressDepth -= 1;
+        }
+        if (name === "script" && openLdJson) {
+          addJsonLdBlock(jsonLd, openLdJson.join(""));
+          openLdJson = null;
         }
         if (name === "noscript" && noscriptDepth > 0) {
           noscriptDepth -= 1;
@@ -244,6 +261,7 @@ export function analyzeHtml(
     images,
     links: Array.from(linksByTarget.values()),
     hasStructuredData,
+    jsonLd: summarizeJsonLd(jsonLd),
     hreflangTags,
   };
 }

--- a/src/server/lib/audit/types.ts
+++ b/src/server/lib/audit/types.ts
@@ -3,6 +3,7 @@
  */
 
 import { z } from "zod";
+import type { JsonLdSummary } from "@/server/lib/audit/jsonld";
 import { MIN_AUDIT_PAGES, PAID_MAX_AUDIT_PAGES } from "@/shared/audit-limits";
 import { jsonCodec } from "@/shared/json";
 
@@ -82,6 +83,8 @@ export interface PageAnalysis {
 
   // Structured data
   hasStructuredData: boolean;
+  /** Shape of the page's JSON-LD as one graph (see jsonld.ts). */
+  jsonLd: JsonLdSummary;
 
   // Hreflang
   hreflangTags: string[];
@@ -151,6 +154,8 @@ export interface CrawledPageResult {
   images: Array<{ src: string | null; alt: string | null }>;
   links: PageLink[];
   hasStructuredData: boolean;
+  /** Shape of the page's JSON-LD as one graph (see jsonld.ts). */
+  jsonLd: JsonLdSummary;
   hreflangTags: string[];
   isIndexable: boolean;
   responseTimeMs: number;

--- a/src/server/workflows/site-audit-workflow-helpers.ts
+++ b/src/server/workflows/site-audit-workflow-helpers.ts
@@ -3,6 +3,7 @@ import type {
   PageFetchClass,
 } from "@/server/lib/audit/types";
 import { sha256Hex } from "@/server/lib/audit/ids";
+import { EMPTY_JSON_LD_SUMMARY } from "@/server/lib/audit/jsonld";
 import { normalizeUrl } from "@/server/lib/audit/url-utils";
 
 const CRAWL_USER_AGENT = "OpenSEO-Audit/1.0";
@@ -182,6 +183,7 @@ export async function crawlPage(
       images: analysis.images,
       links: analysis.links,
       hasStructuredData: analysis.hasStructuredData,
+      jsonLd: analysis.jsonLd,
       hreflangTags: analysis.hreflangTags,
       isIndexable,
       responseTimeMs,
@@ -280,6 +282,7 @@ function emptyPageResult(input: {
     images: [],
     links: [],
     hasStructuredData: false,
+    jsonLd: EMPTY_JSON_LD_SUMMARY,
     hreflangTags: [],
     isIndexable: false,
     responseTimeMs: input.responseTimeMs,

--- a/src/server/workflows/siteAuditWorkflowPhases.ts
+++ b/src/server/workflows/siteAuditWorkflowPhases.ts
@@ -16,6 +16,7 @@ import { AuditRepository } from "@/server/features/audit/repositories/AuditRepos
 import { getAuditScratchpad } from "@/server/features/audit/AuditScratchpad";
 import { AuditProgressKV } from "@/server/lib/audit/progress-kv";
 import { runMultipageChecks } from "@/server/lib/audit/issues/multipage";
+import { runSiteChecks } from "@/server/lib/audit/issues/site-checks";
 import type { DetectedIssue } from "@/server/lib/audit/issues/page-reporters";
 import type { AuditConfig } from "@/server/lib/audit/types";
 import { captureServerEvent } from "@/server/lib/posthog";
@@ -98,6 +99,8 @@ export async function runAuditPhases(
     billingCustomer,
     projectId,
     startUrl,
+    origin,
+    robotsText: discovery.robotsText,
     config,
     crawl,
   });
@@ -322,6 +325,9 @@ async function finalizeAudit(args: {
   billingCustomer: BillingCustomerContext;
   projectId: string;
   startUrl: string;
+  origin: string;
+  /** Checkpointed by the discovery step, so replays see the same robots.txt. */
+  robotsText: string | null;
   config: AuditConfig;
   crawl: CrawlPhaseResult;
 }) {
@@ -332,6 +338,8 @@ async function finalizeAudit(args: {
     billingCustomer,
     projectId,
     startUrl,
+    origin,
+    robotsText,
     config,
     crawl,
   } = args;
@@ -355,6 +363,10 @@ async function finalizeAudit(args: {
 
     const issues = await runMultipageChecks({ auditId });
     issues.push(...(await runScratchpadLinkChecks(auditId, startUrl, crawl)));
+    // Site-level findings ride along with the multipage step: same
+    // checkpoint, and insertIssues is idempotent, so a retry that re-fetches
+    // the root resource can't duplicate rows.
+    issues.push(...(await runSiteChecks({ origin, robotsText })));
     await AuditRepository.insertIssues(auditId, issues);
     return { issueCount: issues.length };
   });

--- a/src/shared/audit-issues.ts
+++ b/src/shared/audit-issues.ts
@@ -232,6 +232,22 @@ export const AUDIT_ISSUE_TYPES = {
     howToFix:
       "Add links from higher-level pages (hubs, category pages, navigation) to flatten the path to this page.",
   },
+  "jsonld-not-linked-graph": {
+    severity: "info",
+    title: "Structured data is not a linked graph",
+    explanation:
+      "The page publishes several independent JSON-LD entities that never reference each other. Each block is valid on its own, but search engines and AI assistants read structured data as one graph — without links they see unrelated fragments instead of 'this Article, written by this Person, published by this Organization', which is what earns rich results and accurate citations.",
+    howToFix:
+      'Emit the page\'s entities inside a single @graph, or give each entity a stable @id and reference it from the others (for example, set the Article\'s author to {"@id": "https://example.com/#person"}).',
+  },
+  "schemamap-missing": {
+    severity: "info",
+    title: "No schemamap",
+    explanation:
+      "The site serves no /schemamap.xml and declares no Schemamap: directive in robots.txt. A schemamap points crawlers and AI agents at where a site's structured data lives, so they can find your entities without crawling every page first. It is an emerging convention, so this is an opportunity rather than a defect.",
+    howToFix:
+      "Publish a schemamap at /schemamap.xml listing the URLs that carry structured data, and reference it from robots.txt with a `Schemamap: https://example.com/schemamap.xml` line.",
+  },
 } as const satisfies Record<string, AuditIssueDescriptor>;
 
 export type AuditIssueType = keyof typeof AUDIT_ISSUE_TYPES;


### PR DESCRIPTION
Part 2 of #99 — the two checks #122 explicitly leaves open.

@WAHIB-EL-KHADIRI offered these two in [his comment](https://github.com/every-app/open-seo/issues/99#issuecomment-5043694362) after shipping the other three in #122, so this PR takes them and touches nothing #122 owns conceptually. There is file overlap (`audit-issues.ts`, `page-analyzer.ts`, `types.ts`, `siteAuditWorkflowPhases.ts`) — whoever lands second rebases, and I'm happy for that to be me.

## The two checks

### `jsonld-not-linked-graph` — page-level, `info`

Fires when a page publishes **two or more independent JSON-LD entities that never reference each other**.

Each block can be perfectly valid on its own; that's the point. Consumers merge structured data into one graph and then ask it questions — who wrote this, who published it — and three disconnected islands answer none of them. The fix is a single `@graph`, or a stable `@id` per entity referenced from the others.

Never fires on: one entity, a `@graph`, a resolvable cross-block `@id`, malformed JSON, or a non-HTML response.

### `schemamap-missing` — site-level, `info`

Fires when the site serves no `/schemamap.xml` **and** names none via a `Schemamap:` directive in robots.txt. Absence is an opportunity, not a defect (the convention is young), hence `info`.

`robots-parser` only surfaces directives it knows about, so the directive is read off the raw robots.txt text the discovery phase already checkpoints — no second fetch of robots.txt.

## Two structural choices worth reviewing

**JSON-LD is folded into counters, never buffered.** `page-analyzer.ts` exists because a full DOM per page was the engine's dominant OOM cause at 25 concurrent parses on a 128MB isolate, so I did not want to reintroduce that by accumulating raw JSON-LD strings. Blocks are folded one at a time into five scalars (`blocks`, `nodes`, `hasGraph`, `crossReferenced`, `truncated`) — at most one block's text is live at any moment. Blocks past the size/count caps mark the summary `truncated`, which **suppresses** the check rather than guessing from partial data.

The `jsonLd` field is transient like `isHtml`/`htmlBytes`: `runPageReporters` runs on the in-memory result inside the crawl chunk, so **no DB migration and no new persisted column**.

The cheerio parity reference in `page-analyzer.test.ts` folds through the same pure accumulator, so `expect(streamed).toEqual(reference)` still compares tokenizer against DOM and nothing else.

**`schemamap-missing` is the engine's first site-level issue.** Everything before it hangs off a page row, so this needed a small amount of new shape:

- It emits `pageId: null` with the origin as `pageUrl`. The issues table already allows a null page reference (`pageId` is not `.notNull()`), and `pageUrl` is required, so the origin fills it.
- It rides **inside the existing `multipage-checks` step** rather than adding a phase: same checkpoint, and `insertIssues` is idempotent via `deterministicAuditRowId` + `onConflictDoNothing`, so a retry that re-fetches `/schemamap.xml` cannot duplicate rows.
- `finalizeAudit` now receives `origin` and the checkpointed `robotsText`.

The impure entry point (`runSiteChecks`) is one thin function; every decision lives in a pure predicate, mirroring how `discovery.ts` splits `fetchRobotsTxtText` from `parseRobotsTxt`.

One judgement call I'd flag: a network error fetching `/schemamap.xml` is treated as "not served", so a site whose root is briefly unreachable can surface the issue. The alternative — suppress on error — hides it permanently for anyone with a flaky root. For an `info` finding I think a rare false positive beats a silent false negative, but say the word and I'll flip it.

## badseo

New **Structured data** category with a matched pair:

- `/structured-data/unlinked-graph` — Article + Organization + Person as three islands → `["jsonld-not-linked-graph"]`
- `/structured-data/linked-graph` — the same three entities joined by `@id` → `[]`

The second one is the point: it's the regression guard that stops this check firing on correct markup, and it's realistic (separate blocks emitted by separate components, agreeing on identifiers).

Site-level issues have no fixture to hang off, so the harness asserts `schemamap-missing` directly (modeled on the existing trailing-slash guard) and lists it in a `SITE_LEVEL_ISSUES` coverage exemption — asserted, so the exemption isn't a lie. `crawl()` now returns `robotsText` so the site check can reuse it.

## Verification

| Gate | Result |
| --- | --- |
| `tsc --noEmit` | clean |
| `tsc --noEmit -p badseo/tsconfig.json` | clean |
| `oxlint --type-aware` | 0 warnings, 0 errors |
| `vitest run` | **1013 passed** (124 files) |
| badseo harness, live instance | **44/44 checks**, issue-type coverage **29/29** |

Harness output for the new rows:

```
✓ Structured data is not a linked graph           jsonld-not-linked-graph
✓ Structured data as a linked graph               clean
✓ Site: no schemamap declared                     schemamap-missing reported
```

`knip` still fails on `vite.config.ts` (`Cannot read properties of undefined (reading 'join')`) — pre-existing on a clean `main`, unrelated to this change.
