### PR TITLE
fix(sam): add a stop control that cancels the in-flight chat turn (fixes #200)

### DIFF
--- a/src/client/features/onboarding/OnboardingChatParts.tsx
+++ b/src/client/features/onboarding/OnboardingChatParts.tsx
@@ -5,7 +5,7 @@ import {
   type FormEvent,
   type KeyboardEvent,
 } from "react";
-import { ArrowUp, Check, Globe, Loader2, Sparkles } from "lucide-react";
+import { ArrowUp, Check, Globe, Loader2, Sparkles, Square } from "lucide-react";
 import { FREE_ONBOARDING_QUESTION_LIMIT } from "@/shared/onboardingChat";
 
 const DISCORD_URL = "https://discord.gg/c9uGs3cFXr";
@@ -252,10 +252,14 @@ export function ChatGate({
 export function ChatComposer({
   busy,
   onSend,
+  onStop,
   placeholder = "Ask Sam about your strategy or OpenSEO…",
 }: {
   busy: boolean;
   onSend: (text: string) => void;
+  // When provided, the send button becomes a stop button while a response is
+  // generating — callers without a server-side cancel path keep the spinner.
+  onStop?: () => void;
   placeholder?: string;
 }) {
   const [value, setValue] = useState("");
@@ -303,18 +307,29 @@ export function ChatComposer({
         placeholder={placeholder}
         className="max-h-40 flex-1 resize-none border-0 bg-transparent px-1 py-1 text-sm leading-relaxed outline-none placeholder:text-base-content/50 focus:outline-none"
       />
-      <button
-        type="submit"
-        aria-label="Send message"
-        disabled={busy || !value.trim()}
-        className="btn btn-primary btn-circle btn-sm"
-      >
-        {busy ? (
-          <Loader2 className="size-4 animate-spin" />
-        ) : (
-          <ArrowUp className="size-4" />
-        )}
-      </button>
+      {busy && onStop ? (
+        <button
+          type="button"
+          aria-label="Stop generating"
+          onClick={onStop}
+          className="btn btn-primary btn-circle btn-sm"
+        >
+          <Square className="size-3.5 fill-current" />
+        </button>
+      ) : (
+        <button
+          type="submit"
+          aria-label="Send message"
+          disabled={busy || !value.trim()}
+          className="btn btn-primary btn-circle btn-sm"
+        >
+          {busy ? (
+            <Loader2 className="size-4 animate-spin" />
+          ) : (
+            <ArrowUp className="size-4" />
+          )}
+        </button>
+      )}
     </form>
   );
 }

--- a/src/client/features/sam/SamConversation.tsx
+++ b/src/client/features/sam/SamConversation.tsx
@@ -30,7 +30,7 @@ export function SamConversation({
   // session id. The WebSocket is authorized in the Worker (src/server.ts) before
   // it reaches the DO; billing gates come back as normal assistant messages.
   const agent = useAgent({ agent: "sam-chat", name: sessionId });
-  const { messages, sendMessage, setMessages, clearHistory, status } =
+  const { messages, sendMessage, setMessages, clearHistory, status, stop } =
     useAgentChat({ agent });
 
   const isBusy = status === "submitted" || status === "streaming";
@@ -65,6 +65,23 @@ export function SamConversation({
   const undoFrom = (messageId: string) => void rewindTo(messageId);
   const editAndResend = async (messageId: string, newText: string) => {
     if (await rewindTo(messageId)) sendText(newText);
+  };
+
+  // Stop the in-flight turn server-side. `stop()` alone only closes the client
+  // stream — the DO keeps generating and persists the full reply (which is why
+  // reloading mid-answer used to show the finished text anyway) — so cancel the
+  // turn on the agent first, then sync the local view to whatever partial
+  // reply made it to storage.
+  const stopGenerating = async () => {
+    void stop();
+    const response = await fetch(`/agents/sam-chat/${sessionId}/stop`, {
+      method: "POST",
+    });
+    if (!response.ok) return;
+    const fresh = await fetch(
+      `/agents/sam-chat/${sessionId}/get-messages`,
+    ).then((res) => (res.ok ? res.json() : null));
+    if (Array.isArray(fresh)) setMessages(fresh);
   };
 
   // The DO names the session from its first message during the turn, so refresh
@@ -184,6 +201,7 @@ export function SamConversation({
           <ChatComposer
             busy={isBusy}
             onSend={sendText}
+            onStop={isBusy ? () => void stopGenerating() : undefined}
             placeholder="Ask SAM to research, analyze, or track anything…"
           />
         </div>

--- a/src/server/features/sam/SamChatAgent.test.ts
+++ b/src/server/features/sam/SamChatAgent.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SamChatAgent } from "./SamChatAgent";
+
+const mocks = vi.hoisted(() => ({
+  cancelAllChats: vi.fn(),
+  waitUntilStable: vi.fn(),
+  storageDelete: vi.fn(),
+  deleteMessages: vi.fn(),
+  superOnRequest: vi.fn<(request: Request) => Promise<Response>>(),
+}));
+
+// Stand in for the Think base class so the test never loads the real agent
+// runtime (which pulls cloudflare:-protocol modules node can't resolve).
+// super.onRequest routes to superOnRequest for the delegation assertions.
+vi.mock("@cloudflare/think", () => ({
+  Think: class {
+    ctx: unknown;
+    constructor(ctx: unknown) {
+      this.ctx = ctx;
+    }
+    onRequest(request: Request): Promise<Response> {
+      return mocks.superOnRequest(request);
+    }
+  },
+}));
+vi.mock("agents/chat", () => ({
+  clearChatTerminal: (storage: { delete: (key: string) => Promise<void> }) =>
+    storage.delete("chat-terminal"),
+}));
+vi.mock("@/db", () => ({ db: {}, withPgClient: (fn: () => unknown) => fn() }));
+vi.mock("@/db/schema", () => ({ user: {} }));
+vi.mock("@/server/lib/chatAgent", () => ({
+  openRouterCostUsd: vi.fn(),
+  staticAssistantModel: vi.fn(),
+}));
+vi.mock("@/server/features/sam/SamSessionRepository", () => ({
+  SamSessionRepository: {},
+}));
+vi.mock("@/server/features/sam/SamProjectMemoryRepository", () => ({
+  SamProjectMemoryRepository: {},
+}));
+vi.mock("@/server/features/projects/repositories/ProjectRepository", () => ({
+  ProjectRepository: {},
+}));
+vi.mock("@/server/features/sam/samChatTools", () => ({
+  buildSamMcpTools: vi.fn(),
+}));
+vi.mock("@/server/features/sam/samSystemPrompt", () => ({
+  buildSamSystemPrompt: vi.fn(),
+}));
+vi.mock("@/server/lib/openrouter", () => ({
+  buildChatAgentModel: vi.fn(),
+}));
+vi.mock("@/server/lib/runtime-env", () => ({
+  getEnvValueSync: vi.fn(),
+  isHostedServerAuthMode: vi.fn(),
+}));
+vi.mock("@/server/billing/subscription", () => ({
+  checkUsageCreditsDepleted: vi.fn(),
+  trackUsageCreditSpend: vi.fn(),
+}));
+vi.mock("@/server/mcp/public-origin", () => ({
+  getPublicOrigin: vi.fn(),
+}));
+
+// The agent is a Durable Object backed by Think; the /stop and /rewind routes
+// only touch cancelAllChats/waitUntilStable/storage, so construct it against
+// the mocked (constructor-free) base class with a minimal storage double.
+function buildAgent(): SamChatAgent {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the mocked base class does not inspect DO constructor context
+  const ctx = {} as DurableObjectState;
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the mocked base class does not inspect DO constructor context
+  const env = {} as Cloudflare.Env;
+  const agent = new SamChatAgent(ctx, env);
+  Object.assign(agent, {
+    ctx: { storage: { delete: mocks.storageDelete } },
+    session: { deleteMessages: mocks.deleteMessages },
+    cancelAllChats: mocks.cancelAllChats,
+    waitUntilStable: mocks.waitUntilStable,
+  });
+  return agent;
+}
+
+const stopRequest = () =>
+  new Request("https://app.openseo.so/agents/sam-chat/session_1/stop", {
+    method: "POST",
+  });
+
+describe("SamChatAgent POST /stop", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.waitUntilStable.mockResolvedValue(undefined);
+    mocks.superOnRequest.mockResolvedValue(new Response("agent"));
+  });
+
+  it("cancels the in-flight turn and settles before responding", async () => {
+    const agent = buildAgent();
+
+    const response = await agent.onRequest(stopRequest());
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    expect(mocks.cancelAllChats).toHaveBeenCalledTimes(1);
+    expect(mocks.waitUntilStable).toHaveBeenCalledWith({ timeout: 5000 });
+    // The aborted turn must not be replayed as an error to reconnects…
+    expect(mocks.storageDelete).toHaveBeenCalledTimes(1);
+    // …but the transcript is kept: nothing is rewound or deleted.
+    expect(mocks.deleteMessages).not.toHaveBeenCalled();
+  });
+
+  it("waits for the turn to settle before clearing the terminal record", async () => {
+    const order: string[] = [];
+    mocks.cancelAllChats.mockImplementation(() => {
+      order.push("cancel");
+    });
+    mocks.waitUntilStable.mockImplementation(async () => {
+      order.push("stable");
+    });
+    mocks.storageDelete.mockImplementation(async () => {
+      order.push("clear-terminal");
+    });
+
+    await buildAgent().onRequest(stopRequest());
+
+    expect(order).toEqual(["cancel", "stable", "clear-terminal"]);
+  });
+
+  it("delegates non-stop requests to Think", async () => {
+    const agent = buildAgent();
+    const response = await agent.onRequest(
+      new Request("https://app.openseo.so/agents/sam-chat/session_1/other", {
+        method: "POST",
+      }),
+    );
+
+    expect(mocks.superOnRequest).toHaveBeenCalledTimes(1);
+    expect(mocks.cancelAllChats).not.toHaveBeenCalled();
+    expect(response.status).toBe(200);
+  });
+});

--- a/src/server/features/sam/SamChatAgent.ts
+++ b/src/server/features/sam/SamChatAgent.ts
@@ -352,6 +352,22 @@ export class SamChatAgent extends Think {
   async onRequest(request: Request): Promise<Response> {
     if (
       request.method === "POST" &&
+      new URL(request.url).pathname.endsWith("/stop")
+    ) {
+      // Stop the in-flight turn without touching the transcript, so the user
+      // keeps whatever partial reply already streamed in. Same settle-before-
+      // respond race as rewind: returning while the loop is still aborting
+      // would let late chunks persist (and stream) after we claim it stopped.
+      this.cancelAllChats();
+      await this.waitUntilStable({ timeout: 5000 });
+      // The aborted turn surfaces to Think as a chat error, which stores a
+      // terminal record that reconnecting clients replay as "Something went
+      // wrong" — but the user stopped this turn on purpose, so drop it.
+      await clearChatTerminal(this.ctx.storage);
+      return Response.json({ ok: true });
+    }
+    if (
+      request.method === "POST" &&
       new URL(request.url).pathname.endsWith("/rewind")
     ) {
       const body = z


### PR DESCRIPTION
## Problem

The Sam chat offers no way to end a generation that is taking too long (#200). Because the turn runs inside the `SamChatAgent` Durable Object, there is nothing the client can do about it on its own: reloading the page or losing the socket leaves the DO still generating, and the full reply is persisted and waiting when the user comes back. The reporter reproduced this three times in a row.

## Approach

- **Server (`SamChatAgent`)**: `POST /agents/sam-chat/:sessionId/stop` cancels the in-flight turn using the same machinery the `/rewind` handler already trusts — `cancelAllChats()` then `await waitUntilStable({ timeout: 5000 })` — but deletes nothing, so the user keeps whatever partial reply already streamed. It also clears the stored chat-terminal record: the aborted turn surfaces to Think as a chat error, and without this, every reconnect would replay "Something went wrong" for a turn the user stopped on purpose.
- **Client (`SamConversation`)**: while a response is generating, the composer's send button becomes a stop button. Stopping calls the hook's `stop()` to close the client stream immediately, `POST`s to `/stop` to cancel the server-side turn, then re-syncs the local view from `/get-messages` — the same reconciliation pattern rewind uses, since an aborted turn may have persisted a partial assistant message.
- **`ChatComposer`**: grows an optional `onStop` prop. Callers without a server-side cancel path (the onboarding chat) keep the existing spinner; only Sam's usage changes behavior.

## Verification

- New unit tests for the agent route (`SamChatAgent.test.ts`): stop cancels the turn and settles before responding, the terminal record is cleared only after the turn settles, the transcript is left untouched (no `deleteMessages`), and non-stop requests still delegate to the base class.
- Full local gate on the branch: `vitest run` (124 files / 1009 tests), `tsc --noEmit`, `oxlint . --type-aware`, and `prettier --check` all clean.
- Manual repro path: ask Sam a question that runs long (a multi-step research prompt), press stop mid-stream — the spinner/typing state ends immediately, the partial reply stays in the transcript, and a reload no longer shows the completed answer.

Fixes #200