### PR TITLE
fix(audit): skip Cloudflare's /cdn-cgi/ namespace when crawling

### DIFF
--- a/src/server/lib/audit/url-policy.test.ts
+++ b/src/server/lib/audit/url-policy.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppError } from "@/server/lib/errors";
 import {
+  isCrawlableUrl,
   normalizeAndValidateStartUrl,
   resolveStartUrlRedirects,
 } from "@/server/lib/audit/url-policy";
@@ -132,5 +133,27 @@ describe("resolveStartUrlRedirects", () => {
     ).rejects.toMatchObject({
       code: "CRAWL_TARGET_BLOCKED",
     } satisfies Partial<AppError>);
+  });
+});
+
+describe("isCrawlableUrl", () => {
+  it("accepts ordinary same-site content URLs", () => {
+    expect(isCrawlableUrl("https://example.com/blog/post")).toBe(true);
+  });
+
+  it("rejects Cloudflare's /cdn-cgi/ infrastructure namespace", () => {
+    expect(
+      isCrawlableUrl("https://example.com/cdn-cgi/l/email-protection"),
+    ).toBe(false);
+    expect(isCrawlableUrl("https://example.com/cdn-cgi/challenge")).toBe(false);
+  });
+
+  it("does not reject content paths that merely mention cdn-cgi", () => {
+    expect(isCrawlableUrl("https://example.com/blog/cdn-cgi")).toBe(true);
+  });
+
+  it("rejects non-http schemes and unparsable URLs", () => {
+    expect(isCrawlableUrl("mailto:hello@example.com")).toBe(false);
+    expect(isCrawlableUrl("not a url")).toBe(false);
   });
 });

--- a/src/server/lib/audit/url-policy.ts
+++ b/src/server/lib/audit/url-policy.ts
@@ -187,11 +187,21 @@ async function hostnameResolvesToBlockedAddress(
 }
 
 /**
+ * CDN/proxy infrastructure namespaces that are not site content. Cloudflare
+ * reserves /cdn-cgi/ on every proxied zone and injects links into it (e.g.
+ * the /cdn-cgi/l/email-protection href its Email Address Obfuscation
+ * rewrites mailto: links into), and those URLs 404 when fetched directly —
+ * crawling them only manufactures broken-link false positives. Mainstream
+ * crawlers skip the namespace for the same reason.
+ */
+const INFRASTRUCTURE_PATH_PREFIXES = ["/cdn-cgi/"];
+
+/**
  * Synchronous SSRF check for URLs discovered mid-crawl (links, redirect
  * targets, sitemap entries). Blocks non-http(s) schemes, private/loopback IP
- * literals, and internal hostnames. DNS resolution is only performed for the
- * start URL (see normalizeAndValidateStartUrl); per-link DoH lookups would be
- * prohibitively slow.
+ * literals, internal hostnames, and CDN infrastructure paths. DNS resolution
+ * is only performed for the start URL (see normalizeAndValidateStartUrl);
+ * per-link DoH lookups would be prohibitively slow.
  */
 export function isCrawlableUrl(url: string): boolean {
   let parsed: URL;
@@ -201,6 +211,13 @@ export function isCrawlableUrl(url: string): boolean {
     return false;
   }
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return false;
+  }
+  if (
+    INFRASTRUCTURE_PATH_PREFIXES.some((prefix) =>
+      parsed.pathname.startsWith(prefix),
+    )
+  ) {
     return false;
   }
   return !isBlockedHost(parsed.hostname);


### PR DESCRIPTION
## Problem

Cloudflare reserves the `/cdn-cgi/` path namespace on every proxied zone and injects links into it. The most common case is Email Address Obfuscation, which rewrites `mailto:` links in the served HTML into `<a href="/cdn-cgi/l/email-protection#...">`. That URL 404s when fetched directly, so on any Cloudflare-proxied site with a visible email address an audit currently reports:

- one **critical `broken-internal-link`** finding for every page that renders an email link — on a recent 27-page audit that was 26 of the 31 total findings, and
- one **`broken-page`** finding for the `/cdn-cgi/l/email-protection` target itself.

All false positives: the namespace is CDN infrastructure, not site content, and mainstream crawlers (Screaming Frog, Ahrefs) skip it for the same reason.

## Fix

Add an infrastructure-path exclusion (`/cdn-cgi/`) to `isCrawlableUrl` in `url-policy.ts`. That function is the shared policy gate for both sitemap seeding (`siteAuditWorkflowPhases`) and mid-crawl link queueing (`shouldQueueCrawlLink`), so excluded URLs are never fetched and never get a `page_mirror` row — and since `runFinalizeChecks` only flags broken links whose target was actually crawled (`JOIN page_mirror`), neither issue type can surface. Link edges pointing at the namespace are still recorded; they just never join to a crawled page.

## Tests

Added `isCrawlableUrl` cases: the namespace is rejected, a content path that merely mentions `cdn-cgi` (`/blog/cdn-cgi`) is still allowed, and non-http schemes/unparsable URLs are rejected.

- `vitest run src/server/lib/audit src/server/workflows` — 74 passed (8 files)
- `oxlint --type-aware` — clean on both changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)