### PR TITLE
feat(ai): add first-party MiniMax M3 endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,13 @@
 # the in-app SEO agent. Create a key at https://openrouter.ai/settings/keys.
 # OPENROUTER_API_KEY=replace-with-your-openrouter-api-key
 
+# Optional first-party MiniMax route. The defaults are the global Anthropic
+# endpoint with adaptive thinking; use cn and/or openai when required.
+# MINIMAX_API_KEY=replace-with-your-minimax-api-key
+# MINIMAX_REGION=global
+# MINIMAX_API_FORMAT=anthropic
+# MINIMAX_THINKING=adaptive
+
 # Optional in self-hosted modes. Required if you want Google Search Console
 # integration and MCP tools. BETTER_AUTH_SECRET is also required for GSC (it
 # encrypts the stored OAuth tokens). See docs/SELF_HOSTING_GOOGLE_SEARCH_CONSOLE.md.

--- a/.env.selfhost.example
+++ b/.env.selfhost.example
@@ -18,6 +18,10 @@ ACCESS_ALLOWED_EMAILS=
 # SAM, the in-app agent (hidden if unset)
 # OPENROUTER_API_KEY=
 # OPENROUTER_MODEL=
+# MINIMAX_API_KEY=
+# MINIMAX_REGION=global
+# MINIMAX_API_FORMAT=anthropic
+# MINIMAX_THINKING=adaptive
 
 # Your own PostHog product analytics
 # POSTHOG_PUBLIC_KEY=

--- a/compose.yaml
+++ b/compose.yaml
@@ -30,6 +30,10 @@ services:
       # Optional: AI features (SAM, the in-app SEO agent)
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
       - OPENROUTER_MODEL=${OPENROUTER_MODEL:-}
+      - MINIMAX_API_KEY=${MINIMAX_API_KEY:-}
+      - MINIMAX_REGION=${MINIMAX_REGION:-}
+      - MINIMAX_API_FORMAT=${MINIMAX_API_FORMAT:-}
+      - MINIMAX_THINKING=${MINIMAX_THINKING:-}
       - VITE_SHOW_DEVTOOLS=false
     ports:
       - "127.0.0.1:${PORT:-3001}:${PORT:-3001}"

--- a/package.json
+++ b/package.json
@@ -74,6 +74,8 @@
     }
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "3.0.103",
+    "@ai-sdk/openai-compatible": "2.0.62",
     "@ai-sdk/react": "^3.0.211",
     "@better-auth/api-key": "1.6.22",
     "@cloudflare/ai-chat": "^0.10.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,12 @@ importers:
 
   .:
     dependencies:
+      '@ai-sdk/anthropic':
+        specifier: 3.0.103
+        version: 3.0.103(zod@4.3.6)
+      '@ai-sdk/openai-compatible':
+        specifier: 2.0.62
+        version: 2.0.62(zod@4.3.6)
       '@ai-sdk/react':
         specifier: ^3.0.211
         version: 3.0.211(react@19.2.4)(zod@4.3.6)
@@ -250,6 +256,12 @@ importers:
 
 packages:
 
