### PR TITLE
Make the free backlink checker's daily spend cap atomic

### DIFF
--- a/web/src/lib/backlink-budget.ts
+++ b/web/src/lib/backlink-budget.ts
@@ -1,0 +1,53 @@
+/**
+ * Global daily spend cap for the free backlink checker.
+ *
+ * A Durable Object is the only primitive on Workers that makes this an actual
+ * ceiling. It is one instance globally, and its input gates serialize the
+ * read-modify-write below, so N concurrent reservations consume N units.
+ *
+ * The KV counter this replaces did a non-atomic read-modify-write against a
+ * read-cached value: concurrent requests all read the same count, all passed
+ * the check, and all billed DataForSEO while the stored count advanced by one.
+ */
+
+// Hard ceiling on paid DataForSEO lookups per day (~$0.04 each). Cached checks
+// don't count. Bumping this is a deliberate spend decision.
+export const DAILY_CHECK_BUDGET = 500;
+
+const BUDGET_KEY = "budget";
+
+// Single record, so the count resets at UTC midnight without a TTL and storage
+// never grows.
+type BudgetRecord = { day: string; used: number };
+
+export type BudgetReservation = { allowed: boolean; used: number };
+
+type DurableStorage = {
+  get<T>(key: string): Promise<T | undefined>;
+  put<T>(key: string, value: T): Promise<void>;
+};
+
+export class BacklinkCheckBudget {
+  #storage: DurableStorage;
+
+  constructor(state: { storage: DurableStorage }) {
+    this.#storage = state.storage;
+  }
+
+  async fetch(): Promise<Response> {
+    const day = new Date().toISOString().slice(0, 10);
+    const stored = await this.#storage.get<BudgetRecord>(BUDGET_KEY);
+    const used = stored?.day === day ? stored.used : 0;
+
+    if (used >= DAILY_CHECK_BUDGET) {
+      return Response.json({ allowed: false, used } satisfies BudgetReservation);
+    }
+
+    const next = used + 1;
+    await this.#storage.put<BudgetRecord>(BUDGET_KEY, { day, used: next });
+    return Response.json({
+      allowed: true,
+      used: next,
+    } satisfies BudgetReservation);
+  }
+}

--- a/web/src/routes/api/backlink-check.ts
+++ b/web/src/routes/api/backlink-check.ts
@@ -1,13 +1,11 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { env } from "cloudflare:workers";
 import { z } from "zod";
+import type { BudgetReservation } from "@/lib/backlink-budget";
 
 const DATAFORSEO_BASE = "https://api.dataforseo.com";
 const TOP_BACKLINKS_LIMIT = 15;
 const CACHE_TTL_SECONDS = 86_400;
