### PR TITLE
feat: support comma-separated hosts in ALLOWED_HOST

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@
 # PORT=3001
 
 # Optional reverse-proxy hosts for Docker self-hosting
-# ALLOWED_HOST=yourdomain.com
+# ALLOWED_HOST=yourdomain.com            # comma-separated for multiple hosts
 
 # Optional image tag override for Docker self-hosting
 # OPEN_SEO_IMAGE=ghcr.io/every-app/open-seo:latest

--- a/docs/SELF_HOSTING_DOCKER.md
+++ b/docs/SELF_HOSTING_DOCKER.md
@@ -30,7 +30,7 @@ Open `http://localhost:<PORT>` (default `3001`). The first start builds the app 
 Optional env values:
 
 - `PORT` (defaults to `3001`)
-- `ALLOWED_HOST` (single reverse-proxy hostname to allow in Vite preview)
+- `ALLOWED_HOST` (reverse-proxy hostname(s) to allow in Vite preview; comma-separated for multiple, e.g. `app.example.com,mcp.example.com`)
 - `AUTH_MODE=local_noauth` (already set in compose)
 - `OPEN_SEO_IMAGE` (defaults to `ghcr.io/every-app/open-seo:latest`)
 - `OPENROUTER_API_KEY` (required for AI features such as SAM; see [OpenRouter](https://openrouter.ai/settings/keys))

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,7 +16,7 @@ export default defineConfig(({ mode }) => {
       : 3001;
   const showDevtools = env.VITE_SHOW_DEVTOOLS !== "false";
   const allowedHosts = [
-    env.ALLOWED_HOST,
+    ...(env.ALLOWED_HOST?.split(",").map((host) => host.trim()) ?? []),
     env.BETTER_AUTH_URL ? new URL(env.BETTER_AUTH_URL).hostname : undefined,
   ].filter((host): host is string => Boolean(host));
   const emitSourcemaps = env.POSTHOG_SOURCEMAPS === "true";


### PR DESCRIPTION
## What

`ALLOWED_HOST` now accepts a comma-separated list of hostnames, e.g.:

```
ALLOWED_HOST=app.example.com,mcp.example.com
```

Single-value configs behave exactly as before (split on a string without commas yields the same single host).

## Why

We self-host OpenSEO behind an authenticating reverse proxy. The UI is served on one hostname, while `/mcp` is exposed through a separate MCP gateway hostname (so MCP clients authenticate with OAuth Bearer tokens while humans use the interactive login). Vite's `allowedHosts` is already an array, but `ALLOWED_HOST` only fills one slot, so the second hostname gets blocked with Vite's "Blocked request" page.

## Changes

- `vite.config.ts`: split `ALLOWED_HOST` on commas (trimmed) before building `allowedHosts`
- `docs/SELF_HOSTING_DOCKER.md`, `.env.example`: document the comma-separated form

## Checks

- [x] `pnpm ci:check`
- [x] `pnpm test:ci` (992 passed)
- [x] `pnpm vite build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)