+  '@ai-sdk/anthropic@3.0.103':
+    resolution: {integrity: sha512-aefFtdBHYowKccDaQdf2hX6kvIiqeShaOAPo3DujsaGH7m8lSW5GficJOhMCXpPBBv+4lZnEWrnIIyV5YeouDw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/anthropic@4.0.24':
     resolution: {integrity: sha512-ywMZXK/uOIxUKwo2vaow0kt2XqMjIEeZWBOxif/oDka3294fUDX0gcUESUjPzd8254Fnvz1lRO70gr9LOgLkww==}
     engines: {node: '>=22'}
@@ -264,6 +276,12 @@ packages:
 
   '@ai-sdk/gateway@3.0.134':
     resolution: {integrity: sha512-PfUkQp01EihEyNM6e+nexXmVANiY5KcHMui/MmaHsC4KVVQYh/MwPeOsD3bTPu63e581BKO+AwaPPNmD4x943A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai-compatible@2.0.62':
+    resolution: {integrity: sha512-lRe54zvyIS1a60N8UVhnwKZRI5I+GSV8uhKkPpId+aiKO7z7UgSbNqFmXkBBMD3yc9UrLnQnATV2EQyXNhzEkA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -286,6 +304,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@4.0.40':
+    resolution: {integrity: sha512-OL5IrpUm9Y8Dwy+w/vvFwPotS6m52O9W0op2oXgXdCROMJIBalBI0oro6OIBYkPxvm5Xg02GSkoQN25RlR0bnw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider-utils@5.0.15':
     resolution: {integrity: sha512-dnDM4/fS17qO+D7LxVU4003V1+8ZDEWgG7rPhvcDNNFs269qLx+Jnm2mTf72ejyjdzu+f0J+rKNSLXWjZWzxwA==}
     engines: {node: '>=22'}
@@ -294,6 +318,10 @@ packages:
 
   '@ai-sdk/provider@3.0.10':
     resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@3.0.14':
+    resolution: {integrity: sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==}
     engines: {node: '>=18'}
 
   '@ai-sdk/provider@4.0.4':
@@ -6102,6 +6130,12 @@ packages:
 
 snapshots:
 
+  '@ai-sdk/anthropic@3.0.103(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.14
+      '@ai-sdk/provider-utils': 4.0.40(zod@4.3.6)
+      zod: 4.3.6
+
   '@ai-sdk/anthropic@4.0.24(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 4.0.4
@@ -6120,6 +6154,12 @@ snapshots:
       '@ai-sdk/provider': 3.0.10
       '@ai-sdk/provider-utils': 4.0.30(zod@4.3.6)
       '@vercel/oidc': 3.2.0
+      zod: 4.3.6
+
+  '@ai-sdk/openai-compatible@2.0.62(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.14
+      '@ai-sdk/provider-utils': 4.0.40(zod@4.3.6)
       zod: 4.3.6
 
   '@ai-sdk/openai@4.0.24(zod@4.3.6)':
@@ -6142,6 +6182,13 @@ snapshots:
       eventsource-parser: 3.0.8
       zod: 4.3.6
 
+  '@ai-sdk/provider-utils@4.0.40(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.14
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.8
+      zod: 4.3.6
+
   '@ai-sdk/provider-utils@5.0.15(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 4.0.4
@@ -6152,6 +6199,10 @@ snapshots:
       zod: 4.3.6
 
   '@ai-sdk/provider@3.0.10':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@3.0.14':
     dependencies:
       json-schema: 0.4.0
 

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -50,6 +50,13 @@ declare namespace Cloudflare {
     OPENROUTER_API_KEY?: string;
     // Optional OpenRouter model slug override (defaults in openrouter.ts).
     OPENROUTER_MODEL?: string;
+
+    // Optional first-party MiniMax configuration for the in-app chat agents.
+    // When set, this takes precedence over the routed provider above.
+    MINIMAX_API_KEY?: string;
+    MINIMAX_REGION?: "global" | "cn";
+    MINIMAX_API_FORMAT?: "anthropic" | "openai";
+    MINIMAX_THINKING?: "adaptive" | "disabled";
   }
 }
 

--- a/src/lib/selfhost-preflight.test.ts
+++ b/src/lib/selfhost-preflight.test.ts
@@ -72,6 +72,18 @@ describe("runSelfhostPreflight", () => {
     expect(itemFor(result, "Search Console")?.message).toContain("32");
   });
 
+  it("recognizes a first-party MiniMax chat key", () => {
+    const result = runSelfhostPreflight({
+      AUTH_MODE: "local_noauth",
+      MINIMAX_API_KEY: "test-key",
+    });
+
+    expect(itemFor(result, "AI features")).toMatchObject({
+      level: "ok",
+      message: "MINIMAX_API_KEY set",
+    });
+  });
+
   it("fails hosted mode listing every missing variable", () => {
     const result = runSelfhostPreflight({
       AUTH_MODE: "hosted",

--- a/src/lib/selfhost-preflight.ts
+++ b/src/lib/selfhost-preflight.ts
@@ -195,20 +195,25 @@ function checkOptionalFeatures(env: EnvRecord, items: PreflightItem[]): void {
     });
   }
 
+  const chatProvider = get(env, "MINIMAX_API_KEY")
+    ? "MINIMAX_API_KEY"
+    : get(env, "OPENROUTER_API_KEY")
+      ? "OPENROUTER_API_KEY"
+      : null;
   items.push(
-    get(env, "OPENROUTER_API_KEY")
+    chatProvider
       ? {
           key: "ai",
           name: "AI features",
           level: "ok",
-          message: "OPENROUTER_API_KEY set",
+          message: `${chatProvider} set`,
         }
       : {
           key: "ai",
           name: "AI features",
           level: "info",
           message:
-            "OPENROUTER_API_KEY not set (optional) — SAM, the in-app SEO agent, is disabled.",
+            "No chat provider API key set (optional) — SAM, the in-app SEO agent, is disabled.",
         },
   );
 }

--- a/src/server/features/sam/SamChatAgent.ts
+++ b/src/server/features/sam/SamChatAgent.ts
@@ -22,11 +22,11 @@ import { SamProjectMemoryRepository } from "@/server/features/sam/SamProjectMemo
 import { ProjectRepository } from "@/server/features/projects/repositories/ProjectRepository";
 import { buildSamMcpTools } from "@/server/features/sam/samChatTools";
 import { buildSamSystemPrompt } from "@/server/features/sam/samSystemPrompt";
-import { buildChatAgentModel } from "@/server/lib/openrouter";
 import {
-  getEnvValueSync,
-  isHostedServerAuthMode,
-} from "@/server/lib/runtime-env";
+  buildChatAgentModel,
+  resolveChatAgentConfig,
+} from "@/server/lib/openrouter";
+import { isHostedServerAuthMode } from "@/server/lib/runtime-env";
 import {
   checkUsageCreditsDepleted,
   trackUsageCreditSpend,
@@ -122,14 +122,9 @@ export class SamChatAgent extends Think {
   }
 
   getModel() {
-    const apiKey = getEnvValueSync(this.env, "OPENROUTER_API_KEY");
-    if (!apiKey) {
-      throw new Error("OPENROUTER_API_KEY is required for the SAM agent");
-    }
-    return buildChatAgentModel(
-      apiKey,
-      getEnvValueSync(this.env, "OPENROUTER_MODEL"),
-    );
+    const config = resolveChatAgentConfig(this.env);
+    if (!config) throw new Error("A chat provider API key is required");
+    return buildChatAgentModel(config);
   }
 
   configureSession(session: Session): Session {

--- a/src/server/lib/openrouter.test.ts
+++ b/src/server/lib/openrouter.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildChatAgentModel,
+  MINIMAX_M3_PROFILE,
+  resolveChatAgentConfig,
+} from "./openrouter";
+
+type TestParams = {
+  prompt: unknown[];
+  providerOptions?: Record<string, Record<string, unknown>>;
+};
+
+type TestMiddleware = {
+  transformParams: (options: {
+    type: "stream";
+    params: TestParams;
+    model: unknown;
+  }) => Promise<TestParams>;
+};
+
+type OpenAICompatibleSettings = {
+  name: string;
+  apiKey: string;
+  baseURL: string;
+  includeUsage: boolean;
+  transformRequestBody: (
+    body: Record<string, unknown>,
+  ) => Record<string, unknown>;
+};
+
+const mocks = vi.hoisted(() => {
+  const anthropicModel = { provider: "minimax.anthropic" };
+  const anthropicProvider = vi.fn((_modelId: string) => anthropicModel);
+  const chatModel = vi.fn((_modelId: string) => ({ provider: "minimax" }));
+  const routedModel = vi.fn(() => ({ provider: "routed" }));
+  return {
+    anthropicModel,
+    anthropicProvider,
+    chatModel,
+    createAnthropic: vi.fn(() => anthropicProvider),
+    createOpenAICompatible: vi.fn((_settings: OpenAICompatibleSettings) => ({
+      chatModel,
+    })),
+    createOpenRouter: vi.fn(() => routedModel),
+    routedModel,
+    wrapLanguageModel: vi.fn(
+      ({ model }: { model: unknown; middleware: TestMiddleware }) => model,
+    ),
+  };
+});
+
+vi.mock("cloudflare:workers", () => ({ env: {} }));
+vi.mock("@ai-sdk/anthropic", () => ({
+  createAnthropic: mocks.createAnthropic,
+}));
+vi.mock("@ai-sdk/openai-compatible", () => ({
+  createOpenAICompatible: mocks.createOpenAICompatible,
+}));
+vi.mock("@openrouter/ai-sdk-provider", () => ({
+  createOpenRouter: mocks.createOpenRouter,
+}));
+vi.mock("ai", () => ({
+  wrapLanguageModel: mocks.wrapLanguageModel,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  for (const name of [
+    "MINIMAX_API_KEY",
+    "MINIMAX_REGION",
+    "MINIMAX_API_FORMAT",
+    "MINIMAX_THINKING",
+    "OPENROUTER_API_KEY",
+    "OPENROUTER_MODEL",
+  ]) {
+    vi.stubEnv(name, "");
+  }
+  mocks.anthropicProvider.mockReturnValue(mocks.anthropicModel);
+  mocks.createAnthropic.mockReturnValue(mocks.anthropicProvider);
+  mocks.createOpenAICompatible.mockReturnValue({ chatModel: mocks.chatModel });
+  mocks.createOpenRouter.mockReturnValue(mocks.routedModel);
+});
+
+describe("resolveChatAgentConfig", () => {
+  it("uses the global Anthropic endpoint with adaptive thinking by default", () => {
+    expect(resolveChatAgentConfig({ MINIMAX_API_KEY: "test-key" })).toEqual({
+      kind: "minimax",
+      apiKey: "test-key",
+      region: "global",
+      apiFormat: "anthropic",
+      thinking: "adaptive",
+    });
+  });
+
+  it("supports the CN OpenAI endpoint with thinking disabled", () => {
+    expect(
+      resolveChatAgentConfig({
+        MINIMAX_API_KEY: "test-key",
+        MINIMAX_REGION: "cn",
+        MINIMAX_API_FORMAT: "openai",
+        MINIMAX_THINKING: "disabled",
+      }),
+    ).toMatchObject({
+      kind: "minimax",
+      region: "cn",
+      apiFormat: "openai",
+      thinking: "disabled",
+    });
+  });
+
+  it("rejects unsupported first-party settings", () => {
+    expect(() =>
+      resolveChatAgentConfig({
+        MINIMAX_API_KEY: "test-key",
+        MINIMAX_REGION: "unsupported",
+      }),
+    ).toThrow(/MINIMAX_REGION/);
+  });
+});
+
+describe("buildChatAgentModel", () => {
+  it("configures the global Anthropic endpoint, cache, and adaptive thinking", async () => {
+    buildChatAgentModel({
+      kind: "minimax",
+      apiKey: "test-key",
+      region: "global",
+      apiFormat: "anthropic",
+      thinking: "adaptive",
+    });
+
+    expect(mocks.createAnthropic).toHaveBeenCalledWith({
+      authToken: "test-key",
+      baseURL: "https://api.minimax.io/anthropic/v1",
+      name: "minimax.anthropic",
+    });
+    expect(mocks.anthropicProvider).toHaveBeenCalledWith("MiniMax-M3");
+
+    const middleware = mocks.wrapLanguageModel.mock.calls[0]?.[0].middleware;
+    const transformed = await middleware.transformParams({
+      type: "stream",
+      params: { prompt: [] },
+      model: mocks.anthropicModel,
+    });
+    expect(transformed.providerOptions?.anthropic).toEqual({
+      thinking: { type: "adaptive" },
+      cacheControl: { type: "ephemeral" },
+    });
+  });
+
+  it("configures the CN OpenAI endpoint and disabled thinking request body", () => {
+    buildChatAgentModel({
+      kind: "minimax",
+      apiKey: "test-key",
+      region: "cn",
+      apiFormat: "openai",
+      thinking: "disabled",
+    });
+
+    const settings = mocks.createOpenAICompatible.mock.calls[0]?.[0];
+    expect(settings).toMatchObject({
+      name: "minimax",
+      apiKey: "test-key",
+      baseURL: "https://api.minimaxi.com/v1",
+      includeUsage: true,
+    });
+    expect(settings.transformRequestBody({ messages: [] })).toEqual({
+      messages: [],
+      thinking: { type: "disabled" },
+      reasoning_split: true,
+    });
+    expect(mocks.chatModel).toHaveBeenCalledWith("MiniMax-M3");
+  });
+
+  it("publishes the current context, pricing, cache, and modality metadata", () => {
+    expect(MINIMAX_M3_PROFILE).toMatchObject({
+      contextWindow: 1_000_000,
+      pricingUsdPerMillionTokens: {
+        input: 0.6,
+        output: 2.4,
+        cacheRead: 0.12,
+        cacheWrite: null,
+      },
+      inputModalities: ["text", "image", "video"],
+      thinkingModes: ["adaptive", "disabled"],
+    });
+  });
+});

--- a/src/server/lib/openrouter.ts
+++ b/src/server/lib/openrouter.ts
@@ -1,15 +1,116 @@
+import { createAnthropic } from "@ai-sdk/anthropic";
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import {
   createOpenRouter,
   type LanguageModelV3,
 } from "@openrouter/ai-sdk-provider";
-import {
-  getOptionalEnvValue,
-  getRequiredEnvValue,
-} from "@/server/lib/runtime-env";
+import { wrapLanguageModel } from "ai";
+import { getEnvValueSync, getOptionalEnvValue } from "@/server/lib/runtime-env";
 
 // OpenRouter model slug used for the in-app chat agents (onboarding + SAM).
 // Override with OPENROUTER_MODEL to swap models without a code change.
 const DEFAULT_CHAT_AGENT_MODEL = "minimax/minimax-m3";
+
+export const MINIMAX_M3_PROFILE = {
+  modelId: "MiniMax-M3",
+  contextWindow: 1_000_000,
+  pricingUsdPerMillionTokens: {
+    input: 0.6,
+    output: 2.4,
+    cacheRead: 0.12,
+    cacheWrite: null,
+  },
+  inputModalities: ["text", "image", "video"],
+  thinkingModes: ["adaptive", "disabled"],
+  endpoints: {
+    global: {
+      openai: "https://api.minimax.io/v1",
+      anthropic: "https://api.minimax.io/anthropic",
+    },
+    cn: {
+      openai: "https://api.minimaxi.com/v1",
+      anthropic: "https://api.minimaxi.com/anthropic",
+    },
+  },
+} as const;
+
+type MiniMaxRegion = keyof typeof MINIMAX_M3_PROFILE.endpoints;
+type MiniMaxApiFormat = keyof (typeof MINIMAX_M3_PROFILE.endpoints)["global"];
+type MiniMaxThinking = (typeof MINIMAX_M3_PROFILE.thinkingModes)[number];
+
+export type ChatAgentConfig =
+  | { kind: "routed"; apiKey: string; modelId: string }
+  | {
+      kind: "minimax";
+      apiKey: string;
+      region: MiniMaxRegion;
+      apiFormat: MiniMaxApiFormat;
+      thinking: MiniMaxThinking;
+    };
+
+const CHAT_ENV_NAMES = [
+  "MINIMAX_API_KEY",
+  "MINIMAX_REGION",
+  "MINIMAX_API_FORMAT",
+  "MINIMAX_THINKING",
+  "OPENROUTER_API_KEY",
+  "OPENROUTER_MODEL",
+] as const;
+
+function isChoice<T extends string>(
+  value: string,
+  values: readonly T[],
+): value is T {
+  return values.some((candidate) => candidate === value);
+}
+
+function choice<T extends string>(
+  name: string,
+  value: string | undefined,
+  values: readonly T[],
+  fallback: T,
+): T {
+  if (!value) return fallback;
+  if (isChoice(value, values)) return value;
+  throw new Error(`${name} must be one of: ${values.join(", ")}`);
+}
+
+export function resolveChatAgentConfig(env: object): ChatAgentConfig | null {
+  const read = (name: string) => getEnvValueSync(env, name);
+  const minimaxApiKey = read("MINIMAX_API_KEY");
+  if (minimaxApiKey) {
+    return {
+      kind: "minimax",
+      apiKey: minimaxApiKey,
+      region: choice(
+        "MINIMAX_REGION",
+        read("MINIMAX_REGION"),
+        ["global", "cn"],
+        "global",
+      ),
+      apiFormat: choice(
+        "MINIMAX_API_FORMAT",
+        read("MINIMAX_API_FORMAT"),
+        ["anthropic", "openai"],
+        "anthropic",
+      ),
+      thinking: choice(
+        "MINIMAX_THINKING",
+        read("MINIMAX_THINKING"),
+        MINIMAX_M3_PROFILE.thinkingModes,
+        "adaptive",
+      ),
+    };
+  }
+
+  const routedApiKey = read("OPENROUTER_API_KEY");
+  if (!routedApiKey) return null;
+  return {
+    kind: "routed",
+    apiKey: routedApiKey,
+    modelId: read("OPENROUTER_MODEL") ?? DEFAULT_CHAT_AGENT_MODEL,
+  };
+}
 
 /**
  * Returns the AI SDK LanguageModel for the chat agents. `usage: { include: true }`
@@ -34,9 +135,16 @@ const DEFAULT_CHAT_AGENT_MODEL = "minimax/minimax-m3";
  * is configured.
  */
 export async function getChatAgentModel(): Promise<LanguageModelV3> {
-  const apiKey = await getRequiredEnvValue("OPENROUTER_API_KEY");
-  const modelId = await getOptionalEnvValue("OPENROUTER_MODEL");
-  return buildChatAgentModel(apiKey, modelId);
+  const values = Object.fromEntries(
+    await Promise.all(
+      CHAT_ENV_NAMES.map(
+        async (name) => [name, await getOptionalEnvValue(name)] as const,
+      ),
+    ),
+  );
+  const config = resolveChatAgentConfig(values);
+  if (!config) throw new Error("A chat provider API key is required");
+  return buildChatAgentModel(config);
 }
 
 /**
@@ -44,11 +152,48 @@ export async function getChatAgentModel(): Promise<LanguageModelV3> {
  * `getModel()` hook is sync and runs on every turn, so the SAM agent reads the
  * key/model from its DO env and builds the model here.
  */
-export function buildChatAgentModel(
-  apiKey: string,
-  modelId?: string,
-): LanguageModelV3 {
-  return createOpenRouter({ apiKey })(modelId ?? DEFAULT_CHAT_AGENT_MODEL, {
+export function buildChatAgentModel(config: ChatAgentConfig): LanguageModelV3 {
+  if (config.kind === "minimax") {
+    const endpoints = MINIMAX_M3_PROFILE.endpoints[config.region];
+    if (config.apiFormat === "openai") {
+      return createOpenAICompatible({
+        name: "minimax",
+        apiKey: config.apiKey,
+        baseURL: endpoints.openai,
+        includeUsage: true,
+        transformRequestBody: (body) => ({
+          ...body,
+          thinking: { type: config.thinking },
+          reasoning_split: true,
+        }),
+      }).chatModel(MINIMAX_M3_PROFILE.modelId);
+    }
+
+    const model = createAnthropic({
+      authToken: config.apiKey,
+      baseURL: `${endpoints.anthropic}/v1`,
+      name: "minimax.anthropic",
+    })(MINIMAX_M3_PROFILE.modelId);
+    return wrapLanguageModel({
+      model,
+      middleware: {
+        specificationVersion: "v3",
+        transformParams: async ({ params }) => ({
+          ...params,
+          providerOptions: {
+            ...params.providerOptions,
+            anthropic: {
+              ...params.providerOptions?.anthropic,
+              thinking: { type: config.thinking },
+              cacheControl: { type: "ephemeral" },
+            },
+          },
+        }),
+      },
+    });
+  }
+
+  return createOpenRouter({ apiKey: config.apiKey })(config.modelId, {
     usage: { include: true },
     reasoning: { effort: "medium" },
     provider: {

--- a/src/serverFunctions/samAccess.ts
+++ b/src/serverFunctions/samAccess.ts
@@ -6,8 +6,8 @@ import {
 } from "@/server/lib/runtime-env";
 import { requireProjectContext } from "@/serverFunctions/middleware";
 
-const OPENROUTER_KEY_MISSING_MESSAGE =
-  "OPENROUTER_API_KEY is not set for this deployment yet. Add it to your environment, restart OpenSEO, then confirm here.";
+const CHAT_KEY_MISSING_MESSAGE =
+  "No chat provider API key is set for this deployment yet. Add one to your environment, restart OpenSEO, then confirm here.";
 
 const projectScopedSchema = z.object({ projectId: z.string().min(1) });
 
@@ -27,9 +27,13 @@ export const getSamAccessSetupStatus = createServerFn({ method: "GET" })
       return { enabled: true, errorMessage: null };
     }
 
-    const enabled = Boolean(await getOptionalEnvValue("OPENROUTER_API_KEY"));
+    const [routedKey, minimaxKey] = await Promise.all([
+      getOptionalEnvValue("OPENROUTER_API_KEY"),
+      getOptionalEnvValue("MINIMAX_API_KEY"),
+    ]);
+    const enabled = Boolean(routedKey || minimaxKey);
     return {
       enabled,
-      errorMessage: enabled ? null : OPENROUTER_KEY_MISSING_MESSAGE,
+      errorMessage: enabled ? null : CHAT_KEY_MISSING_MESSAGE,
     };
   });


### PR DESCRIPTION
Reason: parameter-refresh | 2026-08-11 | MiniMax-M3 is active only through OpenRouter with reasoning effort fixed to medium, while the implementation lacks MiniMax global/CN OpenAI/Anthropic endpoint selection and the target M3 context, pricing/cache, image/video input, and adaptive/disabled thinking parameters; open PRs #115 and #159 add only generic OpenAI-compatible base URLs.

## Summary

- Add first-party MiniMax M3 configuration for the global and CN OpenAI- and Anthropic-compatible endpoints.
- Support adaptive or disabled thinking while keeping the existing routed configuration as a fallback.
- Publish the current context window, pricing/cache, and text/image/video input metadata in one tested profile.
- Forward and document the new environment variables for self-hosted deployments.

## Checks

- `pnpm exec vitest run src/lib/selfhost-preflight.test.ts src/server/lib/openrouter.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm exec oxlint . --type-aware`
- `pnpm exec prettier --check .env.example .env.selfhost.example compose.yaml package.json pnpm-lock.yaml src/env.d.ts src/lib/selfhost-preflight.ts src/server/features/sam/SamChatAgent.ts src/server/lib/openrouter.ts src/server/lib/openrouter.test.ts src/serverFunctions/samAccess.ts`
- `git diff --check`
