### PR TITLE
feat(self-host): optional CUSTOM_DOMAIN for non-prod stages

### DIFF
--- a/alchemy.run.ts
+++ b/alchemy.run.ts
@@ -307,6 +307,9 @@ export default Alchemy.Stack(
       Config.withDefault("cloudflare_access"),
     );
     const databaseProvider = yield* optionalVar("DATABASE_PROVIDER");
+    // Optional custom domain for non-prod stages (e.g. a self-host deploy
+    // behind its own hostname); prod keeps its hardcoded domains below.
+    const customDomain = yield* optionalVar("CUSTOM_DOMAIN");
     const workersSubdomain = yield* readWorkersSubdomain({ required: false });
 
     // Auth needs an absolute BETTER_AUTH_URL. Prod sets it explicitly;
@@ -354,7 +357,11 @@ export default Alchemy.Stack(
     const app = yield* Cloudflare.Worker("open-seo", {
       name: workerName(stage),
       // Prod serves the real domains; the zone is inferred from the hostname.
-      domain: prod ? ["app.openseo.so", "www.app.openseo.so"] : undefined,
+      domain: prod
+        ? ["app.openseo.so", "www.app.openseo.so"]
+        : customDomain
+          ? [customDomain]
+          : undefined,
       // Prebuilt worker from `vite build` (@cloudflare/vite-plugin). The entry
       // exports the DO + WorkflowEntrypoint classes (re-exported by
       // src/server.ts), which `bundle: false` requires. Sibling chunks under


### PR DESCRIPTION
Proof of concept for #226 — I read `docs/CONTRIBUTING.md`, so no merge expected; this is here to make the issue concrete.

Reads an optional `CUSTOM_DOMAIN` env var (same `optionalVar` mechanism as the rest of the config) and passes it to the Worker `domain` prop on non-prod stages. Prod keeps its hardcoded domains. Unset, nothing changes.

Running on our selfhost stage since 2026-08-15: with `CUSTOM_DOMAIN=seo.<our-domain>` in `.env.selfhost` the deploy reports `Reconciling custom domains (1)` and the domain survives every deploy; before the change the reconcile deleted it (`Reconciling custom domains (0)`).