-// Hard ceiling on paid DataForSEO lookups per day (~$0.04 each). Cached
-// checks don't count. Bumping this is a deliberate spend decision.
-const DAILY_CHECK_BUDGET = 500;
 
 const requestSchema = z.object({
   target: z.string().trim().min(1, "Enter a domain").max(300),
@@ -67,13 +65,9 @@ type RateLimiter = {
   limit(options: { key: string }): Promise<{ success: boolean }>;
 };
 
-type KvStore = {
-  get(key: string): Promise<string | null>;
-  put(
-    key: string,
-    value: string,
-    options?: { expirationTtl?: number },
-  ): Promise<void>;
+type BudgetNamespace = {
+  idFromName(name: string): unknown;
+  get(id: unknown): { fetch(url: string, init?: RequestInit): Promise<Response> };
 };
 
 function normalizeDomain(input: string): string | null {
@@ -220,31 +214,38 @@ export const Route = createFileRoute("/api/backlink-check")({
         const cached = await cache.match(cacheKey);
         if (cached) return cached;
 
-        // Global daily budget. Best-effort: KV reads are edge-cached and the
-        // increment is non-atomic, so the ceiling is approximate — the hard
-        // spend bound is the DataForSEO account balance. Counts attempts, not
-        // successes, so charged-but-failed calls still consume budget, and a
-        // KV error can never fail a request the user already paid latency for.
-        const kv = (env as any).BACKLINK_CHECK_KV as KvStore | undefined;
-        if (kv) {
-          const budgetKey = `daily-checks:${new Date().toISOString().slice(0, 10)}`;
+        // Global daily budget, reserved atomically in a Durable Object so a
+        // burst of concurrent requests consumes one unit each instead of all
+        // racing on the same count. Counts attempts, not successes, so
+        // charged-but-failed calls still consume budget. Fails closed: a
+        // spend cap that opens under error isn't a cap.
+        const budget = (env as any).BACKLINK_CHECK_BUDGET as
+          | BudgetNamespace
+          | undefined;
+        if (budget) {
+          let reservation: BudgetReservation;
           try {
-            const stored = Number(await kv.get(budgetKey));
-            const used = Number.isFinite(stored) ? stored : 0;
-            if (used >= DAILY_CHECK_BUDGET) {
-              return jsonResponse(
-                {
-                  error:
-                    "The free checker has reached today's limit. Try again tomorrow, or sign up for OpenSEO for full backlink research.",
-                },
-                429,
-              );
-            }
-            await kv.put(budgetKey, String(used + 1), {
-              expirationTtl: 2 * 86_400,
+            const stub = budget.get(budget.idFromName("global"));
+            const res = await stub.fetch("https://backlink-budget/reserve", {
+              method: "POST",
             });
+            if (!res.ok) throw new Error(`budget DO HTTP ${res.status}`);
+            reservation = (await res.json()) as BudgetReservation;
           } catch (err) {
             console.error("Backlink check budget counter error:", err);
+            return jsonResponse(
+              { error: "Service temporarily unavailable. Try again shortly." },
+              503,
+            );
+          }
+          if (!reservation.allowed) {
+            return jsonResponse(
+              {
+                error:
+                  "The free checker has reached today's limit. Try again tomorrow, or sign up for OpenSEO for full backlink research.",
+              },
+              429,
+            );
           }
         }
 

--- a/web/src/server.ts
+++ b/web/src/server.ts
@@ -1,0 +1,13 @@
+import {
+  createStartHandler,
+  defaultStreamHandler,
+} from "@tanstack/react-start/server";
+
+// Durable Object classes must be named exports of the Worker entry, which is
+// why this file replaces the default `@tanstack/react-start/server-entry` as
+// `main` in wrangler.jsonc (same arrangement as the app's src/server.ts).
+export { BacklinkCheckBudget } from "./lib/backlink-budget";
+
+export default {
+  fetch: createStartHandler(defaultStreamHandler),
+};

--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -3,7 +3,7 @@
   "name": "open-seo-landing",
   "compatibility_date": "2026-02-19",
   "compatibility_flags": ["nodejs_compat"],
-  "main": "@tanstack/react-start/server-entry",
+  "main": "src/server.ts",
   "assets": {
     "directory": "./dist/client",
     "html_handling": "drop-trailing-slash",
@@ -27,10 +27,18 @@
       "custom_domain": true,
     },
   ],
-  "kv_namespaces": [
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "BACKLINK_CHECK_BUDGET",
+        "class_name": "BacklinkCheckBudget",
+      },
+    ],
+  },
+  "migrations": [
     {
-      "binding": "BACKLINK_CHECK_KV",
-      "id": "b3a051a75a7b478e93b46cdaf6da3572",
+      "tag": "v1",
+      "new_sqlite_classes": ["BacklinkCheckBudget"],
     },
   ],
   "ratelimits": [
@@ -42,18 +50,23 @@
   ],
   "env": {
     // Bindings are not inherited by named envs; keep preview's copies in sync.
-    // Shared KV id is deliberate: one global daily budget across both workers.
+    // `script_name` is the deliberate equivalent of the old shared KV id: it
+    // points preview at the production worker's Durable Object, so both share
+    // one global daily budget. Preview must not re-declare the migration.
     "preview": {
       "name": "open-seo-landing-preview",
       "workers_dev": true,
       "preview_urls": true,
       "routes": [],
-      "kv_namespaces": [
-        {
-          "binding": "BACKLINK_CHECK_KV",
-          "id": "b3a051a75a7b478e93b46cdaf6da3572",
-        },
-      ],
+      "durable_objects": {
+        "bindings": [
+          {
+            "name": "BACKLINK_CHECK_BUDGET",
+            "class_name": "BacklinkCheckBudget",
+            "script_name": "open-seo-landing",
+          },
+        ],
+      },
       "ratelimits": [
         {
           "name": "BACKLINK_CHECK_RATE_LIMIT",


### PR DESCRIPTION
## TL;DR

`DAILY_CHECK_BUDGET` is meant to cap the free backlink checker at 500 paid
DataForSEO lookups a day. It currently caps serialized checks rather than spend:
requests that overlap can each reach the paid call while the stored count
advances by one.

## What is happening

The budget counter in `web/src/routes/api/backlink-check.ts` reads from KV,
compares, then writes back. Overlapping requests all read the same value, all
pass the check, and all reach the paid call. Workers KV also serves reads from a
colo-local cache, so the count a colo sees can be stale even without overlap.

Measured locally by lowering `DAILY_CHECK_BUDGET` to 5 and issuing 40
simultaneous checks for distinct domains:

|         | reached the paid call |
| ------- | --------------------- |
| before  | 33 of 40              |
| after   | 5 of 40               |

Miniflare doesn't emulate KV's edge read-cache, so real-world overshoot should
be larger rather than smaller.

## What this changes

Reserves from a Durable Object instead — one instance globally, and its input
gates serialize the read-modify-write, so N concurrent reservations consume N
units. Reservation fails closed, since a spend cap that opens under error isn't
a cap.

- `main` moves to a new `web/src/server.ts`, because Durable Object classes must
  be named exports of the Worker entry. This mirrors the app's existing
  `src/server.ts`.
- Preview keeps sharing production's budget via `script_name`, matching the
  intent of the shared KV namespace it replaces.
- `BACKLINK_CHECK_KV` is now unused and removed from the config. The namespace
  itself can be deleted separately.

`types:check`, `prettier --check`, and a full `vite build` pass, and
prerendering is unaffected. Normal paths are unchanged: a single check still
reaches DataForSEO, an invalid domain still returns 400.

## Caveats

Verified in Miniflare, not on Cloudflare. The `script_name` cross-worker binding
for preview is the one piece only a real deploy will confirm.

I know from `docs/CONTRIBUTING.md` that external PRs aren't being merged right
now. Filing this as the proof-of-concept form described there — happy for it to
be closed and reimplemented however you prefer.

## Two things worth checking regardless of this patch

1. `wrangler secret list --name open-seo-landing`. I couldn't find any Turnstile
   code in the deployed bundles reachable from `main.js`. If
   `TURNSTILE_SECRET_KEY` is set while the deployed build lacks
   `VITE_TURNSTILE_SITE_KEY`, checks would currently be returning 403 to real
   users — which is the case the error string at that branch already anticipates.
2. Capping the DataForSEO account (prepaid balance, auto-recharge off) bounds
   worst-case spend regardless of what the code does.
