### PR TITLE
feat(mcp): let AgentOnboard agents authenticate into the MCP server

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -18,6 +18,7 @@ import {
 import { requestWithPublicOrigin } from "@/server/mcp/public-origin";
 import { MCP_ROUTE } from "@/server/mcp/context";
 import { handleSelfHostedOpenSeoMcpRequest } from "@/server/mcp/transport";
+import { handleAgentOnboardMcpRequest } from "@/server/agentonboard/agentonboard-mcp";
 import { withPgClient } from "@/db";
 import {
   AUTUMN_WEBHOOK_PATH,
@@ -136,11 +137,11 @@ function fetch(
   return withPgClient(() => Promise.resolve(handleFetch(request, env, ctx)));
 }
 
-function handleFetch(
+async function handleFetch(
   request: Request,
   env: Env,
   ctx: ExecutionContext,
-): Response | Promise<Response> {
+): Promise<Response> {
   ctx.waitUntil(maybeSendSelfHostHeartbeat());
 
   const authMode = getAuthMode(env.AUTH_MODE);
@@ -158,6 +159,20 @@ function handleFetch(
   if (isHostedAuthMode(authMode)) {
     if (pathname === AUTUMN_WEBHOOK_PATH) {
       return handleAutumnWebhookRequest(publicRequest);
+    }
+
+    // AgentOnboard agents reach the MCP server with a session token instead of
+    // an OAuth grant. Try that path first (returns null for non-agent
+    // requests); if it does not apply, fall through to the OAuth provider.
+    if (pathname === MCP_ROUTE) {
+      const agentOnboardResponse = await handleAgentOnboardMcpRequest(
+        publicRequest,
+        env,
+        ctx,
+      );
+      if (agentOnboardResponse) {
+        return agentOnboardResponse;
+      }
     }
 
     return openSeoOAuthProvider.fetch(

--- a/src/server/agentonboard/agentonboard-mcp.test.ts
+++ b/src/server/agentonboard/agentonboard-mcp.test.ts
@@ -17,7 +17,12 @@ const { handleAuthenticatedOpenSeoMcpRequestMock } = vi.hoisted(() => ({
 }));
 
 vi.mock("@/server/mcp/transport", () => ({
-  handleAuthenticatedOpenSeoMcpRequest: handleAuthenticatedOpenSeoMcpRequestMock,
+  handleAuthenticatedOpenSeoMcpRequest:
+    handleAuthenticatedOpenSeoMcpRequestMock,
+}));
+
+vi.mock("@/lib/auth", () => ({
+  getHostedBaseUrl: () => "https://open-seo.test",
 }));
 
 import { handleAgentOnboardMcpRequest } from "@/server/agentonboard/agentonboard-mcp";
@@ -46,7 +51,7 @@ beforeEach(() => {
     organizationId: "org-1",
   });
   handleAuthenticatedOpenSeoMcpRequestMock.mockImplementation(
-    async (request, props, env, ctx) => new Response("mcp response", { status: 200 }),
+    async () => new Response("mcp response", { status: 200 }),
   );
 });
 

--- a/src/server/agentonboard/agentonboard-mcp.test.ts
+++ b/src/server/agentonboard/agentonboard-mcp.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getSessionTokenHeaderMock, resolveAgentContextMock } = vi.hoisted(
+  () => ({
+    getSessionTokenHeaderMock: vi.fn(),
+    resolveAgentContextMock: vi.fn(),
+  }),
+);
+
+vi.mock("@/server/agentonboard/agentonboard", () => ({
+  getSessionTokenHeader: getSessionTokenHeaderMock,
+  resolveAgentContext: resolveAgentContextMock,
+}));
+
+const { handleAuthenticatedOpenSeoMcpRequestMock } = vi.hoisted(() => ({
+  handleAuthenticatedOpenSeoMcpRequestMock: vi.fn(),
+}));
+
+vi.mock("@/server/mcp/transport", () => ({
+  handleAuthenticatedOpenSeoMcpRequest: handleAuthenticatedOpenSeoMcpRequestMock,
+}));
+
+import { handleAgentOnboardMcpRequest } from "@/server/agentonboard/agentonboard-mcp";
+import { AppError } from "@/server/lib/errors";
+
+const ctx: ExecutionContext = {
+  waitUntil() {},
+  passThroughOnException() {},
+  props: {},
+};
+
+function makeRequest(sessionToken?: string, method = "GET") {
+  const headers = new Headers();
+  if (sessionToken) {
+    headers.set("x-session-token", sessionToken);
+  }
+  return new Request("https://openseo.so/mcp", { method, headers });
+}
+
+beforeEach(() => {
+  getSessionTokenHeaderMock.mockReturnValue("x-session-token");
+  resolveAgentContextMock.mockResolvedValue({
+    userId: "user-1",
+    userEmail: "agent@openseo.test",
+    emailVerified: true,
+    organizationId: "org-1",
+  });
+  handleAuthenticatedOpenSeoMcpRequestMock.mockImplementation(
+    async (request, props, env, ctx) => new Response("mcp response", { status: 200 }),
+  );
+});
+
+describe("handleAgentOnboardMcpRequest", () => {
+  it("does not run for non-MCP routes", async () => {
+    const req = new Request("https://openseo.so/other", { method: "GET" });
+    await expect(
+      handleAgentOnboardMcpRequest(req, {}, ctx),
+    ).resolves.toBeNull();
+  });
+
+  it("returns null for OPTIONS preflight", async () => {
+    await expect(
+      handleAgentOnboardMcpRequest(makeRequest(undefined, "OPTIONS"), {}, ctx),
+    ).resolves.toBeNull();
+  });
+
+  it("returns null when no session token is present", async () => {
+    await expect(
+      handleAgentOnboardMcpRequest(makeRequest(), {}, ctx),
+    ).resolves.toBeNull();
+  });
+
+  it("serves the request through the hosted transport for a valid token", async () => {
+    const result = await handleAgentOnboardMcpRequest(
+      makeRequest("good-token"),
+      {},
+      ctx,
+    );
+    expect(handleAuthenticatedOpenSeoMcpRequestMock).toHaveBeenCalled();
+    expect(result).not.toBeNull();
+    expect(await result?.text()).toBe("mcp response");
+  });
+
+  it("returns null when identity resolution yields nothing", async () => {
+    resolveAgentContextMock.mockResolvedValue(null);
+    await expect(
+      handleAgentOnboardMcpRequest(makeRequest("token"), {}, ctx),
+    ).resolves.toBeNull();
+  });
+
+  it("surfaces a rejected agent request as a JSON-RPC 401 error", async () => {
+    const message =
+      "No account exists with this email. Create an OpenSEO account with the same email you use on AgentOnboard, then try again.";
+    resolveAgentContextMock.mockRejectedValue(
+      new AppError("UNAUTHENTICATED", message),
+    );
+    const response = await handleAgentOnboardMcpRequest(
+      makeRequest("good-token"),
+      {},
+      ctx,
+    );
+    expect(response).not.toBeNull();
+    expect(response?.status).toBe(401);
+    expect(await response?.text()).toContain(message);
+  });
+
+  it("surfaces an internal failure as a JSON-RPC 500 error", async () => {
+    resolveAgentContextMock.mockRejectedValue(new Error("boom"));
+    const response = await handleAgentOnboardMcpRequest(
+      makeRequest("good-token"),
+      {},
+      ctx,
+    );
+    expect(response?.status).toBe(500);
+  });
+});

--- a/src/server/agentonboard/agentonboard-mcp.ts
+++ b/src/server/agentonboard/agentonboard-mcp.ts
@@ -1,0 +1,95 @@
+import { getHostedBaseUrl } from "@/lib/auth";
+import { MCP_OAUTH_SCOPES } from "@/lib/oauth-resource";
+import { createWorkersOAuthMcpProps, MCP_ROUTE } from "@/server/mcp/context";
+import { handleAuthenticatedOpenSeoMcpRequest } from "@/server/mcp/transport";
+import { asAppError } from "@/server/lib/errors";
+import {
+  getSessionTokenHeader,
+  resolveAgentContext,
+} from "@/server/agentonboard/agentonboard";
+
+// The AgentOnboard entry point into the MCP server, mirroring the API-key auth
+// path (handleMcpApiKeyRequest): verify the agent's session token, synthesize
+// the same MCP auth props, and let the hosted transport serve the request.
+// Returns null when the request is not an AO agent request (no x-session-token
+// header) so the caller can fall through to the normal OAuth path unchanged.
+export async function handleAgentOnboardMcpRequest(
+  request: Request,
+  env: unknown,
+  ctx: ExecutionContext,
+): Promise<Response | null> {
+  const url = new URL(request.url);
+  if (url.pathname !== MCP_ROUTE || request.method === "OPTIONS") {
+    return null;
+  }
+
+  if (!request.headers.get(getSessionTokenHeader())) {
+    return null;
+  }
+
+  let identity;
+  try {
+    identity = await resolveAgentContext(request.headers);
+  } catch (error) {
+    return agentErrorResponse(error);
+  }
+
+  if (!identity) {
+    return null;
+  }
+
+  // The agent acts as the matched user. A distinct clientId marks these calls
+  // as AgentOnboard agents (vs OAuth clients / api_key) and satisfies the
+  // hosted transport's fail-closed props schema.
+  const props = createWorkersOAuthMcpProps({
+    userId: identity.userId,
+    userEmail: identity.userEmail,
+    organizationId: identity.organizationId,
+    baseUrl: getHostedBaseUrl(),
+    scopes: [...MCP_OAUTH_SCOPES],
+    clientId: "agent_onboard",
+  });
+
+  return handleAuthenticatedOpenSeoMcpRequest(request, props, env, ctx);
+}
+
+// Surface a rejected agent request as a JSON-RPC error (the MCP protocol's
+// error shape) rather than letting the AppError throw up to the caller, which
+// would surface as an opaque HTTP 500 instead of the message the agent can act
+// on. A UNAUTHENTICATED failure (no matching account / unverified email) is
+// the agent-visible case; everything else is a server-side problem we log.
+function agentErrorResponse(error: unknown): Response {
+  const appError = asAppError(error);
+  if (appError?.code === "UNAUTHENTICATED") {
+    return new Response(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: null,
+        error: {
+          code: -32001,
+          message: appError.message,
+        },
+      }),
+      {
+        status: 401,
+        headers: { "content-type": "application/json" },
+      },
+    );
+  }
+
+  console.error("AgentOnboard request failed:", error);
+  return new Response(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id: null,
+      error: {
+        code: -32603,
+        message: "Internal error",
+      },
+    }),
+    {
+      status: 500,
+      headers: { "content-type": "application/json" },
+    },
+  );
+}

