### PR TITLE
Add focused Google Analytics dashboard widgets

### DIFF
--- a/src/client/features/dashboard/DashboardPage.tsx
+++ b/src/client/features/dashboard/DashboardPage.tsx
@@ -5,6 +5,8 @@ import { toast } from "sonner";
 import { ChevronLeft, ChevronRight, Check } from "lucide-react";
 import { captureClientEvent } from "@/client/lib/posthog";
 import { Ga4ConnectCard } from "@/client/features/dashboard/Ga4ConnectCard";
+import { Ga4DashboardCards } from "@/client/features/dashboard/Ga4DashboardCards";
+import { shouldShowDashboardGa4 } from "@/client/features/dashboard/ga4Dashboard";
 import {
   computeNextStep,
   isStepDone,
@@ -28,6 +30,7 @@ import {
 import { setProjectDomain } from "@/serverFunctions/projects";
 import { GA4_OAUTH_APP_PENDING } from "@/shared/ga4";
 import type { DashboardHeroStep } from "@/types/schemas/dashboard";
+import { isHostedClientAuthMode } from "@/lib/auth-mode";
 
 const HERO_COPY: Record<
   DashboardHeroStep,
@@ -301,6 +304,12 @@ export function DashboardPage({ projectId }: { projectId: string }) {
   const showBacklinks = activation.domain !== null;
   const gscConnected = activation.gsc.connected;
   const ga4Connected = activation.ga4.connected;
+  const showGa4 = shouldShowDashboardGa4({
+    hosted: isHostedClientAuthMode(),
+    oauthAppPending: GA4_OAUTH_APP_PENDING,
+    connected: ga4Connected,
+    dismissedAt: activation.ga4.cardDismissedAt,
+  });
 
   return (
     <div className="px-4 py-4 pb-24 md:px-6 md:py-6 md:pb-8">
@@ -336,13 +345,17 @@ export function DashboardPage({ projectId }: { projectId: string }) {
               hasData: gscConnected,
               node: <GscCard projectId={projectId} connected={gscConnected} />,
             },
-            ...(!GA4_OAUTH_APP_PENDING &&
-            (ga4Connected || !activation.ga4.cardDismissedAt)
+            ...(showGa4
               ? [
                   {
                     key: "ga4",
                     hasData: ga4Connected,
-                    node: (
+                    node: ga4Connected ? (
+                      <Ga4DashboardCards
+                        projectId={projectId}
+                        connected={ga4Connected}
+                      />
+                    ) : (
                       <Ga4ConnectCard
                         projectId={projectId}
                         connected={ga4Connected}
@@ -380,7 +393,12 @@ export function DashboardPage({ projectId }: { projectId: string }) {
           ]
             .toSorted((a, b) => Number(b.hasData) - Number(a.hasData))
             .map((card) => (
-              <div key={card.key}>{card.node}</div>
+              <div
+                key={card.key}
+                className={card.key === "ga4" ? "contents" : undefined}
+              >
+                {card.node}
+              </div>
             ))}
         </div>
       </div>

--- a/src/client/features/dashboard/DashboardPage.tsx
+++ b/src/client/features/dashboard/DashboardPage.tsx
@@ -6,7 +6,10 @@ import { ChevronLeft, ChevronRight, Check } from "lucide-react";
 import { captureClientEvent } from "@/client/lib/posthog";
 import { Ga4ConnectCard } from "@/client/features/dashboard/Ga4ConnectCard";
 import { Ga4DashboardCards } from "@/client/features/dashboard/Ga4DashboardCards";
-import { shouldShowDashboardGa4 } from "@/client/features/dashboard/ga4Dashboard";
+import {
+  ga4DashboardHasDataForSort,
+  shouldShowDashboardGa4,
+} from "@/client/features/dashboard/ga4Dashboard";
 import {
   computeNextStep,
   isStepDone,
@@ -349,7 +352,10 @@ export function DashboardPage({ projectId }: { projectId: string }) {
               ? [
                   {
                     key: "ga4",
-                    hasData: ga4Connected,
+                    hasData: ga4DashboardHasDataForSort({
+                      gscConnected,
+                      ga4Connected,
+                    }),
                     node: ga4Connected ? (
                       <Ga4DashboardCards
                         projectId={projectId}

--- a/src/client/features/dashboard/Ga4ConversionBreakdownCard.test.ts
+++ b/src/client/features/dashboard/Ga4ConversionBreakdownCard.test.ts
@@ -1,0 +1,66 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { ConversionBreakdownCard } from "./Ga4DashboardCards";
+
+vi.mock("@/serverFunctions/ga4", () => ({
+  getDashboardGa4Summary: vi.fn(),
+}));
+
+function renderCard(
+  input: Partial<Parameters<typeof ConversionBreakdownCard>[0]> = {},
+) {
+  return renderToStaticMarkup(
+    createElement(ConversionBreakdownCard, {
+      events: [],
+      eventTypeCount: 0,
+      limited: false,
+      ...input,
+    }),
+  );
+}
+
+describe("ConversionBreakdownCard", () => {
+  it("keeps long friendly and exact event names visible", () => {
+    const eventName =
+      "form_submit_contact_request_from_google_ads_campaign_landing_page";
+    const markup = renderCard({
+      events: [{ eventName, keyEvents: 12, users: 7 }],
+      eventTypeCount: 1,
+    });
+
+    expect(markup).toContain(
+      "Contact Request From Google Ads Campaign Landing Page form submission",
+    );
+    expect(markup).toContain(eventName);
+    expect(markup).toContain("break-words");
+    expect(markup).toContain("break-all");
+    expect(markup).not.toContain("truncate");
+  });
+
+  it("does not treat a limited empty report as zero conversions", () => {
+    const markup = renderCard({ limited: true });
+
+    expect(markup).toContain(
+      "Google Analytics did not return a complete key-event breakdown",
+    );
+    expect(markup).not.toContain("No key events were recorded");
+  });
+
+  it("uses the true-zero copy for a complete empty report", () => {
+    const markup = renderCard();
+
+    expect(markup).toContain("No key events were recorded for this period.");
+  });
+
+  it("avoids an exact total when Google truncates the breakdown", () => {
+    const markup = renderCard({
+      events: [{ eventName: "purchase", keyEvents: 3, users: 2 }],
+      eventTypeCount: null,
+      limited: true,
+    });
+
+    expect(markup).toContain("more active conversion types exist");
+    expect(markup).not.toContain("of 1 active conversion types");
+  });
+});

--- a/src/client/features/dashboard/Ga4DashboardCards.tsx
+++ b/src/client/features/dashboard/Ga4DashboardCards.tsx
@@ -10,6 +10,7 @@ import {
 import {
   formatGa4Count,
   formatGa4CountWithUnit,
+  formatGa4EventName,
   formatGa4Rate,
   getGa4DashboardViewState,
 } from "@/client/features/dashboard/ga4Dashboard";
@@ -48,6 +49,7 @@ export function Ga4DashboardCards({
     return (
       <div className="contents" aria-busy>
         <Ga4CardSkeleton title="Google Analytics" />
+        <Ga4CardSkeleton title="Conversion breakdown" />
         <Ga4CardSkeleton title="Popular pages & cities" />
       </div>
     );
@@ -122,6 +124,31 @@ export function Ga4DashboardCards({
           </p>
         ) : null}
         {data.limitedData.summary ? <LimitedDataNote /> : null}
+      </CardShell>
+
+      <CardShell title="Conversion breakdown" stamp={GA4_STAMP}>
+        <RankedList
+          heading="What counted as a conversion"
+          empty="No key events were recorded for this period."
+          rows={data.conversionEvents.slice(0, 5).map((event) => ({
+            key: event.eventName,
+            primary: formatGa4EventName(event.eventName),
+            secondary: event.eventName,
+            value: formatGa4CountWithUnit(event.keyEvents, "event"),
+            subvalue: formatGa4CountWithUnit(event.users, "user"),
+          }))}
+        />
+        {data.conversionEventTypeCount > data.conversionEvents.length ? (
+          <p className="mt-3 text-xs text-base-content/55">
+            Showing the top {data.conversionEvents.length} of{" "}
+            {data.conversionEventTypeCount} active conversion types.
+          </p>
+        ) : null}
+        <p className="mt-3 text-[11px] leading-relaxed text-base-content/45">
+          Events can repeat. Analytics users are not unique CRM leads.
+          Conversion rate is the share of sessions with at least one key event.
+        </p>
+        {data.limitedData.conversions ? <LimitedDataNote /> : null}
       </CardShell>
 
       <CardShell title="Popular pages & cities" stamp={GA4_STAMP}>
@@ -231,6 +258,7 @@ function RankedList({
     primary: string;
     secondary?: string;
     value: string;
+    subvalue?: string;
   }>;
 }) {
   return (
@@ -262,8 +290,13 @@ function RankedList({
                   </span>
                 ) : null}
               </span>
-              <span className="shrink-0 tabular-nums text-base-content/65">
-                {row.value}
+              <span className="shrink-0 text-right tabular-nums text-base-content/65">
+                <span className="block">{row.value}</span>
+                {row.subvalue ? (
+                  <span className="block text-xs text-base-content/50">
+                    {row.subvalue}
+                  </span>
+                ) : null}
               </span>
             </li>
           ))}

--- a/src/client/features/dashboard/Ga4DashboardCards.tsx
+++ b/src/client/features/dashboard/Ga4DashboardCards.tsx
@@ -126,30 +126,11 @@ export function Ga4DashboardCards({
         {data.limitedData.summary ? <LimitedDataNote /> : null}
       </CardShell>
 
-      <CardShell title="Conversion breakdown" stamp={GA4_STAMP}>
-        <RankedList
-          heading="What counted as a conversion"
-          empty="No key events were recorded for this period."
-          rows={data.conversionEvents.slice(0, 5).map((event) => ({
-            key: event.eventName,
-            primary: formatGa4EventName(event.eventName),
-            secondary: event.eventName,
-            value: formatGa4CountWithUnit(event.keyEvents, "event"),
-            subvalue: formatGa4CountWithUnit(event.users, "user"),
-          }))}
-        />
-        {data.conversionEventTypeCount > data.conversionEvents.length ? (
-          <p className="mt-3 text-xs text-base-content/55">
-            Showing the top {data.conversionEvents.length} of{" "}
-            {data.conversionEventTypeCount} active conversion types.
-          </p>
-        ) : null}
-        <p className="mt-3 text-[11px] leading-relaxed text-base-content/45">
-          Events can repeat. Analytics users are not unique CRM leads.
-          Conversion rate is the share of sessions with at least one key event.
-        </p>
-        {data.limitedData.conversions ? <LimitedDataNote /> : null}
-      </CardShell>
+      <ConversionBreakdownCard
+        events={data.conversionEvents}
+        eventTypeCount={data.conversionEventTypeCount}
+        limited={data.limitedData.conversions}
+      />
 
       <CardShell title="Popular pages & cities" stamp={GA4_STAMP}>
         <div className="grid gap-5 sm:grid-cols-2">
@@ -177,6 +158,56 @@ export function Ga4DashboardCards({
         ) : null}
       </CardShell>
     </div>
+  );
+}
+
+export function ConversionBreakdownCard({
+  events,
+  eventTypeCount,
+  limited,
+}: {
+  events: Array<{
+    eventName: string;
+    keyEvents: number | null;
+    users: number | null;
+  }>;
+  eventTypeCount: number | null;
+  limited: boolean;
+}) {
+  return (
+    <CardShell title="Conversion breakdown" stamp={GA4_STAMP}>
+      <RankedList
+        heading="What counted as a conversion"
+        empty={
+          limited
+            ? "Google Analytics did not return a complete key-event breakdown for this period."
+            : "No key events were recorded for this period."
+        }
+        rows={events.slice(0, 5).map((event) => ({
+          key: event.eventName,
+          primary: formatGa4EventName(event.eventName),
+          secondary: event.eventName,
+          value: formatGa4CountWithUnit(event.keyEvents, "event"),
+          subvalue: formatGa4CountWithUnit(event.users, "user"),
+          wrapLabels: true,
+        }))}
+      />
+      {eventTypeCount === null && events.length > 0 ? (
+        <p className="mt-3 text-xs text-base-content/55">
+          Showing the top {events.length}; more active conversion types exist.
+        </p>
+      ) : eventTypeCount !== null && eventTypeCount > events.length ? (
+        <p className="mt-3 text-xs text-base-content/55">
+          Showing the top {events.length} of {eventTypeCount} active conversion
+          types.
+        </p>
+      ) : null}
+      <p className="mt-3 text-[11px] leading-relaxed text-base-content/45">
+        Events can repeat. Analytics users are not unique CRM leads. Conversion
+        rate is the share of sessions with at least one key event.
+      </p>
+      {limited ? <LimitedDataNote /> : null}
+    </CardShell>
   );
 }
 
@@ -259,6 +290,7 @@ function RankedList({
     secondary?: string;
     value: string;
     subvalue?: string;
+    wrapLabels?: boolean;
   }>;
 }) {
   return (
@@ -281,11 +313,15 @@ function RankedList({
                 {index + 1}
               </span>
               <span className="min-w-0 flex-1">
-                <span className="block truncate font-medium">
+                <span
+                  className={`block font-medium ${row.wrapLabels ? "break-words" : "truncate"}`}
+                >
                   {row.primary}
                 </span>
                 {row.secondary ? (
-                  <span className="block truncate text-xs text-base-content/50">
+                  <span
+                    className={`block text-xs text-base-content/50 ${row.wrapLabels ? "break-all" : "truncate"}`}
+                  >
                     {row.secondary}
                   </span>
                 ) : null}

--- a/src/client/features/dashboard/Ga4DashboardCards.tsx
+++ b/src/client/features/dashboard/Ga4DashboardCards.tsx
@@ -1,0 +1,257 @@
+import { Link } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
+import {
+  CardShell,
+  moreDetailsClass,
+  PercentDelta,
+  Stat,
+} from "@/client/features/dashboard/cardParts";
+import {
+  formatGa4Count,
+  formatGa4Rate,
+  getGa4DashboardViewState,
+} from "@/client/features/dashboard/ga4Dashboard";
+import { getDashboardGa4Summary } from "@/serverFunctions/ga4";
+
+const FIVE_MINUTES_MS = 5 * 60 * 1_000;
+const ONE_HOUR_MS = 60 * 60 * 1_000;
+const GA4_STAMP = "Google Analytics · all traffic · last 28 complete days";
+
+export function Ga4DashboardCards({
+  projectId,
+  connected,
+}: {
+  projectId: string;
+  connected: boolean;
+}) {
+  const summaryQuery = useQuery({
+    queryKey: ["dashboardGa4Summary", projectId],
+    queryFn: () => getDashboardGa4Summary({ data: { projectId } }),
+    enabled: connected,
+    staleTime: FIVE_MINUTES_MS,
+    gcTime: ONE_HOUR_MS,
+    retry: false,
+    refetchOnWindowFocus: false,
+  });
+  const state = getGa4DashboardViewState({
+    connected,
+    isPending: summaryQuery.isPending,
+    isError: summaryQuery.isError,
+    data: summaryQuery.data,
+  });
+
+  if (state.kind === "hidden") return null;
+
+  if (state.kind === "loading") {
+    return (
+      <div className="contents" aria-busy>
+        <Ga4CardSkeleton title="Google Analytics" />
+        <Ga4CardSkeleton title="Popular pages & cities" />
+      </div>
+    );
+  }
+
+  if (state.kind === "error") {
+    return (
+      <CardShell
+        title="Google Analytics"
+        stamp={GA4_STAMP}
+        action={
+          <SettingsLink projectId={projectId} label="Review connection" />
+        }
+      >
+        <div className="space-y-3">
+          <p className="text-sm text-base-content/70">{state.message}</p>
+          <button
+            type="button"
+            className="btn btn-outline btn-sm"
+            onClick={() => void summaryQuery.refetch()}
+          >
+            Try again
+          </button>
+        </div>
+      </CardShell>
+    );
+  }
+
+  const { data } = state;
+  return (
+    <div className="contents">
+      <CardShell
+        title="Google Analytics"
+        stamp={GA4_STAMP}
+        action={<SettingsLink projectId={projectId} label="Change property" />}
+      >
+        <div className="grid grid-cols-2 gap-3">
+          <Stat
+            label="Visits"
+            value={formatGa4Count(data.metrics.visits)}
+            sub={
+              data.metrics.visits !== null && data.previous.visits !== null ? (
+                <PercentDelta
+                  current={data.metrics.visits}
+                  previous={data.previous.visits}
+                />
+              ) : undefined
+            }
+          />
+          <Stat
+            label="Conversions"
+            value={formatGa4Count(data.metrics.conversions)}
+            sub={
+              data.metrics.conversions !== null &&
+              data.previous.conversions !== null ? (
+                <PercentDelta
+                  current={data.metrics.conversions}
+                  previous={data.previous.conversions}
+                />
+              ) : undefined
+            }
+          />
+          <Stat
+            label="Conversion rate"
+            value={formatGa4Rate(data.metrics.conversionRate)}
+          />
+          <Stat
+            label="Engagement rate"
+            value={formatGa4Rate(data.metrics.engagementRate)}
+          />
+        </div>
+        {state.summaryUnavailable ? (
+          <p className="mt-3 text-xs text-base-content/55">
+            Summary metrics are unavailable for this period.
+          </p>
+        ) : null}
+        {data.limitedData.summary ? <LimitedDataNote /> : null}
+      </CardShell>
+
+      <CardShell title="Popular pages & cities" stamp={GA4_STAMP}>
+        <div className="grid gap-5 sm:grid-cols-2">
+          <RankedList
+            heading="Popular pages"
+            empty={
+              data.limitedData.pages
+                ? "Page data is unavailable for this period."
+                : "No page views were recorded in this period."
+            }
+            rows={data.topPages.slice(0, 3).map((page) => ({
+              key: page.path,
+              primary: page.title,
+              secondary: page.title === page.path ? undefined : page.path,
+              value: formatGa4Count(page.views),
+            }))}
+          />
+          <RankedList
+            heading="Top cities"
+            empty={
+              data.limitedData.cities
+                ? "City data is unavailable for this period."
+                : "No city visits were recorded in this period."
+            }
+            rows={data.topCities.slice(0, 3).map((city) => ({
+              key: city.city,
+              primary: city.city || "Unknown city",
+              value: formatGa4Count(city.visits),
+            }))}
+          />
+        </div>
+        {data.limitedData.pages || data.limitedData.cities ? (
+          <LimitedDataNote />
+        ) : null}
+      </CardShell>
+    </div>
+  );
+}
+
+function Ga4CardSkeleton({ title }: { title: string }) {
+  return (
+    <CardShell title={title} stamp={GA4_STAMP}>
+      <div className="grid grid-cols-2 gap-3">
+        {Array.from({ length: 4 }, (_, index) => (
+          <div key={index} className="skeleton h-16" />
+        ))}
+      </div>
+    </CardShell>
+  );
+}
+
+function SettingsLink({
+  projectId,
+  label,
+}: {
+  projectId: string;
+  label: string;
+}) {
+  return (
+    <Link
+      to="/p/$projectId/settings"
+      params={{ projectId }}
+      hash="google-analytics"
+      className={moreDetailsClass}
+    >
+      {label}
+    </Link>
+  );
+}
+
+function RankedList({
+  heading,
+  empty,
+  rows,
+}: {
+  heading: string;
+  empty: string;
+  rows: Array<{
+    key: string;
+    primary: string;
+    secondary?: string;
+    value: string;
+  }>;
+}) {
+  return (
+    <section className="min-w-0">
+      <h3 className="text-xs font-medium uppercase tracking-wide text-base-content/60">
+        {heading}
+      </h3>
+      {rows.length === 0 ? (
+        <p className="mt-2 text-xs leading-relaxed text-base-content/55">
+          {empty}
+        </p>
+      ) : (
+        <ol className="mt-2 space-y-2">
+          {rows.map((row, index) => (
+            <li
+              key={row.key}
+              className="flex min-w-0 items-start gap-2 text-sm"
+            >
+              <span className="w-3 shrink-0 text-xs tabular-nums text-base-content/40">
+                {index + 1}
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block truncate font-medium">
+                  {row.primary}
+                </span>
+                {row.secondary ? (
+                  <span className="block truncate text-xs text-base-content/50">
+                    {row.secondary}
+                  </span>
+                ) : null}
+              </span>
+              <span className="shrink-0 tabular-nums text-base-content/65">
+                {row.value}
+              </span>
+            </li>
+          ))}
+        </ol>
+      )}
+    </section>
+  );
+}
+
+function LimitedDataNote() {
+  return (
+    <p className="mt-3 text-[11px] leading-relaxed text-base-content/45">
+      Limited data: Google Analytics marked some results as incomplete.
+    </p>
+  );
+}

--- a/src/client/features/dashboard/Ga4DashboardCards.tsx
+++ b/src/client/features/dashboard/Ga4DashboardCards.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { Link } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
 import {
@@ -8,6 +9,7 @@ import {
 } from "@/client/features/dashboard/cardParts";
 import {
   formatGa4Count,
+  formatGa4CountWithUnit,
   formatGa4Rate,
   getGa4DashboardViewState,
 } from "@/client/features/dashboard/ga4Dashboard";
@@ -62,13 +64,10 @@ export function Ga4DashboardCards({
       >
         <div className="space-y-3">
           <p className="text-sm text-base-content/70">{state.message}</p>
-          <button
-            type="button"
-            className="btn btn-outline btn-sm"
-            onClick={() => void summaryQuery.refetch()}
-          >
-            Try again
-          </button>
+          <ReportRetryAction
+            retryAfterSeconds={state.retryAfterSeconds}
+            onRetry={() => void summaryQuery.refetch()}
+          />
         </div>
       </CardShell>
     );
@@ -128,30 +127,21 @@ export function Ga4DashboardCards({
       <CardShell title="Popular pages & cities" stamp={GA4_STAMP}>
         <div className="grid gap-5 sm:grid-cols-2">
           <RankedList
-            heading="Popular pages"
-            empty={
-              data.limitedData.pages
-                ? "Page data is unavailable for this period."
-                : "No page views were recorded in this period."
-            }
+            heading="Popular pages by views"
+            empty="No identifiable page data was returned for this period."
             rows={data.topPages.slice(0, 3).map((page) => ({
               key: page.path,
-              primary: page.title,
-              secondary: page.title === page.path ? undefined : page.path,
-              value: formatGa4Count(page.views),
+              primary: page.path,
+              value: formatGa4CountWithUnit(page.views, "view"),
             }))}
           />
           <RankedList
-            heading="Top cities"
-            empty={
-              data.limitedData.cities
-                ? "City data is unavailable for this period."
-                : "No city visits were recorded in this period."
-            }
+            heading="Top cities by visits"
+            empty="No identifiable city data was returned for this period."
             rows={data.topCities.slice(0, 3).map((city) => ({
               key: city.city,
               primary: city.city || "Unknown city",
-              value: formatGa4Count(city.visits),
+              value: formatGa4CountWithUnit(city.visits, "visit"),
             }))}
           />
         </div>
@@ -160,6 +150,41 @@ export function Ga4DashboardCards({
         ) : null}
       </CardShell>
     </div>
+  );
+}
+
+function ReportRetryAction({
+  retryAfterSeconds,
+  onRetry,
+}: {
+  retryAfterSeconds?: number;
+  onRetry: () => void;
+}) {
+  const [canRetry, setCanRetry] = useState(
+    retryAfterSeconds === undefined || retryAfterSeconds <= 0,
+  );
+
+  useEffect(() => {
+    if (retryAfterSeconds === undefined || retryAfterSeconds <= 0) {
+      setCanRetry(true);
+      return;
+    }
+    setCanRetry(false);
+    const timeout = setTimeout(
+      () => setCanRetry(true),
+      retryAfterSeconds * 1_000,
+    );
+    return () => clearTimeout(timeout);
+  }, [retryAfterSeconds]);
+
+  return canRetry ? (
+    <button type="button" className="btn btn-outline btn-sm" onClick={onRetry}>
+      Try again
+    </button>
+  ) : (
+    <p className="text-xs text-base-content/55">
+      Try again in about {retryAfterSeconds} seconds.
+    </p>
   );
 }
 

--- a/src/client/features/dashboard/ga4Dashboard.test.ts
+++ b/src/client/features/dashboard/ga4Dashboard.test.ts
@@ -45,7 +45,7 @@ describe("getGa4DashboardViewState", () => {
     ).toEqual({ kind: "hidden" });
   });
 
-  it("shows the two-card loading state for a connected project", () => {
+  it("shows the loading state for a connected project", () => {
     expect(
       getGa4DashboardViewState({
         connected: true,

--- a/src/client/features/dashboard/ga4Dashboard.test.ts
+++ b/src/client/features/dashboard/ga4Dashboard.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatGa4Count,
+  formatGa4Rate,
+  getGa4DashboardViewState,
+  shouldShowDashboardGa4,
+  type DashboardGa4Summary,
+} from "./ga4Dashboard";
+
+const summary: Extract<DashboardGa4Summary, { status: "ok" }> = {
+  status: "ok",
+  metrics: {
+    visits: 120,
+    conversions: 8,
+    conversionRate: 0.0667,
+    engagementRate: 0.625,
+  },
+  previous: { visits: 100, conversions: 5 },
+  topPages: [{ title: "Home", path: "/", views: 80 }],
+  topCities: [{ city: "Manila", visits: 30 }],
+  limitedData: { summary: false, pages: false, cities: false },
+};
+
+describe("getGa4DashboardViewState", () => {
+  it("stays hidden when the project is not connected", () => {
+    expect(
+      getGa4DashboardViewState({
+        connected: false,
+        isPending: true,
+        isError: false,
+        data: undefined,
+      }),
+    ).toEqual({ kind: "hidden" });
+  });
+
+  it("shows the two-card loading state for a connected project", () => {
+    expect(
+      getGa4DashboardViewState({
+        connected: true,
+        isPending: true,
+        isError: false,
+        data: undefined,
+      }),
+    ).toEqual({ kind: "loading" });
+  });
+
+  it("shows successful report data", () => {
+    const state = getGa4DashboardViewState({
+      connected: true,
+      isPending: false,
+      isError: false,
+      data: summary,
+    });
+
+    expect(state).toMatchObject({
+      kind: "success",
+      summaryUnavailable: false,
+      pagesEmpty: false,
+      citiesEmpty: false,
+      limited: false,
+    });
+    if (state.kind === "success") {
+      expect(state.data.metrics).toEqual({
+        visits: 120,
+        conversions: 8,
+        conversionRate: 0.0667,
+        engagementRate: 0.625,
+      });
+      expect(state.data.previous).toEqual({ visits: 100, conversions: 5 });
+      expect(state.data.topPages).toEqual([
+        { title: "Home", path: "/", views: 80 },
+      ]);
+      expect(state.data.topCities).toEqual([{ city: "Manila", visits: 30 }]);
+    }
+  });
+
+  it("collapses transport and expected report failures into one recovery state", () => {
+    expect(
+      getGa4DashboardViewState({
+        connected: true,
+        isPending: false,
+        isError: true,
+        data: undefined,
+      }).kind,
+    ).toBe("error");
+    expect(
+      getGa4DashboardViewState({
+        connected: true,
+        isPending: false,
+        isError: false,
+        data: {
+          status: "error",
+          error: {
+            code: "ga4_reconnect_required",
+            message: "Reconnect Google Analytics.",
+          },
+        },
+      }),
+    ).toEqual({
+      kind: "error",
+      message: "Google Analytics access needs to be reconnected.",
+    });
+  });
+
+  it("preserves honest empty and restricted states", () => {
+    const state = getGa4DashboardViewState({
+      connected: true,
+      isPending: false,
+      isError: false,
+      data: {
+        ...summary,
+        metrics: {
+          visits: null,
+          conversions: null,
+          conversionRate: null,
+          engagementRate: null,
+        },
+        topPages: [],
+        topCities: [],
+        limitedData: { summary: true, pages: true, cities: true },
+      },
+    });
+
+    expect(state).toMatchObject({
+      kind: "success",
+      summaryUnavailable: true,
+      pagesEmpty: true,
+      citiesEmpty: true,
+      limited: true,
+    });
+    expect(formatGa4Count(null)).toBe("—");
+    expect(formatGa4Rate(null)).toBe("—");
+  });
+});
+
+describe("shouldShowDashboardGa4", () => {
+  it("shows connected and self-hosted projects during hosted OAuth approval", () => {
+    expect(
+      shouldShowDashboardGa4({
+        hosted: true,
+        oauthAppPending: true,
+        connected: true,
+        dismissedAt: "2026-01-01",
+      }),
+    ).toBe(true);
+    expect(
+      shouldShowDashboardGa4({
+        hosted: false,
+        oauthAppPending: true,
+        connected: false,
+        dismissedAt: "2026-01-01",
+      }),
+    ).toBe(true);
+  });
+
+  it("suppresses only hosted, unconnected projects while approval is pending", () => {
+    expect(
+      shouldShowDashboardGa4({
+        hosted: true,
+        oauthAppPending: true,
+        connected: false,
+        dismissedAt: null,
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowDashboardGa4({
+        hosted: true,
+        oauthAppPending: false,
+        connected: false,
+        dismissedAt: null,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("GA4 metric formatting", () => {
+  it("formats GA4 rates as percentages", () => {
+    expect(formatGa4Rate(0.625)).toBe("62.5%");
+    expect(formatGa4Count(1200)).toBe("1,200");
+  });
+});

--- a/src/client/features/dashboard/ga4Dashboard.test.ts
+++ b/src/client/features/dashboard/ga4Dashboard.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   formatGa4Count,
   formatGa4CountWithUnit,
+  formatGa4EventName,
   formatGa4Rate,
   ga4DashboardHasDataForSort,
   getGa4DashboardViewState,
@@ -20,7 +21,16 @@ const summary: Extract<DashboardGa4Summary, { status: "ok" }> = {
   previous: { visits: 100, conversions: 5 },
   topPages: [{ path: "/", views: 80 }],
   topCities: [{ city: "Manila", visits: 30 }],
-  limitedData: { summary: false, pages: false, cities: false },
+  conversionEvents: [
+    { eventName: "form_submit_contact", keyEvents: 8, users: 6 },
+  ],
+  conversionEventTypeCount: 1,
+  limitedData: {
+    summary: false,
+    pages: false,
+    cities: false,
+    conversions: false,
+  },
 };
 
 describe("getGa4DashboardViewState", () => {
@@ -68,6 +78,10 @@ describe("getGa4DashboardViewState", () => {
       expect(state.data.previous).toEqual({ visits: 100, conversions: 5 });
       expect(state.data.topPages).toEqual([{ path: "/", views: 80 }]);
       expect(state.data.topCities).toEqual([{ city: "Manila", visits: 30 }]);
+      expect(state.data.conversionEvents).toEqual([
+        { eventName: "form_submit_contact", keyEvents: 8, users: 6 },
+      ]);
+      expect(state.data.conversionEventTypeCount).toBe(1);
     }
   });
 
@@ -138,7 +152,14 @@ describe("getGa4DashboardViewState", () => {
         },
         topPages: [],
         topCities: [],
-        limitedData: { summary: true, pages: true, cities: true },
+        conversionEvents: [],
+        conversionEventTypeCount: 0,
+        limitedData: {
+          summary: true,
+          pages: true,
+          cities: true,
+          conversions: true,
+        },
       },
     });
 
@@ -215,5 +236,11 @@ describe("GA4 metric formatting", () => {
     expect(formatGa4CountWithUnit(1, "view")).toBe("1 view");
     expect(formatGa4CountWithUnit(1200, "visit")).toBe("1,200 visits");
     expect(formatGa4CountWithUnit(null, "view")).toBe("—");
+    expect(formatGa4EventName("form_submit_contact")).toBe(
+      "Contact form submission",
+    );
+    expect(formatGa4EventName("form_submit")).toBe("Form submission");
+    expect(formatGa4EventName("phone-click_sales")).toBe("Sales phone click");
+    expect(formatGa4EventName("purchase")).toBe("Purchase");
   });
 });

--- a/src/client/features/dashboard/ga4Dashboard.test.ts
+++ b/src/client/features/dashboard/ga4Dashboard.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   formatGa4Count,
+  formatGa4CountWithUnit,
   formatGa4Rate,
+  ga4DashboardHasDataForSort,
   getGa4DashboardViewState,
   shouldShowDashboardGa4,
   type DashboardGa4Summary,
@@ -16,7 +18,7 @@ const summary: Extract<DashboardGa4Summary, { status: "ok" }> = {
     engagementRate: 0.625,
   },
   previous: { visits: 100, conversions: 5 },
-  topPages: [{ title: "Home", path: "/", views: 80 }],
+  topPages: [{ path: "/", views: 80 }],
   topCities: [{ city: "Manila", visits: 30 }],
   limitedData: { summary: false, pages: false, cities: false },
 };
@@ -55,9 +57,6 @@ describe("getGa4DashboardViewState", () => {
     expect(state).toMatchObject({
       kind: "success",
       summaryUnavailable: false,
-      pagesEmpty: false,
-      citiesEmpty: false,
-      limited: false,
     });
     if (state.kind === "success") {
       expect(state.data.metrics).toEqual({
@@ -67,9 +66,7 @@ describe("getGa4DashboardViewState", () => {
         engagementRate: 0.625,
       });
       expect(state.data.previous).toEqual({ visits: 100, conversions: 5 });
-      expect(state.data.topPages).toEqual([
-        { title: "Home", path: "/", views: 80 },
-      ]);
+      expect(state.data.topPages).toEqual([{ path: "/", views: 80 }]);
       expect(state.data.topCities).toEqual([{ city: "Manila", visits: 30 }]);
     }
   });
@@ -98,7 +95,31 @@ describe("getGa4DashboardViewState", () => {
       }),
     ).toEqual({
       kind: "error",
+      code: "ga4_reconnect_required",
       message: "Google Analytics access needs to be reconnected.",
+    });
+  });
+
+  it("preserves quota retry guidance and suppresses immediate retry", () => {
+    expect(
+      getGa4DashboardViewState({
+        connected: true,
+        isPending: false,
+        isError: false,
+        data: {
+          status: "error",
+          error: {
+            code: "ga4_quota_exhausted",
+            message: "Try later.",
+            retryAfterSeconds: 90,
+          },
+        },
+      }),
+    ).toEqual({
+      kind: "error",
+      code: "ga4_quota_exhausted",
+      message: "Google Analytics is temporarily rate-limited.",
+      retryAfterSeconds: 90,
     });
   });
 
@@ -124,9 +145,6 @@ describe("getGa4DashboardViewState", () => {
     expect(state).toMatchObject({
       kind: "success",
       summaryUnavailable: true,
-      pagesEmpty: true,
-      citiesEmpty: true,
-      limited: true,
     });
     expect(formatGa4Count(null)).toBe("—");
     expect(formatGa4Rate(null)).toBe("—");
@@ -173,9 +191,29 @@ describe("shouldShowDashboardGa4", () => {
   });
 });
 
+describe("GA4 dashboard ordering", () => {
+  it("keeps Analytics with Search performance in mixed connection states", () => {
+    expect(
+      ga4DashboardHasDataForSort({
+        gscConnected: false,
+        ga4Connected: true,
+      }),
+    ).toBe(false);
+    expect(
+      ga4DashboardHasDataForSort({
+        gscConnected: true,
+        ga4Connected: true,
+      }),
+    ).toBe(true);
+  });
+});
+
 describe("GA4 metric formatting", () => {
   it("formats GA4 rates as percentages", () => {
     expect(formatGa4Rate(0.625)).toBe("62.5%");
     expect(formatGa4Count(1200)).toBe("1,200");
+    expect(formatGa4CountWithUnit(1, "view")).toBe("1 view");
+    expect(formatGa4CountWithUnit(1200, "visit")).toBe("1,200 visits");
+    expect(formatGa4CountWithUnit(null, "view")).toBe("—");
   });
 });

--- a/src/client/features/dashboard/ga4Dashboard.ts
+++ b/src/client/features/dashboard/ga4Dashboard.ts
@@ -1,0 +1,138 @@
+import type { DashboardGa4SummaryResult } from "@/serverFunctions/ga4";
+
+type SuccessfulDashboardGa4Summary = Extract<
+  DashboardGa4SummaryResult,
+  { status: "ok" }
+>;
+
+export type DashboardGa4Summary =
+  | Pick<
+      SuccessfulDashboardGa4Summary,
+      | "status"
+      | "metrics"
+      | "previous"
+      | "topPages"
+      | "topCities"
+      | "limitedData"
+    >
+  | Extract<DashboardGa4SummaryResult, { status: "error" }>;
+
+type Ga4DashboardQueryState = {
+  connected: boolean;
+  isPending: boolean;
+  isError: boolean;
+  data: DashboardGa4Summary | undefined;
+};
+
+export type Ga4DashboardViewState =
+  | { kind: "hidden" }
+  | { kind: "loading" }
+  | { kind: "error"; message: string }
+  | {
+      kind: "success";
+      data: Ga4DashboardDisplayData;
+      summaryUnavailable: boolean;
+      pagesEmpty: boolean;
+      citiesEmpty: boolean;
+      limited: boolean;
+    };
+
+export type Ga4DashboardDisplayData = {
+  metrics: {
+    visits: number | null;
+    conversions: number | null;
+    conversionRate: number | null;
+    engagementRate: number | null;
+  };
+  previous: {
+    visits: number | null;
+    conversions: number | null;
+  };
+  topPages: Array<{ title: string; path: string; views: number | null }>;
+  topCities: Array<{ city: string; visits: number | null }>;
+  limitedData: {
+    summary: boolean;
+    pages: boolean;
+    cities: boolean;
+  };
+};
+
+/**
+ * Keeps the component branches deterministic and testable without requiring a
+ * browser DOM. Expected GA4 failures are returned as data, while an unexpected
+ * transport failure still reaches the same single recovery state.
+ */
+export function getGa4DashboardViewState(
+  query: Ga4DashboardQueryState,
+): Ga4DashboardViewState {
+  if (!query.connected) return { kind: "hidden" };
+  if (query.isPending) return { kind: "loading" };
+  if (query.isError || !query.data) {
+    return {
+      kind: "error",
+      message:
+        "We couldn't load Google Analytics data. Review the connection and try again.",
+    };
+  }
+  if (query.data.status === "error") {
+    return {
+      kind: "error",
+      message: recoveryMessage(query.data.error.code),
+    };
+  }
+
+  const response = query.data;
+  const data: Ga4DashboardDisplayData = {
+    metrics: response.metrics,
+    previous: response.previous,
+    topPages: response.topPages,
+    topCities: response.topCities,
+    limitedData: response.limitedData,
+  };
+  return {
+    kind: "success",
+    data,
+    summaryUnavailable: Object.values(data.metrics).every(
+      (value) => value === null,
+    ),
+    pagesEmpty: data.topPages.length === 0,
+    citiesEmpty: data.topCities.length === 0,
+    limited: Object.values(data.limitedData).some(Boolean),
+  };
+}
+
+function recoveryMessage(code: string): string {
+  if (code === "ga4_reconnect_required" || code === "ga4_not_connected") {
+    return "Google Analytics access needs to be reconnected.";
+  }
+  if (code === "ga4_property_inaccessible") {
+    return "This Google Analytics property is no longer accessible.";
+  }
+  return "Google Analytics couldn't return this report. Try again shortly or review the connection.";
+}
+
+export function shouldShowDashboardGa4(input: {
+  hosted: boolean;
+  oauthAppPending: boolean;
+  connected: boolean;
+  dismissedAt: string | null;
+}): boolean {
+  // The pending OAuth approval is a hosted-connect restriction, not a global
+  // GA4 kill switch. Existing connections and self-hosted OAuth keep working.
+  if (input.connected || !input.hosted) return true;
+  if (input.oauthAppPending) return false;
+  return input.dismissedAt === null;
+}
+
+export function formatGa4Count(value: number | null): string {
+  return value === null ? "—" : value.toLocaleString();
+}
+
+export function formatGa4Rate(value: number | null): string {
+  if (value === null) return "—";
+  return value.toLocaleString(undefined, {
+    style: "percent",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 1,
+  });
+}

--- a/src/client/features/dashboard/ga4Dashboard.ts
+++ b/src/client/features/dashboard/ga4Dashboard.ts
@@ -24,38 +24,23 @@ type Ga4DashboardQueryState = {
   data: DashboardGa4Summary | undefined;
 };
 
-export type Ga4DashboardViewState =
+type Ga4DashboardViewState =
   | { kind: "hidden" }
   | { kind: "loading" }
-  | { kind: "error"; message: string }
+  | {
+      kind: "error";
+      message: string;
+      code: string;
+      retryAfterSeconds?: number;
+    }
   | {
       kind: "success";
-      data: Ga4DashboardDisplayData;
+      data: Pick<
+        SuccessfulDashboardGa4Summary,
+        "metrics" | "previous" | "topPages" | "topCities" | "limitedData"
+      >;
       summaryUnavailable: boolean;
-      pagesEmpty: boolean;
-      citiesEmpty: boolean;
-      limited: boolean;
     };
-
-export type Ga4DashboardDisplayData = {
-  metrics: {
-    visits: number | null;
-    conversions: number | null;
-    conversionRate: number | null;
-    engagementRate: number | null;
-  };
-  previous: {
-    visits: number | null;
-    conversions: number | null;
-  };
-  topPages: Array<{ title: string; path: string; views: number | null }>;
-  topCities: Array<{ city: string; visits: number | null }>;
-  limitedData: {
-    summary: boolean;
-    pages: boolean;
-    cities: boolean;
-  };
-};
 
 /**
  * Keeps the component branches deterministic and testable without requiring a
@@ -70,19 +55,25 @@ export function getGa4DashboardViewState(
   if (query.isError || !query.data) {
     return {
       kind: "error",
+      code: "transport_error",
       message:
         "We couldn't load Google Analytics data. Review the connection and try again.",
     };
   }
   if (query.data.status === "error") {
+    const isQuotaError = query.data.error.code === "ga4_quota_exhausted";
     return {
       kind: "error",
+      code: query.data.error.code,
       message: recoveryMessage(query.data.error.code),
+      ...(isQuotaError
+        ? { retryAfterSeconds: query.data.error.retryAfterSeconds ?? 60 }
+        : {}),
     };
   }
 
   const response = query.data;
-  const data: Ga4DashboardDisplayData = {
+  const data = {
     metrics: response.metrics,
     previous: response.previous,
     topPages: response.topPages,
@@ -95,9 +86,6 @@ export function getGa4DashboardViewState(
     summaryUnavailable: Object.values(data.metrics).every(
       (value) => value === null,
     ),
-    pagesEmpty: data.topPages.length === 0,
-    citiesEmpty: data.topCities.length === 0,
-    limited: Object.values(data.limitedData).some(Boolean),
   };
 }
 
@@ -108,7 +96,17 @@ function recoveryMessage(code: string): string {
   if (code === "ga4_property_inaccessible") {
     return "This Google Analytics property is no longer accessible.";
   }
+  if (code === "ga4_quota_exhausted") {
+    return "Google Analytics is temporarily rate-limited.";
+  }
   return "Google Analytics couldn't return this report. Try again shortly or review the connection.";
+}
+
+export function ga4DashboardHasDataForSort(input: {
+  gscConnected: boolean;
+  ga4Connected: boolean;
+}): boolean {
+  return input.gscConnected && input.ga4Connected;
 }
 
 export function shouldShowDashboardGa4(input: {
@@ -126,6 +124,15 @@ export function shouldShowDashboardGa4(input: {
 
 export function formatGa4Count(value: number | null): string {
   return value === null ? "—" : value.toLocaleString();
+}
+
+export function formatGa4CountWithUnit(
+  value: number | null,
+  singularUnit: string,
+): string {
+  if (value === null) return "—";
+  const unit = value === 1 ? singularUnit : `${singularUnit}s`;
+  return `${formatGa4Count(value)} ${unit}`;
 }
 
 export function formatGa4Rate(value: number | null): string {

--- a/src/client/features/dashboard/ga4Dashboard.ts
+++ b/src/client/features/dashboard/ga4Dashboard.ts
@@ -13,6 +13,8 @@ export type DashboardGa4Summary =
       | "previous"
       | "topPages"
       | "topCities"
+      | "conversionEvents"
+      | "conversionEventTypeCount"
       | "limitedData"
     >
   | Extract<DashboardGa4SummaryResult, { status: "error" }>;
@@ -37,7 +39,13 @@ type Ga4DashboardViewState =
       kind: "success";
       data: Pick<
         SuccessfulDashboardGa4Summary,
-        "metrics" | "previous" | "topPages" | "topCities" | "limitedData"
+        | "metrics"
+        | "previous"
+        | "topPages"
+        | "topCities"
+        | "conversionEvents"
+        | "conversionEventTypeCount"
+        | "limitedData"
       >;
       summaryUnavailable: boolean;
     };
@@ -78,6 +86,8 @@ export function getGa4DashboardViewState(
     previous: response.previous,
     topPages: response.topPages,
     topCities: response.topCities,
+    conversionEvents: response.conversionEvents,
+    conversionEventTypeCount: response.conversionEventTypeCount,
     limitedData: response.limitedData,
   };
   return {
@@ -142,4 +152,27 @@ export function formatGa4Rate(value: number | null): string {
     minimumFractionDigits: 0,
     maximumFractionDigits: 1,
   });
+}
+
+function titleCaseGa4EventParts(parts: string[]): string {
+  return parts
+    .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+    .join(" ");
+}
+
+export function formatGa4EventName(eventName: string): string {
+  const parts = eventName
+    .trim()
+    .split(/[_\s-]+/)
+    .filter(Boolean);
+
+  if (parts[0] === "form" && parts[1] === "submit") {
+    const detail = titleCaseGa4EventParts(parts.slice(2));
+    return detail ? `${detail} form submission` : "Form submission";
+  }
+  if (parts[0] === "phone" && parts[1] === "click") {
+    const detail = titleCaseGa4EventParts(parts.slice(2));
+    return detail ? `${detail} phone click` : "Phone click";
+  }
+  return titleCaseGa4EventParts(parts);
 }

--- a/src/client/features/ga4/GoogleAnalyticsConnectionCard.tsx
+++ b/src/client/features/ga4/GoogleAnalyticsConnectionCard.tsx
@@ -88,6 +88,9 @@ export function GoogleAnalyticsConnectionCard({
     void queryClient.invalidateQueries({
       queryKey: ["dashboardActivation", projectId],
     });
+    void queryClient.invalidateQueries({
+      queryKey: ["dashboardGa4Summary", projectId],
+    });
   };
   const setPropertyMutation = useMutation({
     mutationFn: (selected: Ga4PropertySelection) =>

--- a/src/server/features/ga4/services/Ga4DashboardConversionEvents.test.ts
+++ b/src/server/features/ga4/services/Ga4DashboardConversionEvents.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  Ga4BatchRunReportsResponse,
+  Ga4RunReportRequest,
+  Ga4RunReportResponse,
+} from "@/server/lib/ga4Client";
+import { makeGa4Connection } from "./ga4-test-fixtures";
+import { Ga4DashboardSummaryService } from "./Ga4DashboardSummaryService";
+
+const mocks = vi.hoisted(() => ({
+  getByProjectId: vi.fn(),
+  runReport:
+    vi.fn<(request: Ga4RunReportRequest) => Promise<Ga4RunReportResponse>>(),
+  batchRunReports:
+    vi.fn<
+      (requests: Ga4RunReportRequest[]) => Promise<Ga4BatchRunReportsResponse>
+    >(),
+}));
+
+vi.mock("@/server/features/ga4/repositories/Ga4ConnectionRepository", () => ({
+  Ga4ConnectionRepository: { getByProjectId: mocks.getByProjectId },
+}));
+
+vi.mock("@/server/lib/ga4Client", () => ({
+  createGa4DataClient: () => ({ batchRunReports: mocks.batchRunReports }),
+}));
+
+function responseFor(
+  request: Ga4RunReportRequest,
+  rows: Array<[string, string, string]> = [],
+  input: Omit<
+    Ga4RunReportResponse,
+    "dimensionHeaders" | "metricHeaders" | "rows"
+  > = {},
+): Ga4RunReportResponse {
+  return {
+    dimensionHeaders: request.dimensions.map(({ name }) => ({ name })),
+    metricHeaders: request.metrics.map(({ name }) => ({ name })),
+    rows: rows.map(([eventName, keyEvents, users]) => ({
+      dimensionValues: [{ value: eventName }],
+      metricValues: [{ value: keyEvents }, { value: users }],
+    })),
+    rowCount: rows.length,
+    ...input,
+  };
+}
+
+describe("GA4 dashboard conversion events", () => {
+  beforeEach(() => {
+    mocks.getByProjectId.mockResolvedValue(makeGa4Connection());
+    mocks.batchRunReports.mockImplementation(async (requests) => ({
+      reports: await Promise.all(
+        requests.map((request) => mocks.runReport(request)),
+      ),
+    }));
+    mocks.runReport.mockImplementation(async (request) =>
+      request.dimensions[0]?.name === "eventName"
+        ? responseFor(request)
+        : {
+            dimensionHeaders: request.dimensions.map(({ name }) => ({ name })),
+            metricHeaders: request.metrics.map(({ name }) => ({ name })),
+            rowCount: 0,
+          },
+    );
+  });
+
+  it("uses the fifth batch slot for current all-traffic key events", async () => {
+    const result = await Ga4DashboardSummaryService.getDashboardGa4Summary(
+      { projectId: "project_1" },
+      { now: new Date("2026-08-06T15:00:00Z") },
+    );
+
+    const requests = mocks.batchRunReports.mock.calls[0]?.[0];
+    expect(requests).toHaveLength(5);
+    expect(result.period).toEqual({
+      startDate: "2026-07-09",
+      endDate: "2026-08-05",
+      previousStartDate: "2026-06-11",
+      previousEndDate: "2026-07-08",
+    });
+    expect(requests?.[4]).toMatchObject({
+      dateRanges: [{ startDate: "2026-07-09", endDate: "2026-08-05" }],
+      dimensions: [{ name: "eventName" }],
+      metrics: [{ name: "keyEvents" }, { name: "totalUsers" }],
+      limit: "1000",
+      orderBys: [{ metric: { metricName: "keyEvents" }, desc: true }],
+      metricFilter: {
+        filter: {
+          fieldName: "keyEvents",
+          numericFilter: {
+            operation: "GREATER_THAN",
+            value: { doubleValue: 0 },
+          },
+        },
+      },
+    });
+    for (const request of requests ?? []) {
+      expect(request.dimensionFilter).toBeUndefined();
+    }
+  });
+
+  it("returns the top five named event types and the complete active count", async () => {
+    mocks.runReport.mockImplementation(async (request) => {
+      if (request.dimensions[0]?.name !== "eventName") {
+        return {
+          dimensionHeaders: request.dimensions.map(({ name }) => ({ name })),
+          metricHeaders: request.metrics.map(({ name }) => ({ name })),
+          rowCount: 0,
+        };
+      }
+      return responseFor(request, [
+        ["", "100", "10"],
+        ["(not set)", "90", "9"],
+        ["form_submit", "80", "8"],
+        ["phone_click_sales", "70", "7"],
+        ["phone_click_support", "60", "6"],
+        ["purchase", "50", "5"],
+        ["book_demo", "40", "4"],
+        ["email_click", "30", "3"],
+      ]);
+    });
+
+    const result = await Ga4DashboardSummaryService.getDashboardGa4Summary({
+      projectId: "project_1",
+    });
+
+    expect(result.conversionEvents).toEqual([
+      { eventName: "form_submit", keyEvents: 80, users: 8 },
+      { eventName: "phone_click_sales", keyEvents: 70, users: 7 },
+      { eventName: "phone_click_support", keyEvents: 60, users: 6 },
+      { eventName: "purchase", keyEvents: 50, users: 5 },
+      { eventName: "book_demo", keyEvents: 40, users: 4 },
+    ]);
+    expect(result.conversionEventTypeCount).toBe(6);
+  });
+
+  it("preserves conversion report limitations and quota context", async () => {
+    mocks.runReport.mockImplementation(async (request) => {
+      if (request.dimensions[0]?.name !== "eventName") {
+        return {
+          dimensionHeaders: request.dimensions.map(({ name }) => ({ name })),
+          metricHeaders: request.metrics.map(({ name }) => ({ name })),
+          rowCount: 0,
+        };
+      }
+      return responseFor(request, [["form_submit_contact", "5", "3"]], {
+        metadata: { subjectToThresholding: true },
+        propertyQuota: {
+          tokensPerProjectPerHour: { consumed: 5, remaining: 95 },
+        },
+      });
+    });
+
+    const result = await Ga4DashboardSummaryService.getDashboardGa4Summary({
+      projectId: "project_1",
+    });
+
+    expect(result.limitedData.conversions).toBe(true);
+    expect(result.quota.conversions).toMatchObject({
+      reportMetadata: { hasLimitedData: true, subjectToThresholding: true },
+      quota: {
+        tokensPerProjectPerHour: { consumed: 5, remaining: 95 },
+      },
+    });
+  });
+});

--- a/src/server/features/ga4/services/Ga4DashboardConversionEvents.test.ts
+++ b/src/server/features/ga4/services/Ga4DashboardConversionEvents.test.ts
@@ -163,4 +163,29 @@ describe("GA4 dashboard conversion events", () => {
       },
     });
   });
+
+  it("does not claim an exact event-type total when Google truncates rows", async () => {
+    mocks.runReport.mockImplementation(async (request) => {
+      if (request.dimensions[0]?.name !== "eventName") {
+        return {
+          dimensionHeaders: request.dimensions.map(({ name }) => ({ name })),
+          metricHeaders: request.metrics.map(({ name }) => ({ name })),
+          rowCount: 0,
+        };
+      }
+      return responseFor(request, [["form_submit_contact", "5", "3"]], {
+        rowCount: 1_001,
+      });
+    });
+
+    const result = await Ga4DashboardSummaryService.getDashboardGa4Summary({
+      projectId: "project_1",
+    });
+
+    expect(result.conversionEvents).toEqual([
+      { eventName: "form_submit_contact", keyEvents: 5, users: 3 },
+    ]);
+    expect(result.conversionEventTypeCount).toBeNull();
+    expect(result.limitedData.conversions).toBe(true);
+  });
 });

--- a/src/server/features/ga4/services/Ga4DashboardSummaryService.test.ts
+++ b/src/server/features/ga4/services/Ga4DashboardSummaryService.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
+  Ga4BatchRunReportsResponse,
   Ga4RunReportRequest,
   Ga4RunReportResponse,
 } from "@/server/lib/ga4Client";
@@ -15,6 +16,10 @@ const mocks = vi.hoisted(() => ({
   getByProjectId: vi.fn(),
   runReport:
     vi.fn<(request: Ga4RunReportRequest) => Promise<Ga4RunReportResponse>>(),
+  batchRunReports:
+    vi.fn<
+      (requests: Ga4RunReportRequest[]) => Promise<Ga4BatchRunReportsResponse>
+    >(),
 }));
 
 vi.mock("@/server/features/ga4/repositories/Ga4ConnectionRepository", () => ({
@@ -22,7 +27,7 @@ vi.mock("@/server/features/ga4/repositories/Ga4ConnectionRepository", () => ({
 }));
 
 vi.mock("@/server/lib/ga4Client", () => ({
-  createGa4DataClient: () => ({ runReport: mocks.runReport }),
+  createGa4DataClient: () => ({ batchRunReports: mocks.batchRunReports }),
 }));
 
 const connection = makeGa4Connection();
@@ -81,9 +86,14 @@ function listResponse(
 describe("Ga4DashboardSummaryService", () => {
   beforeEach(() => {
     mocks.getByProjectId.mockResolvedValue(connection);
+    mocks.batchRunReports.mockImplementation(async (requests) => ({
+      reports: await Promise.all(
+        requests.map((request) => mocks.runReport(request)),
+      ),
+    }));
   });
 
-  it("starts the four all-traffic reports together for complete local periods", async () => {
+  it("batches four all-traffic reports for complete local periods", async () => {
     const pending: Array<{
       request: Ga4RunReportRequest;
       resolve: (response: Ga4RunReportResponse) => void;
@@ -105,6 +115,8 @@ describe("Ga4DashboardSummaryService", () => {
       report.resolve(responseFor(report.request, { rowCount: 0 }));
     }
     const result = await resultPromise;
+
+    expect(mocks.batchRunReports).toHaveBeenCalledTimes(1);
 
     expect(result.period).toEqual({
       startDate: "2026-07-09",
@@ -138,7 +150,7 @@ describe("Ga4DashboardSummaryService", () => {
       { startDate: "2026-06-11", endDate: "2026-07-08" },
     ]);
     expect(pages).toMatchObject({
-      dimensions: [{ name: "pageTitle" }, { name: "pagePath" }],
+      dimensions: [{ name: "pagePath" }],
       metrics: [{ name: "screenPageViews" }],
       limit: "10",
       orderBys: [{ metric: { metricName: "screenPageViews" }, desc: true }],
@@ -154,13 +166,13 @@ describe("Ga4DashboardSummaryService", () => {
     }
   });
 
-  it("returns previous-period comparisons and shaped top lists", async () => {
+  it("returns previous-period values and shaped top lists", async () => {
     mocks.runReport.mockImplementation(async (request) => {
       const dimension = request.dimensions[0]?.name;
       if (request.dimensions.some(({ name }) => name === "pagePath")) {
         return listResponse(request, [
-          [["SEO guide", "/guides/seo"], "40"],
-          [["Home", "/"], "30"],
+          ["/guides/seo", "40"],
+          ["/", "30"],
         ]);
       }
       if (dimension === "city") {
@@ -186,15 +198,9 @@ describe("Ga4DashboardSummaryService", () => {
       engagementRate: 0.7,
     });
     expect(result.previous).toEqual({ visits: 80, conversions: 5 });
-    expect(result.comparisons.visits).toEqual({
-      current: 100,
-      previous: 80,
-      absoluteChange: 20,
-      percentChange: 0.25,
-    });
     expect(result.topPages).toEqual([
-      { title: "SEO guide", path: "/guides/seo", views: 40 },
-      { title: "Home", path: "/", views: 30 },
+      { path: "/guides/seo", views: 40 },
+      { path: "/", views: 30 },
     ]);
     expect(result.topCities).toEqual([
       { city: "Manila", visits: 25 },
@@ -207,13 +213,13 @@ describe("Ga4DashboardSummaryService", () => {
       const dimension = request.dimensions[0]?.name;
       if (request.dimensions.some(({ name }) => name === "pagePath")) {
         return listResponse(request, [
-          [["Ignored", ""], "100"],
-          [["Ignored", "(not set)"], "90"],
-          [["Ignored", "   "], "80"],
-          [["One", " /one "], "70"],
-          [["(not set)", "/two"], "60"],
-          [["Three", "/three"], "50"],
-          [["Four", "/four"], "40"],
+          ["", "100"],
+          ["(not set)", "90"],
+          ["   ", "80"],
+          [" /one ", "70"],
+          ["/two", "60"],
+          ["/three", "50"],
+          ["/four", "40"],
         ]);
       }
       if (dimension === "city") {
@@ -276,11 +282,6 @@ describe("Ga4DashboardSummaryService", () => {
       { now: new Date("2026-08-06T15:00:00Z") },
     );
 
-    expect(result.comparisons.visits).toMatchObject({
-      current: 0,
-      previous: 0,
-      absoluteChange: 0,
-    });
     expect(result.metrics).toEqual({
       visits: 0,
       conversions: null,
@@ -288,12 +289,6 @@ describe("Ga4DashboardSummaryService", () => {
       engagementRate: 0,
     });
     expect(result.previous).toEqual({ visits: 0, conversions: 0 });
-    expect(result.comparisons.conversions).toEqual({
-      current: null,
-      previous: 0,
-      absoluteChange: null,
-      percentChange: null,
-    });
     expect(result.quota.current.reportMetadata.restrictedMetrics).toEqual([
       { metricName: "keyEvents", restrictedMetricTypes: ["COST_DATA"] },
     ]);
@@ -304,7 +299,7 @@ describe("Ga4DashboardSummaryService", () => {
     mocks.runReport.mockImplementation(async (request) => {
       const dimension = request.dimensions[0]?.name;
       if (request.dimensions.some(({ name }) => name === "pagePath")) {
-        return listResponse(request, [[["Home", "/"], "5"]], {
+        return listResponse(request, [["/", "5"]], {
           metadata: { dataLossFromOtherRow: true },
           propertyQuota: {
             tokensPerDay: { consumed: 3, remaining: 97 },
@@ -365,6 +360,16 @@ describe("Ga4DashboardSummaryService", () => {
       reportMetadata: { hasLimitedData: true, subjectToThresholding: true },
       quota: { tokensPerHour: { consumed: 4, remaining: 96 } },
     });
+  });
+
+  it("rejects a batch response with missing logical reports", async () => {
+    mocks.batchRunReports.mockResolvedValueOnce({ reports: [] });
+
+    await expect(
+      Ga4DashboardSummaryService.getDashboardGa4Summary({
+        projectId: "project_1",
+      }),
+    ).rejects.toMatchObject({ code: "ga4_malformed_response" });
   });
 
   it("maps connection and quota failures to stable reporting errors", async () => {

--- a/src/server/features/ga4/services/Ga4DashboardSummaryService.test.ts
+++ b/src/server/features/ga4/services/Ga4DashboardSummaryService.test.ts
@@ -93,79 +93,6 @@ describe("Ga4DashboardSummaryService", () => {
     }));
   });
 
-  it("batches four all-traffic reports for complete local periods", async () => {
-    const pending: Array<{
-      request: Ga4RunReportRequest;
-      resolve: (response: Ga4RunReportResponse) => void;
-    }> = [];
-    mocks.runReport.mockImplementation(
-      (request) =>
-        new Promise((resolve) => {
-          pending.push({ request, resolve });
-        }),
-    );
-
-    const resultPromise = Ga4DashboardSummaryService.getDashboardGa4Summary(
-      { projectId: "project_1" },
-      { now: new Date("2026-08-06T15:00:00Z") },
-    );
-    await vi.waitFor(() => expect(pending).toHaveLength(4));
-
-    for (const report of pending) {
-      report.resolve(responseFor(report.request, { rowCount: 0 }));
-    }
-    const result = await resultPromise;
-
-    expect(mocks.batchRunReports).toHaveBeenCalledTimes(1);
-
-    expect(result.period).toEqual({
-      startDate: "2026-07-09",
-      endDate: "2026-08-05",
-      previousStartDate: "2026-06-11",
-      previousEndDate: "2026-07-08",
-    });
-    expect(result.property).toEqual({
-      id: "properties/123",
-      displayName: "Example",
-      timeZone: "America/New_York",
-    });
-    const [current, previous, pages, cities] = pending.map(
-      ({ request }) => request,
-    );
-    expect(current).toMatchObject({
-      dateRanges: [{ startDate: "2026-07-09", endDate: "2026-08-05" }],
-      dimensions: [],
-      metrics: [
-        { name: "sessions" },
-        { name: "keyEvents" },
-        { name: "sessionKeyEventRate" },
-        { name: "engagementRate" },
-      ],
-      limit: "1",
-      orderBys: [],
-      keepEmptyRows: false,
-      returnPropertyQuota: true,
-    });
-    expect(previous?.dateRanges).toEqual([
-      { startDate: "2026-06-11", endDate: "2026-07-08" },
-    ]);
-    expect(pages).toMatchObject({
-      dimensions: [{ name: "pagePath" }],
-      metrics: [{ name: "screenPageViews" }],
-      limit: "10",
-      orderBys: [{ metric: { metricName: "screenPageViews" }, desc: true }],
-    });
-    expect(cities).toMatchObject({
-      dimensions: [{ name: "city" }],
-      metrics: [{ name: "sessions" }],
-      limit: "10",
-      orderBys: [{ metric: { metricName: "sessions" }, desc: true }],
-    });
-    for (const reportRequest of pending.map(({ request }) => request)) {
-      expect(reportRequest.dimensionFilter).toBeUndefined();
-    }
-  });
-
   it("returns previous-period values and shaped top lists", async () => {
     mocks.runReport.mockImplementation(async (request) => {
       const dimension = request.dimensions[0]?.name;
@@ -180,6 +107,9 @@ describe("Ga4DashboardSummaryService", () => {
           ["Manila", "25"],
           ["Dallas", "12"],
         ]);
+      }
+      if (dimension === "eventName") {
+        return responseFor(request, { rowCount: 0 });
       }
       return request.dateRanges[0]?.startDate === "2026-07-09"
         ? aggregateResponse(request, ["100", "10", "0.1", "0.7"])
@@ -231,6 +161,9 @@ describe("Ga4DashboardSummaryService", () => {
           ["Cebu", "60"],
           ["Austin", "50"],
         ]);
+      }
+      if (dimension === "eventName") {
+        return responseFor(request, { rowCount: 0 });
       }
       return aggregateResponse(request, ["0", "0", "0", "0"]);
     });
@@ -314,6 +247,9 @@ describe("Ga4DashboardSummaryService", () => {
           },
         });
       }
+      if (dimension === "eventName") {
+        return responseFor(request, { rowCount: 0 });
+      }
       aggregateCall += 1;
       return aggregateResponse(request, ["1", "1", "1", "1"], {
         metadata:
@@ -340,6 +276,7 @@ describe("Ga4DashboardSummaryService", () => {
       summary: true,
       pages: true,
       cities: true,
+      conversions: false,
     });
     expect(result.quota.current).toMatchObject({
       reportMetadata: { hasLimitedData: true, subjectToThresholding: true },

--- a/src/server/features/ga4/services/Ga4DashboardSummaryService.test.ts
+++ b/src/server/features/ga4/services/Ga4DashboardSummaryService.test.ts
@@ -1,0 +1,415 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  Ga4RunReportRequest,
+  Ga4RunReportResponse,
+} from "@/server/lib/ga4Client";
+import {
+  Ga4DataApiError,
+  Ga4ReportError,
+  toSafeGa4ReportErrorDetail,
+} from "@/server/lib/ga4Errors";
+import { makeGa4Connection } from "./ga4-test-fixtures";
+import { Ga4DashboardSummaryService } from "./Ga4DashboardSummaryService";
+
+const mocks = vi.hoisted(() => ({
+  getByProjectId: vi.fn(),
+  runReport:
+    vi.fn<(request: Ga4RunReportRequest) => Promise<Ga4RunReportResponse>>(),
+}));
+
+vi.mock("@/server/features/ga4/repositories/Ga4ConnectionRepository", () => ({
+  Ga4ConnectionRepository: { getByProjectId: mocks.getByProjectId },
+}));
+
+vi.mock("@/server/lib/ga4Client", () => ({
+  createGa4DataClient: () => ({ runReport: mocks.runReport }),
+}));
+
+const connection = makeGa4Connection();
+
+function responseFor(
+  request: Ga4RunReportRequest,
+  input: Omit<Ga4RunReportResponse, "dimensionHeaders" | "metricHeaders"> = {},
+): Ga4RunReportResponse {
+  return {
+    dimensionHeaders: request.dimensions.map(({ name }) => ({ name })),
+    metricHeaders: request.metrics.map(({ name }) => ({ name })),
+    ...input,
+  };
+}
+
+function aggregateResponse(
+  request: Ga4RunReportRequest,
+  values: [string, string, string, string],
+  input: Omit<
+    Ga4RunReportResponse,
+    "dimensionHeaders" | "metricHeaders" | "rows"
+  > = {},
+): Ga4RunReportResponse {
+  return responseFor(request, {
+    rows: [
+      {
+        dimensionValues: [],
+        metricValues: values.map((value) => ({ value })),
+      },
+    ],
+    rowCount: 1,
+    ...input,
+  });
+}
+
+function listResponse(
+  request: Ga4RunReportRequest,
+  rows: Array<[string | string[], string]>,
+  input: Omit<
+    Ga4RunReportResponse,
+    "dimensionHeaders" | "metricHeaders" | "rows"
+  > = {},
+): Ga4RunReportResponse {
+  return responseFor(request, {
+    rows: rows.map(([dimension, metric]) => ({
+      dimensionValues: (Array.isArray(dimension) ? dimension : [dimension]).map(
+        (value) => ({ value }),
+      ),
+      metricValues: [{ value: metric }],
+    })),
+    rowCount: rows.length,
+    ...input,
+  });
+}
+
+describe("Ga4DashboardSummaryService", () => {
+  beforeEach(() => {
+    mocks.getByProjectId.mockResolvedValue(connection);
+  });
+
+  it("starts the four all-traffic reports together for complete local periods", async () => {
+    const pending: Array<{
+      request: Ga4RunReportRequest;
+      resolve: (response: Ga4RunReportResponse) => void;
+    }> = [];
+    mocks.runReport.mockImplementation(
+      (request) =>
+        new Promise((resolve) => {
+          pending.push({ request, resolve });
+        }),
+    );
+
+    const resultPromise = Ga4DashboardSummaryService.getDashboardGa4Summary(
+      { projectId: "project_1" },
+      { now: new Date("2026-08-06T15:00:00Z") },
+    );
+    await vi.waitFor(() => expect(pending).toHaveLength(4));
+
+    for (const report of pending) {
+      report.resolve(responseFor(report.request, { rowCount: 0 }));
+    }
+    const result = await resultPromise;
+
+    expect(result.period).toEqual({
+      startDate: "2026-07-09",
+      endDate: "2026-08-05",
+      previousStartDate: "2026-06-11",
+      previousEndDate: "2026-07-08",
+    });
+    expect(result.property).toEqual({
+      id: "properties/123",
+      displayName: "Example",
+      timeZone: "America/New_York",
+    });
+    const [current, previous, pages, cities] = pending.map(
+      ({ request }) => request,
+    );
+    expect(current).toMatchObject({
+      dateRanges: [{ startDate: "2026-07-09", endDate: "2026-08-05" }],
+      dimensions: [],
+      metrics: [
+        { name: "sessions" },
+        { name: "keyEvents" },
+        { name: "sessionKeyEventRate" },
+        { name: "engagementRate" },
+      ],
+      limit: "1",
+      orderBys: [],
+      keepEmptyRows: false,
+      returnPropertyQuota: true,
+    });
+    expect(previous?.dateRanges).toEqual([
+      { startDate: "2026-06-11", endDate: "2026-07-08" },
+    ]);
+    expect(pages).toMatchObject({
+      dimensions: [{ name: "pageTitle" }, { name: "pagePath" }],
+      metrics: [{ name: "screenPageViews" }],
+      limit: "10",
+      orderBys: [{ metric: { metricName: "screenPageViews" }, desc: true }],
+    });
+    expect(cities).toMatchObject({
+      dimensions: [{ name: "city" }],
+      metrics: [{ name: "sessions" }],
+      limit: "10",
+      orderBys: [{ metric: { metricName: "sessions" }, desc: true }],
+    });
+    for (const reportRequest of pending.map(({ request }) => request)) {
+      expect(reportRequest.dimensionFilter).toBeUndefined();
+    }
+  });
+
+  it("returns previous-period comparisons and shaped top lists", async () => {
+    mocks.runReport.mockImplementation(async (request) => {
+      const dimension = request.dimensions[0]?.name;
+      if (request.dimensions.some(({ name }) => name === "pagePath")) {
+        return listResponse(request, [
+          [["SEO guide", "/guides/seo"], "40"],
+          [["Home", "/"], "30"],
+        ]);
+      }
+      if (dimension === "city") {
+        return listResponse(request, [
+          ["Manila", "25"],
+          ["Dallas", "12"],
+        ]);
+      }
+      return request.dateRanges[0]?.startDate === "2026-07-09"
+        ? aggregateResponse(request, ["100", "10", "0.1", "0.7"])
+        : aggregateResponse(request, ["80", "5", "0.0625", "0.625"]);
+    });
+
+    const result = await Ga4DashboardSummaryService.getDashboardGa4Summary(
+      { projectId: "project_1" },
+      { now: new Date("2026-08-06T15:00:00Z") },
+    );
+
+    expect(result.metrics).toEqual({
+      visits: 100,
+      conversions: 10,
+      conversionRate: 0.1,
+      engagementRate: 0.7,
+    });
+    expect(result.previous).toEqual({ visits: 80, conversions: 5 });
+    expect(result.comparisons.visits).toEqual({
+      current: 100,
+      previous: 80,
+      absoluteChange: 20,
+      percentChange: 0.25,
+    });
+    expect(result.topPages).toEqual([
+      { title: "SEO guide", path: "/guides/seo", views: 40 },
+      { title: "Home", path: "/", views: 30 },
+    ]);
+    expect(result.topCities).toEqual([
+      { city: "Manila", visits: 25 },
+      { city: "Dallas", visits: 12 },
+    ]);
+  });
+
+  it("drops blank and not-set list dimensions before taking three", async () => {
+    mocks.runReport.mockImplementation(async (request) => {
+      const dimension = request.dimensions[0]?.name;
+      if (request.dimensions.some(({ name }) => name === "pagePath")) {
+        return listResponse(request, [
+          [["Ignored", ""], "100"],
+          [["Ignored", "(not set)"], "90"],
+          [["Ignored", "   "], "80"],
+          [["One", " /one "], "70"],
+          [["(not set)", "/two"], "60"],
+          [["Three", "/three"], "50"],
+          [["Four", "/four"], "40"],
+        ]);
+      }
+      if (dimension === "city") {
+        return listResponse(request, [
+          ["(NOT SET)", "100"],
+          ["", "90"],
+          [" Manila ", "80"],
+          ["Dallas", "70"],
+          ["Cebu", "60"],
+          ["Austin", "50"],
+        ]);
+      }
+      return aggregateResponse(request, ["0", "0", "0", "0"]);
+    });
+
+    const result = await Ga4DashboardSummaryService.getDashboardGa4Summary(
+      { projectId: "project_1" },
+      { now: new Date("2026-08-06T15:00:00Z") },
+    );
+
+    expect(result.topPages.map(({ path }) => path)).toEqual([
+      "/one",
+      "/two",
+      "/three",
+    ]);
+    expect(result.topCities.map(({ city }) => city)).toEqual([
+      "Manila",
+      "Dallas",
+      "Cebu",
+    ]);
+  });
+
+  it("uses zero for missing aggregate data while retaining restricted nulls", async () => {
+    let aggregateCall = 0;
+    mocks.runReport.mockImplementation(async (request) => {
+      if (request.dimensions.length > 0) {
+        return responseFor(request, { rowCount: 0 });
+      }
+      aggregateCall += 1;
+      return responseFor(request, {
+        rowCount: 0,
+        metadata:
+          aggregateCall === 1
+            ? {
+                schemaRestrictionResponse: {
+                  activeMetricRestrictions: [
+                    {
+                      metricName: "keyEvents",
+                      restrictedMetricTypes: ["COST_DATA"],
+                    },
+                  ],
+                },
+              }
+            : undefined,
+      });
+    });
+
+    const result = await Ga4DashboardSummaryService.getDashboardGa4Summary(
+      { projectId: "project_1" },
+      { now: new Date("2026-08-06T15:00:00Z") },
+    );
+
+    expect(result.comparisons.visits).toMatchObject({
+      current: 0,
+      previous: 0,
+      absoluteChange: 0,
+    });
+    expect(result.metrics).toEqual({
+      visits: 0,
+      conversions: null,
+      conversionRate: 0,
+      engagementRate: 0,
+    });
+    expect(result.previous).toEqual({ visits: 0, conversions: 0 });
+    expect(result.comparisons.conversions).toEqual({
+      current: null,
+      previous: 0,
+      absoluteChange: null,
+      percentChange: null,
+    });
+    expect(result.quota.current.reportMetadata.restrictedMetrics).toEqual([
+      { metricName: "keyEvents", restrictedMetricTypes: ["COST_DATA"] },
+    ]);
+  });
+
+  it("keeps limitation and quota context on every report section", async () => {
+    let aggregateCall = 0;
+    mocks.runReport.mockImplementation(async (request) => {
+      const dimension = request.dimensions[0]?.name;
+      if (request.dimensions.some(({ name }) => name === "pagePath")) {
+        return listResponse(request, [[["Home", "/"], "5"]], {
+          metadata: { dataLossFromOtherRow: true },
+          propertyQuota: {
+            tokensPerDay: { consumed: 3, remaining: 97 },
+          },
+        });
+      }
+      if (dimension === "city") {
+        return listResponse(request, [["Manila", "4"]], {
+          metadata: { subjectToThresholding: true },
+          propertyQuota: {
+            tokensPerHour: { consumed: 4, remaining: 96 },
+          },
+        });
+      }
+      aggregateCall += 1;
+      return aggregateResponse(request, ["1", "1", "1", "1"], {
+        metadata:
+          aggregateCall === 1
+            ? { subjectToThresholding: true }
+            : {
+                samplingMetadatas: [
+                  { samplesReadCount: "10", samplingSpaceSize: "100" },
+                ],
+              },
+        propertyQuota:
+          aggregateCall === 1
+            ? { concurrentRequests: { consumed: 1, remaining: 9 } }
+            : { tokensPerHour: { consumed: 2, remaining: 98 } },
+      });
+    });
+
+    const result = await Ga4DashboardSummaryService.getDashboardGa4Summary(
+      { projectId: "project_1" },
+      { now: new Date("2026-08-06T15:00:00Z") },
+    );
+
+    expect(result.limitedData).toEqual({
+      summary: true,
+      pages: true,
+      cities: true,
+    });
+    expect(result.quota.current).toMatchObject({
+      reportMetadata: { hasLimitedData: true, subjectToThresholding: true },
+      quota: { concurrentRequests: { consumed: 1, remaining: 9 } },
+    });
+    expect(result.quota.previous).toMatchObject({
+      reportMetadata: {
+        hasLimitedData: true,
+        sampling: [{ samplesReadCount: "10", samplingSpaceSize: "100" }],
+      },
+      quota: { tokensPerHour: { consumed: 2, remaining: 98 } },
+    });
+    expect(result.quota.pages).toMatchObject({
+      reportMetadata: { hasLimitedData: true, dataLossFromOtherRow: true },
+      quota: { tokensPerDay: { consumed: 3, remaining: 97 } },
+    });
+    expect(result.quota.cities).toMatchObject({
+      reportMetadata: { hasLimitedData: true, subjectToThresholding: true },
+      quota: { tokensPerHour: { consumed: 4, remaining: 96 } },
+    });
+  });
+
+  it("maps connection and quota failures to stable reporting errors", async () => {
+    mocks.getByProjectId.mockResolvedValueOnce(null);
+    await expect(
+      Ga4DashboardSummaryService.getDashboardGa4Summary({
+        projectId: "project_1",
+      }),
+    ).rejects.toMatchObject({ code: "ga4_not_connected" });
+
+    mocks.runReport.mockRejectedValueOnce(
+      new Ga4DataApiError(429, "unsafe upstream body", 90),
+    );
+    await expect(
+      Ga4DashboardSummaryService.getDashboardGa4Summary({
+        projectId: "project_1",
+      }),
+    ).rejects.toMatchObject({
+      code: "ga4_quota_exhausted",
+      retryAfterSeconds: 90,
+    });
+  });
+});
+
+describe("toSafeGa4ReportErrorDetail", () => {
+  it("retains only the stable error contract and optional retry hint", () => {
+    expect(
+      toSafeGa4ReportErrorDetail(
+        new Ga4ReportError("ga4_quota_exhausted", "Try later.", 45),
+      ),
+    ).toEqual({
+      code: "ga4_quota_exhausted",
+      message: "Try later.",
+      retryAfterSeconds: 45,
+    });
+  });
+
+  it("does not expose unexpected exception messages", () => {
+    expect(
+      toSafeGa4ReportErrorDetail(
+        new Error("secret-token and raw Google response"),
+      ),
+    ).toEqual({
+      code: "ga4_upstream_unavailable",
+      message: "Google Analytics reporting is temporarily unavailable.",
+    });
+  });
+});

--- a/src/server/features/ga4/services/Ga4DashboardSummaryService.ts
+++ b/src/server/features/ga4/services/Ga4DashboardSummaryService.ts
@@ -223,6 +223,8 @@ async function getDashboardGa4Summary(
     const currentMetrics = aggregateMetrics(current);
     const previousMetrics = aggregateMetrics(previous);
     const conversionEvents = conversionEventBreakdown(conversions);
+    const conversionEventsTruncated =
+      conversions.totalRowCount > conversions.rows.length;
 
     return {
       status: "ok" as const,
@@ -253,14 +255,18 @@ async function getDashboardGa4Summary(
         visits: city.sessions,
       })),
       conversionEvents: conversionEvents.events,
-      conversionEventTypeCount: conversionEvents.totalEventTypes,
+      conversionEventTypeCount: conversionEventsTruncated
+        ? null
+        : conversionEvents.totalEventTypes,
       limitedData: {
         summary:
           current.reportMetadata.hasLimitedData ||
           previous.reportMetadata.hasLimitedData,
         pages: pages.reportMetadata.hasLimitedData,
         cities: cities.reportMetadata.hasLimitedData,
-        conversions: conversions.reportMetadata.hasLimitedData,
+        conversions:
+          conversions.reportMetadata.hasLimitedData ||
+          conversionEventsTruncated,
       },
       quota: {
         current: reportContext(current),

--- a/src/server/features/ga4/services/Ga4DashboardSummaryService.ts
+++ b/src/server/features/ga4/services/Ga4DashboardSummaryService.ts
@@ -7,7 +7,8 @@ import {
   Ga4MalformedResponseError,
   Ga4ReportError,
 } from "@/server/lib/ga4Errors";
-import { previousPeriod } from "./Ga4ReportEnhancements";
+import { buildGa4ReportRequest } from "./Ga4ReportDefinitions";
+import { COMPLETE_REPORT_LIMIT, previousPeriod } from "./Ga4ReportEnhancements";
 import {
   type Ga4Quota,
   type Ga4ReportMetadata,
@@ -24,6 +25,7 @@ const DASHBOARD_METRICS = [
 ] as const;
 const LIST_FETCH_LIMIT = 10;
 const LIST_RESULT_LIMIT = 3;
+const CONVERSION_EVENT_RESULT_LIMIT = 5;
 
 type DashboardMetric = (typeof DASHBOARD_METRICS)[number];
 type DashboardMetricValues = Record<DashboardMetric, number | null>;
@@ -121,6 +123,24 @@ function topCities(report: NormalizedGa4Report) {
     .slice(0, LIST_RESULT_LIMIT);
 }
 
+function conversionEventBreakdown(report: NormalizedGa4Report) {
+  const activeEvents = report.rows.flatMap((row) => {
+    const eventName = row.eventName;
+    if (!isUsefulDimension(eventName)) return [];
+    return [
+      {
+        eventName: eventName.trim(),
+        keyEvents: typeof row.keyEvents === "number" ? row.keyEvents : null,
+        users: typeof row.totalUsers === "number" ? row.totalUsers : null,
+      },
+    ];
+  });
+  return {
+    events: activeEvents.slice(0, CONVERSION_EVENT_RESULT_LIMIT),
+    totalEventTypes: activeEvents.length,
+  };
+}
+
 async function getDashboardGa4Summary(
   input: { projectId: string },
   opts: { now?: Date } = {},
@@ -153,6 +173,14 @@ async function getDashboardGa4Summary(
     dimensions: ["city"],
     metric: "sessions",
   });
+  const conversionEventsRequest = buildGa4ReportRequest({
+    kind: "key_events",
+    ...currentDateRange,
+    channel: "all",
+    breakdown: "event",
+    offset: 0,
+    limit: COMPLETE_REPORT_LIMIT,
+  });
   const client = createGa4DataClient({
     userId: connection.connectedByUserId,
     ga4AccountId: connection.ga4AccountId,
@@ -165,19 +193,22 @@ async function getDashboardGa4Summary(
       previousRequest,
       topPagesRequest,
       topCitiesRequest,
+      conversionEventsRequest,
     ]);
-    if (reports.length !== 4) throw new Ga4MalformedResponseError();
+    if (reports.length !== 5) throw new Ga4MalformedResponseError();
     const [
       currentResponse,
       previousResponse,
       topPagesResponse,
       topCitiesResponse,
+      conversionEventsResponse,
     ] = reports;
     if (
       !currentResponse ||
       !previousResponse ||
       !topPagesResponse ||
-      !topCitiesResponse
+      !topCitiesResponse ||
+      !conversionEventsResponse
     ) {
       throw new Ga4MalformedResponseError();
     }
@@ -185,8 +216,13 @@ async function getDashboardGa4Summary(
     const previous = normalizeGa4Response(previousResponse, previousRequest);
     const pages = normalizeGa4Response(topPagesResponse, topPagesRequest);
     const cities = normalizeGa4Response(topCitiesResponse, topCitiesRequest);
+    const conversions = normalizeGa4Response(
+      conversionEventsResponse,
+      conversionEventsRequest,
+    );
     const currentMetrics = aggregateMetrics(current);
     const previousMetrics = aggregateMetrics(previous);
+    const conversionEvents = conversionEventBreakdown(conversions);
 
     return {
       status: "ok" as const,
@@ -216,18 +252,22 @@ async function getDashboardGa4Summary(
         city: city.city,
         visits: city.sessions,
       })),
+      conversionEvents: conversionEvents.events,
+      conversionEventTypeCount: conversionEvents.totalEventTypes,
       limitedData: {
         summary:
           current.reportMetadata.hasLimitedData ||
           previous.reportMetadata.hasLimitedData,
         pages: pages.reportMetadata.hasLimitedData,
         cities: cities.reportMetadata.hasLimitedData,
+        conversions: conversions.reportMetadata.hasLimitedData,
       },
       quota: {
         current: reportContext(current),
         previous: reportContext(previous),
         pages: reportContext(pages),
         cities: reportContext(cities),
+        conversions: reportContext(conversions),
       },
     };
   } catch (error) {

--- a/src/server/features/ga4/services/Ga4DashboardSummaryService.ts
+++ b/src/server/features/ga4/services/Ga4DashboardSummaryService.ts
@@ -3,8 +3,11 @@ import {
   createGa4DataClient,
   type Ga4RunReportRequest,
 } from "@/server/lib/ga4Client";
-import { Ga4ReportError } from "@/server/lib/ga4Errors";
-import { previousPeriod, comparisonValue } from "./Ga4ReportEnhancements";
+import {
+  Ga4MalformedResponseError,
+  Ga4ReportError,
+} from "@/server/lib/ga4Errors";
+import { previousPeriod } from "./Ga4ReportEnhancements";
 import {
   type Ga4Quota,
   type Ga4ReportMetadata,
@@ -32,7 +35,7 @@ type DashboardReportContext = {
 function reportRequest(input: {
   startDate: string;
   endDate: string;
-  dimensions?: Array<"pageTitle" | "pagePath" | "city">;
+  dimensions?: Array<"pagePath" | "city">;
   metric?: "screenPageViews" | "sessions";
 }): Ga4RunReportRequest {
   const metrics = input.metric ? [input.metric] : [...DASHBOARD_METRICS];
@@ -90,14 +93,10 @@ function topPages(report: NormalizedGa4Report) {
     .flatMap((row) => {
       const pagePath = row.pagePath;
       if (!isUsefulDimension(pagePath)) return [];
-      const pageTitle = isUsefulDimension(row.pageTitle)
-        ? row.pageTitle.trim()
-        : pagePath.trim();
       return [
         {
-          title: pageTitle,
-          pagePath: pagePath.trim(),
-          screenPageViews:
+          path: pagePath.trim(),
+          views:
             typeof row.screenPageViews === "number"
               ? row.screenPageViews
               : null,
@@ -146,7 +145,7 @@ async function getDashboardGa4Summary(
   const previousRequest = reportRequest(previousDateRange);
   const topPagesRequest = reportRequest({
     ...currentDateRange,
-    dimensions: ["pageTitle", "pagePath"],
+    dimensions: ["pagePath"],
     metric: "screenPageViews",
   });
   const topCitiesRequest = reportRequest({
@@ -161,17 +160,27 @@ async function getDashboardGa4Summary(
   });
 
   try {
+    const { reports } = await client.batchRunReports([
+      currentRequest,
+      previousRequest,
+      topPagesRequest,
+      topCitiesRequest,
+    ]);
+    if (reports.length !== 4) throw new Ga4MalformedResponseError();
     const [
       currentResponse,
       previousResponse,
       topPagesResponse,
       topCitiesResponse,
-    ] = await Promise.all([
-      client.runReport(currentRequest),
-      client.runReport(previousRequest),
-      client.runReport(topPagesRequest),
-      client.runReport(topCitiesRequest),
-    ]);
+    ] = reports;
+    if (
+      !currentResponse ||
+      !previousResponse ||
+      !topPagesResponse ||
+      !topCitiesResponse
+    ) {
+      throw new Ga4MalformedResponseError();
+    }
     const current = normalizeGa4Response(currentResponse, currentRequest);
     const previous = normalizeGa4Response(previousResponse, previousRequest);
     const pages = normalizeGa4Response(topPagesResponse, topPagesRequest);
@@ -202,21 +211,7 @@ async function getDashboardGa4Summary(
         visits: previousMetrics.sessions,
         conversions: previousMetrics.keyEvents,
       },
-      comparisons: {
-        visits: comparisonValue(
-          currentMetrics.sessions,
-          previousMetrics.sessions,
-        ),
-        conversions: comparisonValue(
-          currentMetrics.keyEvents,
-          previousMetrics.keyEvents,
-        ),
-      },
-      topPages: topPages(pages).map((page) => ({
-        title: page.title,
-        path: page.pagePath,
-        views: page.screenPageViews,
-      })),
+      topPages: topPages(pages),
       topCities: topCities(cities).map((city) => ({
         city: city.city,
         visits: city.sessions,

--- a/src/server/features/ga4/services/Ga4DashboardSummaryService.ts
+++ b/src/server/features/ga4/services/Ga4DashboardSummaryService.ts
@@ -1,0 +1,246 @@
+import { Ga4ConnectionRepository } from "@/server/features/ga4/repositories/Ga4ConnectionRepository";
+import {
+  createGa4DataClient,
+  type Ga4RunReportRequest,
+} from "@/server/lib/ga4Client";
+import { Ga4ReportError } from "@/server/lib/ga4Errors";
+import { previousPeriod, comparisonValue } from "./Ga4ReportEnhancements";
+import {
+  type Ga4Quota,
+  type Ga4ReportMetadata,
+  type NormalizedGa4Report,
+  normalizeGa4Response,
+} from "./Ga4ReportNormalization";
+import { mapGa4ReportError, resolveGa4DateRange } from "./Ga4ReportingService";
+
+const DASHBOARD_METRICS = [
+  "sessions",
+  "keyEvents",
+  "sessionKeyEventRate",
+  "engagementRate",
+] as const;
+const LIST_FETCH_LIMIT = 10;
+const LIST_RESULT_LIMIT = 3;
+
+type DashboardMetric = (typeof DASHBOARD_METRICS)[number];
+type DashboardMetricValues = Record<DashboardMetric, number | null>;
+type DashboardReportContext = {
+  reportMetadata: Ga4ReportMetadata;
+  quota: Ga4Quota | null;
+};
+
+function reportRequest(input: {
+  startDate: string;
+  endDate: string;
+  dimensions?: Array<"pageTitle" | "pagePath" | "city">;
+  metric?: "screenPageViews" | "sessions";
+}): Ga4RunReportRequest {
+  const metrics = input.metric ? [input.metric] : [...DASHBOARD_METRICS];
+  const dimensions = (input.dimensions ?? []).map((name) => ({ name }));
+  return {
+    dateRanges: [{ startDate: input.startDate, endDate: input.endDate }],
+    dimensions,
+    metrics: metrics.map((name) => ({ name })),
+    offset: "0",
+    limit: String(dimensions.length > 0 ? LIST_FETCH_LIMIT : 1),
+    orderBys:
+      input.metric === undefined
+        ? []
+        : [{ metric: { metricName: input.metric }, desc: true }],
+    keepEmptyRows: false,
+    returnPropertyQuota: true,
+  };
+}
+
+function reportContext(report: NormalizedGa4Report): DashboardReportContext {
+  return {
+    reportMetadata: report.reportMetadata,
+    quota: report.quota,
+  };
+}
+
+function aggregateMetrics(report: NormalizedGa4Report): DashboardMetricValues {
+  const row = report.rows[0];
+  const restricted = new Set(
+    report.reportMetadata.restrictedMetrics.map(({ metricName }) => metricName),
+  );
+  const value = (metric: DashboardMetric): number | null => {
+    if (restricted.has(metric)) return null;
+    const metricValue = row?.[metric];
+    return typeof metricValue === "number" ? metricValue : 0;
+  };
+  return {
+    sessions: value("sessions"),
+    keyEvents: value("keyEvents"),
+    sessionKeyEventRate: value("sessionKeyEventRate"),
+    engagementRate: value("engagementRate"),
+  };
+}
+
+function isUsefulDimension(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.trim() !== "" &&
+    value.trim().toLowerCase() !== "(not set)"
+  );
+}
+
+function topPages(report: NormalizedGa4Report) {
+  return report.rows
+    .flatMap((row) => {
+      const pagePath = row.pagePath;
+      if (!isUsefulDimension(pagePath)) return [];
+      const pageTitle = isUsefulDimension(row.pageTitle)
+        ? row.pageTitle.trim()
+        : pagePath.trim();
+      return [
+        {
+          title: pageTitle,
+          pagePath: pagePath.trim(),
+          screenPageViews:
+            typeof row.screenPageViews === "number"
+              ? row.screenPageViews
+              : null,
+        },
+      ];
+    })
+    .slice(0, LIST_RESULT_LIMIT);
+}
+
+function topCities(report: NormalizedGa4Report) {
+  return report.rows
+    .flatMap((row) => {
+      const city = row.city;
+      if (!isUsefulDimension(city)) return [];
+      return [
+        {
+          city: city.trim(),
+          sessions: typeof row.sessions === "number" ? row.sessions : null,
+        },
+      ];
+    })
+    .slice(0, LIST_RESULT_LIMIT);
+}
+
+async function getDashboardGa4Summary(
+  input: { projectId: string },
+  opts: { now?: Date } = {},
+) {
+  const connection = await Ga4ConnectionRepository.getByProjectId(
+    input.projectId,
+  );
+  if (!connection) {
+    throw new Ga4ReportError(
+      "ga4_not_connected",
+      "Google Analytics is not connected for this project.",
+    );
+  }
+
+  const currentDateRange = resolveGa4DateRange(
+    {},
+    connection.propertyTimeZone,
+    opts.now,
+  ).resolvedDateRange;
+  const previousDateRange = previousPeriod(currentDateRange);
+  const currentRequest = reportRequest(currentDateRange);
+  const previousRequest = reportRequest(previousDateRange);
+  const topPagesRequest = reportRequest({
+    ...currentDateRange,
+    dimensions: ["pageTitle", "pagePath"],
+    metric: "screenPageViews",
+  });
+  const topCitiesRequest = reportRequest({
+    ...currentDateRange,
+    dimensions: ["city"],
+    metric: "sessions",
+  });
+  const client = createGa4DataClient({
+    userId: connection.connectedByUserId,
+    ga4AccountId: connection.ga4AccountId,
+    propertyId: connection.propertyId,
+  });
+
+  try {
+    const [
+      currentResponse,
+      previousResponse,
+      topPagesResponse,
+      topCitiesResponse,
+    ] = await Promise.all([
+      client.runReport(currentRequest),
+      client.runReport(previousRequest),
+      client.runReport(topPagesRequest),
+      client.runReport(topCitiesRequest),
+    ]);
+    const current = normalizeGa4Response(currentResponse, currentRequest);
+    const previous = normalizeGa4Response(previousResponse, previousRequest);
+    const pages = normalizeGa4Response(topPagesResponse, topPagesRequest);
+    const cities = normalizeGa4Response(topCitiesResponse, topCitiesRequest);
+    const currentMetrics = aggregateMetrics(current);
+    const previousMetrics = aggregateMetrics(previous);
+
+    return {
+      status: "ok" as const,
+      period: {
+        startDate: currentDateRange.startDate,
+        endDate: currentDateRange.endDate,
+        previousStartDate: previousDateRange.startDate,
+        previousEndDate: previousDateRange.endDate,
+      },
+      property: {
+        id: connection.propertyId,
+        displayName: connection.propertyDisplayName,
+        timeZone: connection.propertyTimeZone,
+      },
+      metrics: {
+        visits: currentMetrics.sessions,
+        conversions: currentMetrics.keyEvents,
+        conversionRate: currentMetrics.sessionKeyEventRate,
+        engagementRate: currentMetrics.engagementRate,
+      },
+      previous: {
+        visits: previousMetrics.sessions,
+        conversions: previousMetrics.keyEvents,
+      },
+      comparisons: {
+        visits: comparisonValue(
+          currentMetrics.sessions,
+          previousMetrics.sessions,
+        ),
+        conversions: comparisonValue(
+          currentMetrics.keyEvents,
+          previousMetrics.keyEvents,
+        ),
+      },
+      topPages: topPages(pages).map((page) => ({
+        title: page.title,
+        path: page.pagePath,
+        views: page.screenPageViews,
+      })),
+      topCities: topCities(cities).map((city) => ({
+        city: city.city,
+        visits: city.sessions,
+      })),
+      limitedData: {
+        summary:
+          current.reportMetadata.hasLimitedData ||
+          previous.reportMetadata.hasLimitedData,
+        pages: pages.reportMetadata.hasLimitedData,
+        cities: cities.reportMetadata.hasLimitedData,
+      },
+      quota: {
+        current: reportContext(current),
+        previous: reportContext(previous),
+        pages: reportContext(pages),
+        cities: reportContext(cities),
+      },
+    };
+  } catch (error) {
+    mapGa4ReportError(error);
+  }
+}
+
+export const Ga4DashboardSummaryService = { getDashboardGa4Summary };
+export type DashboardGa4Summary = Awaited<
+  ReturnType<typeof getDashboardGa4Summary>
+>;

--- a/src/server/lib/ga4Client.errors.test.ts
+++ b/src/server/lib/ga4Client.errors.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createGa4DataClient } from "./ga4Client";
+import { Ga4DataApiError, Ga4MalformedResponseError } from "./ga4Errors";
+
+const mocks = vi.hoisted(() => ({
+  getAccessToken: vi.fn(),
+  fetch: vi.fn<typeof fetch>(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  getAuth: () => ({ api: { getAccessToken: mocks.getAccessToken } }),
+}));
+
+const reportRequest = {
+  dateRanges: [{ startDate: "2026-07-01", endDate: "2026-07-28" }],
+  dimensions: [{ name: "hostName" }],
+  metrics: [{ name: "sessions" }],
+  offset: "0",
+  limit: "100",
+  orderBys: [{ metric: { metricName: "sessions" }, desc: true }],
+  keepEmptyRows: false as const,
+  returnPropertyQuota: true as const,
+};
+
+function dataClient(propertyId = "properties/123") {
+  return createGa4DataClient({
+    userId: "user_1",
+    ga4AccountId: "account_1",
+    propertyId,
+  });
+}
+
+describe("ga4Client data API errors", () => {
+  beforeEach(() => {
+    mocks.getAccessToken.mockResolvedValue({ accessToken: "token" });
+    vi.stubGlobal("fetch", mocks.fetch);
+  });
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("classifies quota failures and retains a safe retry delay", async () => {
+    mocks.fetch.mockResolvedValue(
+      new Response('{"error":{"message":"private upstream detail"}}', {
+        status: 429,
+        headers: { "retry-after": "120" },
+      }),
+    );
+    const promise = dataClient().runReport(reportRequest);
+
+    await expect(promise).rejects.toBeInstanceOf(Ga4DataApiError);
+    await expect(promise).rejects.toMatchObject({
+      status: 429,
+      retryAfterSeconds: 120,
+    });
+  });
+
+  it("retains only safe Google error categories from a rejected request", async () => {
+    mocks.fetch.mockResolvedValue(
+      Response.json(
+        {
+          error: {
+            message: "contains project-specific private detail",
+            status: "PERMISSION_DENIED",
+            details: [
+              {
+                reason: "SERVICE_DISABLED",
+                metadata: { service: "analyticsdata.googleapis.com" },
+              },
+            ],
+          },
+        },
+        { status: 403 },
+      ),
+    );
+
+    await expect(dataClient().runReport(reportRequest)).rejects.toMatchObject({
+      status: 403,
+      upstreamReason: "SERVICE_DISABLED",
+    });
+  });
+
+  it("rejects malformed successful responses", async () => {
+    mocks.fetch.mockResolvedValue(Response.json({ rows: "not-an-array" }));
+
+    await expect(dataClient().runReport(reportRequest)).rejects.toBeInstanceOf(
+      Ga4MalformedResponseError,
+    );
+  });
+
+  it("rejects a non-canonical property identifier before fetching", () => {
+    expect(() => dataClient("123")).toThrow();
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+
+  it("converts transport failures to a typed upstream error", async () => {
+    mocks.fetch.mockRejectedValue(new TypeError("DNS failure"));
+
+    await expect(dataClient().runReport(reportRequest)).rejects.toMatchObject({
+      status: 0,
+    });
+  });
+});

--- a/src/server/lib/ga4Client.test.ts
+++ b/src/server/lib/ga4Client.test.ts
@@ -1,11 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createGa4AdminClient, createGa4DataClient } from "./ga4Client";
-import {
-  Ga4AdminApiError,
-  Ga4DataApiError,
-  Ga4MalformedResponseError,
-  Ga4TokenError,
-} from "./ga4Errors";
+import { Ga4AdminApiError, Ga4TokenError } from "./ga4Errors";
 
 const mocks = vi.hoisted(() => ({
   getAccessToken: vi.fn(),
@@ -304,6 +299,41 @@ describe("ga4Client data API", () => {
     );
   });
 
+  it("posts multiple logical reports through one property batch request", async () => {
+    mocks.fetch.mockResolvedValue(
+      Response.json({
+        reports: [
+          {
+            metricHeaders: [{ name: "sessions", type: "TYPE_INTEGER" }],
+            rows: [{ metricValues: [{ value: "12" }] }],
+            rowCount: 1,
+          },
+          {
+            metricHeaders: [{ name: "sessions", type: "TYPE_INTEGER" }],
+            rowCount: 0,
+          },
+        ],
+      }),
+    );
+    const requests = [reportRequest, reportRequest];
+
+    const result = await createGa4DataClient({
+      userId: "user_1",
+      ga4AccountId: "account_1",
+      propertyId: "properties/123",
+    }).batchRunReports(requests);
+
+    expect(result.reports).toHaveLength(2);
+    expect(mocks.fetch).toHaveBeenCalledWith(
+      "https://analyticsdata.googleapis.com/v1beta/properties/123:batchRunReports",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ requests }),
+      }),
+    );
+    expect(mocks.fetch).toHaveBeenCalledTimes(1);
+  });
+
   it("reuses one token promise for concurrent reports on the same client", async () => {
     mocks.fetch.mockImplementation(async () =>
       Response.json({
@@ -325,88 +355,5 @@ describe("ga4Client data API", () => {
 
     expect(mocks.fetch).toHaveBeenCalledTimes(2);
     expect(mocks.getAccessToken).toHaveBeenCalledTimes(1);
-  });
-
-  it("classifies quota failures and retains a safe retry delay", async () => {
-    mocks.fetch.mockResolvedValue(
-      new Response('{"error":{"message":"private upstream detail"}}', {
-        status: 429,
-        headers: { "retry-after": "120" },
-      }),
-    );
-    const promise = createGa4DataClient({
-      userId: "user_1",
-      ga4AccountId: "account_1",
-      propertyId: "properties/123",
-    }).runReport(reportRequest);
-
-    await expect(promise).rejects.toBeInstanceOf(Ga4DataApiError);
-    await expect(promise).rejects.toMatchObject({
-      status: 429,
-      retryAfterSeconds: 120,
-    });
-  });
-
-  it("retains only safe Google error categories from a rejected request", async () => {
-    mocks.fetch.mockResolvedValue(
-      Response.json(
-        {
-          error: {
-            message: "contains project-specific private detail",
-            status: "PERMISSION_DENIED",
-            details: [
-              {
-                reason: "SERVICE_DISABLED",
-                metadata: { service: "analyticsdata.googleapis.com" },
-              },
-            ],
-          },
-        },
-        { status: 403 },
-      ),
-    );
-    await expect(
-      createGa4DataClient({
-        userId: "user_1",
-        ga4AccountId: "account_1",
-        propertyId: "properties/123",
-      }).runReport(reportRequest),
-    ).rejects.toMatchObject({
-      status: 403,
-      upstreamReason: "SERVICE_DISABLED",
-    });
-  });
-
-  it("rejects malformed successful responses", async () => {
-    mocks.fetch.mockResolvedValue(Response.json({ rows: "not-an-array" }));
-    await expect(
-      createGa4DataClient({
-        userId: "user_1",
-        ga4AccountId: "account_1",
-        propertyId: "properties/123",
-      }).runReport(reportRequest),
-    ).rejects.toBeInstanceOf(Ga4MalformedResponseError);
-  });
-
-  it("rejects a non-canonical property identifier before fetching", async () => {
-    expect(() =>
-      createGa4DataClient({
-        userId: "user_1",
-        ga4AccountId: "account_1",
-        propertyId: "123",
-      }),
-    ).toThrow();
-    expect(mocks.fetch).not.toHaveBeenCalled();
-  });
-
-  it("converts transport failures to a typed upstream error", async () => {
-    mocks.fetch.mockRejectedValue(new TypeError("DNS failure"));
-    await expect(
-      createGa4DataClient({
-        userId: "user_1",
-        ga4AccountId: "account_1",
-        propertyId: "properties/123",
-      }).runReport(reportRequest),
-    ).rejects.toMatchObject({ status: 0 });
   });
 });

--- a/src/server/lib/ga4Client.ts
+++ b/src/server/lib/ga4Client.ts
@@ -365,6 +365,10 @@ const runReportResponseSchema = z.object({
   kind: z.string().optional(),
 });
 
+const batchRunReportsResponseSchema = z.object({
+  reports: z.array(runReportResponseSchema),
+});
+
 const googleErrorSchema = z.object({
   error: z.object({
     details: z
@@ -379,6 +383,10 @@ const googleErrorSchema = z.object({
 });
 
 export type Ga4RunReportResponse = z.infer<typeof runReportResponseSchema>;
+
+export type Ga4BatchRunReportsResponse = z.infer<
+  typeof batchRunReportsResponseSchema
+>;
 
 export type Ga4RunReportRequest = {
   dateRanges: Array<{ startDate: string; endDate: string }>;
@@ -419,62 +427,80 @@ export function createGa4DataClient(opts: {
   const propertyId = propertyIdSchema.parse(opts.propertyId);
   const accessToken = memoizedGa4AccessToken(opts);
 
+  async function requestReport(endpoint: string, body: unknown) {
+    const token = await accessToken();
+    let response: Response;
+    try {
+      response = await fetch(`${GA4_DATA_API_BASE}/${propertyId}:${endpoint}`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+      });
+    } catch (error) {
+      if (isAbortError(error)) throw error;
+      throw new Ga4DataApiError(
+        0,
+        "Google Analytics reporting is temporarily unavailable.",
+      );
+    }
+    if (!response.ok) {
+      const responseBody = await response
+        .text()
+        .then((value) => value.slice(0, MAX_ERROR_BODY_LENGTH))
+        .catch(() => "");
+      let upstreamReason: string | null = null;
+      try {
+        const parsed = googleErrorSchema.safeParse(JSON.parse(responseBody));
+        if (parsed.success) {
+          upstreamReason =
+            parsed.data.error.details?.find(
+              (detail) =>
+                detail.metadata?.service === "analyticsdata.googleapis.com",
+            )?.reason ??
+            parsed.data.error.details?.find((detail) => detail.reason)
+              ?.reason ??
+            null;
+        }
+      } catch {
+        // Non-JSON error pages intentionally collapse to status-only errors.
+      }
+      throw new Ga4DataApiError(
+        response.status,
+        dataMessageForStatus(response.status),
+        safeRetryAfter(response),
+        upstreamReason,
+      );
+    }
+
+    try {
+      return await response.json();
+    } catch {
+      throw new Ga4MalformedResponseError();
+    }
+  }
+
   return {
     async runReport(
       request: Ga4RunReportRequest,
     ): Promise<Ga4RunReportResponse> {
-      const token = await accessToken();
-      let response: Response;
-      try {
-        response = await fetch(`${GA4_DATA_API_BASE}/${propertyId}:runReport`, {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${token}`,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify(request),
-        });
-      } catch (error) {
-        if (isAbortError(error)) throw error;
-        throw new Ga4DataApiError(
-          0,
-          "Google Analytics reporting is temporarily unavailable.",
-        );
-      }
-      if (!response.ok) {
-        const body = await response
-          .text()
-          .then((responseBody) => responseBody.slice(0, MAX_ERROR_BODY_LENGTH))
-          .catch(() => "");
-        let upstreamReason: string | null = null;
-        try {
-          const parsed = googleErrorSchema.safeParse(JSON.parse(body));
-          if (parsed.success) {
-            upstreamReason =
-              parsed.data.error.details?.find(
-                (detail) =>
-                  detail.metadata?.service === "analyticsdata.googleapis.com",
-              )?.reason ??
-              parsed.data.error.details?.find((detail) => detail.reason)
-                ?.reason ??
-              null;
-          }
-        } catch {
-          // Non-JSON error pages intentionally collapse to status-only errors.
-        }
-        throw new Ga4DataApiError(
-          response.status,
-          dataMessageForStatus(response.status),
-          safeRetryAfter(response),
-          upstreamReason,
-        );
-      }
+      const parsed = runReportResponseSchema.safeParse(
+        await requestReport("runReport", request),
+      );
+      if (!parsed.success) throw new Ga4MalformedResponseError();
+      return parsed.data;
+    },
 
-      try {
-        return runReportResponseSchema.parse(await response.json());
-      } catch {
-        throw new Ga4MalformedResponseError();
-      }
+    async batchRunReports(
+      requests: Ga4RunReportRequest[],
+    ): Promise<Ga4BatchRunReportsResponse> {
+      const parsed = batchRunReportsResponseSchema.safeParse(
+        await requestReport("batchRunReports", { requests }),
+      );
+      if (!parsed.success) throw new Ga4MalformedResponseError();
+      return parsed.data;
     },
   };
 }

--- a/src/server/lib/ga4Errors.ts
+++ b/src/server/lib/ga4Errors.ts
@@ -37,7 +37,7 @@ export class Ga4MalformedResponseError extends Error {
   }
 }
 
-type Ga4ReportErrorCode =
+export type Ga4ReportErrorCode =
   | "validation_error"
   | "ga4_not_connected"
   | "ga4_reconnect_required"
@@ -56,4 +56,33 @@ export class Ga4ReportError extends Error {
     super(message);
     this.name = "Ga4ReportError";
   }
+}
+
+export type Ga4ReportErrorDetail = {
+  code: Ga4ReportErrorCode;
+  message: string;
+  retryAfterSeconds?: number;
+};
+
+/**
+ * Collapse reporting failures into the small, user-safe contract exposed by
+ * dashboard server functions. Unexpected exceptions intentionally use a
+ * generic message rather than leaking an upstream response or credential.
+ */
+export function toSafeGa4ReportErrorDetail(
+  error: unknown,
+): Ga4ReportErrorDetail {
+  if (error instanceof Ga4ReportError) {
+    return {
+      code: error.code,
+      message: error.message,
+      ...(error.retryAfterSeconds == null
+        ? {}
+        : { retryAfterSeconds: error.retryAfterSeconds }),
+    };
+  }
+  return {
+    code: "ga4_upstream_unavailable",
+    message: "Google Analytics reporting is temporarily unavailable.",
+  };
 }

--- a/src/serverFunctions/ga4.ts
+++ b/src/serverFunctions/ga4.ts
@@ -46,9 +46,22 @@ export const getDashboardGa4Summary = createServerFn({ method: "POST" })
         projectId: context.projectId,
       });
     } catch (error) {
+      const detail = toSafeGa4ReportErrorDetail(error);
+      waitUntil(
+        captureServerEvent({
+          distinctId: context.userId,
+          event: "ga4:dashboard_summary_error",
+          organizationId: context.organizationId,
+          properties: {
+            project_id: context.projectId,
+            error_code: detail.code,
+            retry_after_seconds: detail.retryAfterSeconds,
+          },
+        }),
+      );
       return {
         status: "error",
-        error: toSafeGa4ReportErrorDetail(error),
+        error: detail,
       };
     }
   });

--- a/src/serverFunctions/ga4.ts
+++ b/src/serverFunctions/ga4.ts
@@ -2,6 +2,10 @@ import { createServerFn } from "@tanstack/react-start";
 import { getRequest } from "@tanstack/react-start/server";
 import { waitUntil } from "cloudflare:workers";
 import { z } from "zod";
+import {
+  Ga4DashboardSummaryService,
+  type DashboardGa4Summary,
+} from "@/server/features/ga4/services/Ga4DashboardSummaryService";
 import { Ga4Service } from "@/server/features/ga4/services/Ga4Service";
 import { hasSelfHostedGoogleOAuthConfig } from "@/server/features/google/oauth-config";
 import {
@@ -10,6 +14,10 @@ import {
 } from "@/server/features/google/selfHostedOAuth";
 import { isHostedServerAuthMode } from "@/server/lib/runtime-env";
 import { captureServerEvent } from "@/server/lib/posthog";
+import {
+  toSafeGa4ReportErrorDetail,
+  type Ga4ReportErrorDetail,
+} from "@/server/lib/ga4Errors";
 import { getPublicOrigin } from "@/server/mcp/public-origin";
 import {
   requireAuthenticatedContext,
@@ -24,6 +32,26 @@ const setPropertySchema = projectScopedSchema.extend({
 const startSelfHostedLinkSchema = z.object({
   callbackURL: z.string().min(1),
 });
+
+export type DashboardGa4SummaryResult =
+  | DashboardGa4Summary
+  | { status: "error"; error: Ga4ReportErrorDetail };
+
+export const getDashboardGa4Summary = createServerFn({ method: "POST" })
+  .middleware(requireProjectContext)
+  .validator(projectScopedSchema)
+  .handler(async ({ context }): Promise<DashboardGa4SummaryResult> => {
+    try {
+      return await Ga4DashboardSummaryService.getDashboardGa4Summary({
+        projectId: context.projectId,
+      });
+    } catch (error) {
+      return {
+        status: "error",
+        error: toSafeGa4ReportErrorDetail(error),
+      };
+    }
+  });
 
 export const getGa4Connection = createServerFn({ method: "POST" })
   .middleware(requireProjectContext)


### PR DESCRIPTION
## What changed

- adds focused Google Analytics dashboard cards directly after Search performance for connected projects
- shows visits, conversions, conversion rate, engagement rate, popular pages by views, and top cities by visits
- adds a separate conversion breakdown with the top five active GA4 key events, their exact Analytics names, event occurrences, and Analytics users
- gives common events readable labels such as `Contact form submission` and `Sales phone click` without hiding the raw event name
- clarifies that events can repeat, Analytics users are not unique CRM leads, and conversion rate means sessions with at least one key event
- compares the last 28 complete property-local days with the prior 28-day period
- adds honest loading, empty, limited-data, connection, quota-retry, and truncated-report states
- invalidates the dashboard summary when the selected GA4 property changes or disconnects
- deep-links dashboard actions to the Google Analytics settings section

## Why

OpenSEO already surfaces Search Console performance on the homepage, but users still had to leave the product to understand what Analytics counted as a conversion. The new breakdown answers whether conversions are forms, phone clicks, purchases, or other configured key events without recreating the full Analytics interface or implying that event counts equal leads.

## Implementation notes

- uses one GA4 `batchRunReports` request containing five fixed, all-traffic reports
- requests the conversion breakdown by `eventName` with `keyEvents` and `totalUsers`, ordered by key-event count
- aggregates popular pages by `pagePath` so title changes cannot split totals or duplicate rows
- normalizes missing and restricted values without fabricating data
- avoids an exact conversion-type total when Google truncates the report and marks the section as limited
- preserves safe quota retry hints while keeping upstream payloads and credentials server-side
- emits privacy-safe error telemetry without property, account, event, or row data

## Review

The completed diff received independent reviews for complexity, security/authentication, billing and quota behavior, repository idioms, and product UX/accessibility. Every should-fix finding was independently verified before being changed. Follow-up review confirmed that truncated totals, limited empty states, and long exact event names are handled accurately, with no remaining blocker or should-fix findings.

## Validation

- `pnpm ci:check` — passed (Prettier, Knip, both TypeScript projects, and type-aware Oxlint)
- `pnpm build` — passed (client and SSR production builds plus TypeScript)
- focused GA4 conversion client/service/render suite — 26 tests passed
- full `pnpm test:ci` — 1,033 tests passed across 128 files