--- a/src/server/agentonboard/agentonboard.test.ts
+++ b/src/server/agentonboard/agentonboard.test.ts
@@ -1,0 +1,235 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { isHostedAuthModeMock, optionalEnvMock, requiredEnvMock } = vi.hoisted(
+  () => ({
+    isHostedAuthModeMock: vi.fn(),
+    optionalEnvMock: vi.fn<(name: string) => Promise<string | undefined>>(),
+    requiredEnvMock: vi.fn<(name: string) => Promise<string>>(),
+  }),
+);
+
+vi.mock("@/lib/auth-mode", () => ({
+  isHostedAuthMode: isHostedAuthModeMock,
+}));
+
+vi.mock("@/server/lib/runtime-env", () => ({
+  getOptionalEnvValue: optionalEnvMock,
+  getRequiredEnvValue: requiredEnvMock,
+}));
+
+const { dbQueryUserMock } = vi.hoisted(() => ({
+  dbQueryUserMock: { findFirst: vi.fn() },
+}));
+
+// The real @/db barrel and @/db/schema both drag in cloudflare:workers
+// (db/provider.ts), which is unavailable in the Vitest node environment —
+// stub both so importing them here does not touch the DB client.
+vi.mock("@/db", () => ({ db: { query: { user: dbQueryUserMock } } }));
+
+// The production file imports `user` from @/db/schema for the eq() lookup;
+// the real schema module also loads cloudflare:workers. Provide a stub symbol
+// so the import resolves without loading the schema.
+vi.mock("@/db/schema", () => ({ user: Symbol("user") }));
+
+const { getOrCreateDefaultHostedOrganizationMock } = vi.hoisted(() => ({
+  getOrCreateDefaultHostedOrganizationMock: vi.fn(),
+}));
+
+vi.mock("@/server/auth/default-hosted-organization", () => ({
+  getOrCreateDefaultHostedOrganization:
+    getOrCreateDefaultHostedOrganizationMock,
+}));
+
+import {
+  isAgentOnboardConfigured,
+  resolveAgentContext,
+  verifySessionToken,
+} from "@/server/agentonboard/agentonboard";
+
+const USER = {
+  id: "user-1",
+  email: "agent@openseo.test",
+  emailVerified: true,
+};
+
+function makeHeaders(sessionToken?: string) {
+  const headers = new Headers();
+  if (sessionToken) {
+    headers.set("x-session-token", sessionToken);
+  }
+  return headers;
+}
+
+function mockVerifyOk(email = USER.email) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => Response.json({ email }, { status: 200 })),
+  );
+}
+
+function mockVerifyError(status: number, error: string) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => Response.json({ error }, { status })),
+  );
+}
+
+beforeEach(() => {
+  isHostedAuthModeMock.mockReturnValue(true);
+  optionalEnvMock.mockImplementation(async (name) =>
+    name === "AGENTONBOARD_PARTNER_KEY" ? "partner-key" : undefined,
+  );
+  requiredEnvMock.mockResolvedValue("partner-key");
+  getOrCreateDefaultHostedOrganizationMock.mockResolvedValue("org-1");
+  vi.unstubAllGlobals();
+});
+
+describe("isAgentOnboardConfigured", () => {
+  it("is true when hosted and a partner key is configured", async () => {
+    await expect(isAgentOnboardConfigured()).resolves.toBe(true);
+  });
+
+  it("is false when not hosted", async () => {
+    isHostedAuthModeMock.mockReturnValue(false);
+    await expect(isAgentOnboardConfigured()).resolves.toBe(false);
+  });
+
+  it("is false when no partner key is configured", async () => {
+    optionalEnvMock.mockImplementation(async () => undefined);
+    await expect(isAgentOnboardConfigured()).resolves.toBe(false);
+  });
+});
+
+describe("verifySessionToken", () => {
+  it("returns the email for a valid token", async () => {
+    mockVerifyOk();
+    await expect(verifySessionToken("good-token")).resolves.toEqual({
+      ok: true,
+      email: USER.email,
+    });
+  });
+
+  it("returns an error result for an invalid or expired token", async () => {
+    mockVerifyError(401, "Invalid or expired session token");
+    const result = await verifySessionToken("bad-token");
+    expect(result).toEqual({
+      ok: false,
+      code: "invalid_session",
+      error: "Invalid or expired session token",
+    });
+  });
+
+  it("classifies a revoked partner key as revoked_key", async () => {
+    mockVerifyError(403, "Partner key has been revoked");
+    const result = await verifySessionToken("good-token");
+    expect(result).toEqual({
+      ok: false,
+      code: "revoked_key",
+      error: "Partner key has been revoked",
+    });
+  });
+
+  it("classifies an AgentOnboard 500 as upstream", async () => {
+    mockVerifyError(500, "Internal server error");
+    const result = await verifySessionToken("good-token");
+    expect(result).toEqual({
+      ok: false,
+      code: "upstream",
+      error: "Internal server error",
+    });
+  });
+
+  it("returns an error result when the API is unreachable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new TypeError("fetch failed");
+      }),
+    );
+    const result = await verifySessionToken("good-token");
+    expect(result).toEqual({
+      ok: false,
+      code: "upstream",
+      error: "Network error: cannot reach AgentOnboard",
+    });
+  });
+});
+
+describe("resolveAgentContext", () => {
+  it("returns null when not configured", async () => {
+    optionalEnvMock.mockImplementation(async () => undefined);
+    await expect(resolveAgentContext(makeHeaders("t"))).resolves.toBeNull();
+  });
+
+  it("returns null when no session token header is present", async () => {
+    await expect(resolveAgentContext(makeHeaders())).resolves.toBeNull();
+  });
+
+  it("throws UNAUTHENTICATED when verification fails", async () => {
+    mockVerifyError(401, "Invalid or expired session token");
+    await expect(
+      resolveAgentContext(makeHeaders("bad-token")),
+    ).rejects.toMatchObject({ code: "UNAUTHENTICATED" });
+  });
+
+  it("throws UPSTREAM_UNAVAILABLE when the partner key is revoked", async () => {
+    mockVerifyError(403, "Partner key has been revoked");
+    await expect(
+      resolveAgentContext(makeHeaders("good-token")),
+    ).rejects.toMatchObject({ code: "UPSTREAM_UNAVAILABLE" });
+  });
+
+  it("throws UPSTREAM_UNAVAILABLE on an AgentOnboard upstream failure", async () => {
+    mockVerifyError(500, "Internal server error");
+    await expect(
+      resolveAgentContext(makeHeaders("good-token")),
+    ).rejects.toMatchObject({ code: "UPSTREAM_UNAVAILABLE" });
+  });
+
+  it("throws UPSTREAM_UNAVAILABLE when the AgentOnboard API is unreachable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new TypeError("fetch failed");
+      }),
+    );
+    await expect(
+      resolveAgentContext(makeHeaders("good-token")),
+    ).rejects.toMatchObject({ code: "UPSTREAM_UNAVAILABLE" });
+  });
+
+  it("throws UNAUTHENTICATED with a create-account message when the email has no account", async () => {
+    mockVerifyOk();
+    dbQueryUserMock.findFirst.mockResolvedValue(undefined);
+    await expect(
+      resolveAgentContext(makeHeaders("good-token")),
+    ).rejects.toThrow("No account exists with this email");
+  });
+
+  it("throws UNAUTHENTICATED when the matched user's email is unverified", async () => {
+    mockVerifyOk();
+    dbQueryUserMock.findFirst.mockResolvedValue({
+      ...USER,
+      emailVerified: false,
+    });
+    await expect(
+      resolveAgentContext(makeHeaders("good-token")),
+    ).rejects.toThrow("email on this OpenSEO account is not verified");
+  });
+
+  it("resolves the user's own organization and returns the context", async () => {
+    mockVerifyOk();
+    dbQueryUserMock.findFirst.mockResolvedValue(USER);
+    const context = await resolveAgentContext(makeHeaders("good-token"));
+    expect(getOrCreateDefaultHostedOrganizationMock).toHaveBeenCalledWith(
+      USER.id,
+      expect.any(Function),
+    );
+    expect(context).toEqual({
+      userId: USER.id,
+      userEmail: USER.email,
+      emailVerified: true,
+      organizationId: "org-1",
+    });
+  });
+});

--- a/src/server/agentonboard/agentonboard.ts
+++ b/src/server/agentonboard/agentonboard.ts
@@ -1,0 +1,197 @@
+import { db } from "@/db";
+import { user } from "@/db/schema";
+import { isHostedAuthMode } from "@/lib/auth-mode";
+import { getOrCreateDefaultHostedOrganization } from "@/server/auth/default-hosted-organization";
+import { AppError } from "@/server/lib/errors";
+import {
+  getOptionalEnvValue,
+  getRequiredEnvValue,
+} from "@/server/lib/runtime-env";
+import type { EnsuredUserContext } from "@/middleware/ensure-user/types";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+
+// AgentOnboard (AO) is an identity layer for AI agents. An agent presents a
+// short-lived session token in the `x-session-token` header; we exchange it
+// once against AO's /api/verify and get back the user's AO login email. Email
+// is the join key: we map it to the matching OpenSEO account and serve that
+// account to the agent — with the same permissions the user's own MCP clients
+// have. This file is the hosted-only core shared by the /mcp boundary. See the
+// AgentOnboard Partner Guide for the verify contract and email join-key policy.
+
+const AGENTONBOARD_API_URL = "https://api.ao.aawej.in";
+const SESSION_TOKEN_HEADER = "x-session-token";
+
+// The AO /api/verify response is untrusted cross-boundary data — narrow it
+// with Zod at the trust boundary (same pattern as the OAuth MCP props schema).
+// Success carries `email`; failure carries `error` — never both, so each field
+// is optional and the caller branches on which is present.
+const verifyResponseSchema = z
+  .object({
+    email: z.string().optional(),
+    error: z.string().optional(),
+  })
+  .passthrough();
+
+// Machine-readable classification of an AgentOnboard verification failure, so
+// callers can distinguish "the agent's token is bad" from "our key is broken"
+// without matching on upstream error strings.
+type AgentVerifyFailureCode = "invalid_session" | "revoked_key" | "upstream";
+
+type AgentVerifyResult =
+  | { ok: true; email: string }
+  | { ok: false; code: AgentVerifyFailureCode; error: string };
+
+export function getSessionTokenHeader(): string {
+  return SESSION_TOKEN_HEADER;
+}
+
+// The AgentOnboard path is live only when a partner key is configured AND the
+// deployment is hosted. Hosted is the mode that owns the OAuth'd /mcp server,
+// which is the surface agents target; cloudflare_access / local_noauth opt in
+// later. Unset → the header is ignored and normal auth applies.
+export async function isAgentOnboardConfigured(): Promise<boolean> {
+  if (!isHostedAuthMode(await getOptionalEnvValue("AUTH_MODE"))) {
+    return false;
+  }
+  return Boolean(await getOptionalEnvValue("AGENTONBOARD_PARTNER_KEY"));
+}
+
+// POST {apiUrl}/api/verify — the AgentOnboard partner contract. Returns the
+// user's AO login email on success, or a machine code + reason on failure.
+export async function verifySessionToken(
+  sessionToken: string,
+): Promise<AgentVerifyResult> {
+  const partnerKey = await getRequiredEnvValue("AGENTONBOARD_PARTNER_KEY");
+
+  let response: Response;
+  try {
+    response = await fetch(`${AGENTONBOARD_API_URL}/api/verify`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${partnerKey}`,
+      },
+      body: JSON.stringify({ sessionToken }),
+    });
+  } catch (error) {
+    // Network failure is our problem, not the agent's. The thrown value is
+    // opaque; log it and return a stable classification.
+    console.error("AgentOnboard verify request failed:", error);
+    return {
+      ok: false,
+      code: "upstream",
+      error: "Network error: cannot reach AgentOnboard",
+    };
+  }
+
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    return {
+      ok: false,
+      code: "upstream",
+      error: `Invalid response from AgentOnboard (status ${response.status})`,
+    };
+  }
+
+  const parsed = verifyResponseSchema.safeParse(body);
+  if (response.ok && parsed.success && parsed.data.email) {
+    return { ok: true, email: parsed.data.email };
+  }
+
+  // The contract: 401 = bad/expired session token (the agent's fault);
+  // 403 = partner key revoked (our misconfig); 500 = AO server error.
+  const upstreamError =
+    parsed.success && parsed.data.error
+      ? parsed.data.error
+      : `AgentOnboard returned ${response.status}`;
+
+  if (response.status === 403) {
+    return { ok: false, code: "revoked_key", error: upstreamError };
+  }
+
+  if (response.status >= 500) {
+    return { ok: false, code: "upstream", error: upstreamError };
+  }
+
+  return { ok: false, code: "invalid_session", error: upstreamError };
+}
+
+// The shared core: verify the agent's token, map the AO email to an OpenSEO
+// account, and return the same EnsuredUserContext the rest of the app speaks.
+// Returns null when the request is not an agent request (no session token).
+export async function resolveAgentContext(
+  headers: Headers,
+): Promise<EnsuredUserContext | null> {
+  if (!(await isAgentOnboardConfigured())) {
+    return null;
+  }
+
+  const sessionToken = headers.get(SESSION_TOKEN_HEADER);
+  if (!sessionToken) {
+    return null;
+  }
+
+  const result = await verifySessionToken(sessionToken);
+  if (!result.ok) {
+    // A bad/expired session token is the agent's fault — unauthenticated.
+    if (result.code === "invalid_session") {
+      throw new AppError("UNAUTHENTICATED");
+    }
+    // A revoked partner key (or any AO-server/network failure) is a
+    // server-side problem, not the agent's fault. Log it and fail closed.
+    console.error(
+      result.code === "revoked_key"
+        ? "AgentOnboard partner key has been revoked — rotate it in the partner dashboard"
+        : "AgentOnboard verify upstream failure:",
+      result.error,
+    );
+    throw new AppError("UPSTREAM_UNAVAILABLE", result.error);
+  }
+
+  const agentEmail = result.email;
+  const matchedUser = await db.query.user.findFirst({
+    where: eq(user.email, agentEmail),
+  });
+
+  if (!matchedUser) {
+    // Verify succeeded but there is no OpenSEO account under this email —
+    // the docs' email-mismatch case. Tell the user how to fix it.
+    throw new AppError(
+      "UNAUTHENTICATED",
+      "No account exists with this email. Create an OpenSEO account with the same email you use on AgentOnboard, then try again.",
+    );
+  }
+
+  // An AO-verified email does not prove the OpenSEO email is verified. Fail
+  // closed rather than let an unverified account act through an agent.
+  if (!matchedUser.emailVerified) {
+    throw new AppError(
+      "UNAUTHENTICATED",
+      "The email on this OpenSEO account is not verified. Verify it before using an agent.",
+    );
+  }
+
+  // The agent acts as the user, so it runs in the user's own organization —
+  // mirroring resolveHostedContext. There is no session to read an "active"
+  // org from, so this resolves the user's first-existing membership, or their
+  // default hosted org if none — exactly the hosted resolver's no-session
+  // fallback.
+  const organizationId = await getOrCreateDefaultHostedOrganization(
+    matchedUser.id,
+    (input) =>
+      import("@/lib/auth").then(({ getAuth }) =>
+        getAuth().api.createOrganization({ body: input }),
+      ),
+  );
+
+  return {
+    userId: matchedUser.id,
+    userEmail: agentEmail,
+    // The AO token proves this identity; the user's email is verified.
+    emailVerified: true,
+    organizationId,
+  };
+}


### PR DESCRIPTION
## What this gives you

This PR lets any **AgentOnboard**-connected AI agent call OpenSEO's existing MCP server directly — no MCP client registration, no OAuth consent dance, no API key. The agent sends a short-lived session token and acts as the matching OpenSEO user.

**The agent experience (no setup for the human):**
1. A user tells their agent to "check our keyword rankings on OpenSEO."
2. The agent mints a 5-minute session token with `aon token get` (AgentOnboard CLI).
3. The agent calls `POST /mcp` with `x-session-token: <token>` and runs the standard MCP `tools/list` + `tools/call` handshake.
4. OpenSEO verifies the token once against AgentOnboard's `/api/verify`, maps the AgentOnboard email to the user's OpenSEO account, and serves the request with **exactly the same tools and permissions as that user's own OAuth'd MCP client**.

**What's added:**
- **A new auth path into the existing `/mcp` server.** An additive, header-based entry (`x-session-token`) that synthesizes the same MCP auth context the self-hosted path already uses. It's opt-in and env-gated — set `AGENTONBOARD_PARTNER_KEY` (hosted deployments) and it's live; unset, the header is ignored and the existing OAuth flow is untouched.
- **No new REST API, no changes to server functions, dashboard routes, or existing auth.** This is strictly an additional way into the MCP surface OpenSEO already exposes to agents.
- **Email is the join key.** The returned AgentOnboard email maps to the matching OpenSEO account (unique on email). No matching account → a clear rejection. Unverified email → rejected. The agent runs in the user's own organization.
- **Fail-closed and classified.** Bad/expired token → 401. Revoked partner key or AgentOnboard outage → server-side error (logged), never blamed on the agent. Requests without the header fall through to normal auth.
- **Tests + verified contract.** 23 new tests (service + handler); full suite green. The `/api/verify` contract was exercised against the live AgentOnboard API.

**What it does NOT do (by design):**
- No new endpoints, no agent-visible REST API, no tool-scoping — an AgentOnboard agent is equivalent to the user's own client.
- Agent-call logging is a known follow-up, not in this PR.

### Why this is worth integrating
It's the AgentOnboard distribution channel: agents discover OpenSEO through the AgentOnboard partner directory, and can act on OpenSEO with zero per-agent setup. One integration, any agent.

---

**Testing:** `tsc --noEmit`, `oxlint --type-aware`, `vitest run` (full suite), `knip`, `prettier --check`, and `vite build` all pass. Live `/api/verify` round-trip confirmed against the real AgentOnboard API.
