### PR TITLE
fix(analytics): keep MCP API keys out of PostHog session replay

### DIFF
--- a/src/client/features/settings/ApiKeySettings.tsx
+++ b/src/client/features/settings/ApiKeySettings.tsx
@@ -197,7 +197,11 @@ export function ApiKeySettings() {
                   to <span className="font-mono text-xs">{mcpUrl}</span>.
                 </p>
                 <div className="mt-4 flex items-center gap-2">
-                  <code className="min-w-0 flex-1 overflow-x-auto rounded bg-base-200 px-2.5 py-2 font-mono text-xs">
+                  {/* Plaintext key is shown once; keep it out of PostHog replay. */}
+                  <code
+                    className="ph-mask min-w-0 flex-1 overflow-x-auto rounded bg-base-200 px-2.5 py-2 font-mono text-xs"
+                    data-ph-mask
+                  >
                     {createdKey}
                   </code>
                   <CopyButton

--- a/src/client/lib/posthog-sanitize.test.ts
+++ b/src/client/lib/posthog-sanitize.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from "vitest";
 import {
+  sanitizePostHogCapturedNetworkRequest,
   sanitizePostHogProperties,
   sanitizePostHogUrl,
 } from "@/client/lib/posthog-sanitize";
 
 const consentUrl =
   "https://app.example.test/oauth-consent?response_type=code&client_id=test-client&redirect_uri=https%3A%2F%2Fclient.example%2Fcallback&scope=openid&state=state-secret&code_challenge=pkce-challenge&code_challenge_method=S256&resource=https%3A%2F%2Fapp.example.test%2Fmcp&future_parameter=future-secret";
+
+const sampleApiKey =
+  "oseo_abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOP";
 
 describe("sanitizePostHogUrl", () => {
   it("removes the complete query from OAuth consent URLs", () => {
@@ -41,6 +45,46 @@ describe("sanitizePostHogProperties", () => {
       $session_entry_url: "https://app.example.test/oauth-consent",
       $referrer: "https://app.example.test/oauth-consent",
       event_detail: "kept",
+    });
+  });
+});
+
+describe("sanitizePostHogCapturedNetworkRequest", () => {
+  it("strips bodies from Better Auth API-key create responses", () => {
+    expect(
+      sanitizePostHogCapturedNetworkRequest({
+        name: "https://app.example.test/api/auth/api-key/create",
+        requestBody: '{"name":"laptop"}',
+        responseBody: JSON.stringify({ key: sampleApiKey }),
+        status: 200,
+      }),
+    ).toEqual({
+      name: "https://app.example.test/api/auth/api-key/create",
+      status: 200,
+    });
+  });
+
+  it("redacts oseo_ keys that appear in unrelated captured bodies", () => {
+    expect(
+      sanitizePostHogCapturedNetworkRequest({
+        name: "https://app.example.test/api/projects",
+        responseBody: `{"note":"use ${sampleApiKey}"}`,
+      }),
+    ).toEqual({
+      name: "https://app.example.test/api/projects",
+      responseBody: '{"note":"use oseo_[REDACTED]"}',
+    });
+  });
+
+  it("leaves short display prefixes alone", () => {
+    expect(
+      sanitizePostHogCapturedNetworkRequest({
+        name: "https://app.example.test/api/projects",
+        responseBody: '{"start":"oseo_abcd"}',
+      }),
+    ).toEqual({
+      name: "https://app.example.test/api/projects",
+      responseBody: '{"start":"oseo_abcd"}',
     });
   });
 });

--- a/src/client/lib/posthog-sanitize.ts
+++ b/src/client/lib/posthog-sanitize.ts
@@ -1,5 +1,15 @@
 const OAUTH_CONSENT_PATH = "/oauth-consent";
 
+// Better Auth API-key plugin routes that can return a one-time plaintext key.
+const API_KEY_NETWORK_PATH_MARKERS = [
+  "/api/auth/api-key",
+  "/api/auth/apiKey",
+] as const;
+
+// Full MCP API keys look like oseo_ + high-entropy secret. Prefix-only UI
+// display values (e.g. "oseo_abcd") are shorter and left alone.
+const MCP_API_KEY_PATTERN = /\boseo_[A-Za-z0-9_-]{16,}\b/g;
+
 export const POSTHOG_PERSONAL_DATA_QUERY_PARAMETERS = [
   "email",
   "response_type",
@@ -11,6 +21,13 @@ export const POSTHOG_PERSONAL_DATA_QUERY_PARAMETERS = [
   "code_challenge_method",
   "resource",
 ] as const;
+
+export type PostHogCapturedNetworkRequest = {
+  name: string;
+  requestBody?: string;
+  responseBody?: string;
+  [key: string]: unknown;
+};
 
 export function sanitizePostHogUrl(value: string): string {
   try {
@@ -41,4 +58,43 @@ export function sanitizePostHogProperties(
   }
 
   return properties;
+}
+
+function isApiKeyAuthRequestUrl(name: string): boolean {
+  try {
+    const pathname = new URL(name, "https://example.invalid").pathname;
+    return API_KEY_NETWORK_PATH_MARKERS.some((marker) =>
+      pathname.includes(marker),
+    );
+  } catch {
+    return API_KEY_NETWORK_PATH_MARKERS.some((marker) => name.includes(marker));
+  }
+}
+
+function redactMcpApiKeysInBody(body: string | undefined): string | undefined {
+  if (typeof body !== "string" || body.length === 0) return body;
+  return body.replace(MCP_API_KEY_PATTERN, "oseo_[REDACTED]");
+}
+
+/** Drop or redact bodies that can contain a one-time plaintext MCP API key.
+ *  A custom maskCapturedNetworkRequestFn replaces PostHog's default payload
+ *  redaction, so this must stay explicit. */
+export function sanitizePostHogCapturedNetworkRequest(
+  request: PostHogCapturedNetworkRequest,
+): PostHogCapturedNetworkRequest {
+  const sanitized: PostHogCapturedNetworkRequest = {
+    ...request,
+    name: sanitizePostHogUrl(request.name),
+  };
+
+  if (isApiKeyAuthRequestUrl(request.name)) {
+    // Create responses include the full key once; safest is to omit bodies.
+    delete sanitized.requestBody;
+    delete sanitized.responseBody;
+    return sanitized;
+  }
+
+  sanitized.requestBody = redactMcpApiKeysInBody(request.requestBody);
+  sanitized.responseBody = redactMcpApiKeysInBody(request.responseBody);
+  return sanitized;
 }

--- a/src/client/lib/posthog.ts
+++ b/src/client/lib/posthog.ts
@@ -1,8 +1,8 @@
 import { isHostedClientAuthMode } from "@/lib/auth-mode";
 import {
   POSTHOG_PERSONAL_DATA_QUERY_PARAMETERS,
+  sanitizePostHogCapturedNetworkRequest,
   sanitizePostHogProperties,
-  sanitizePostHogUrl,
 } from "@/client/lib/posthog-sanitize";
 
 // Type-only import: extracts the type at compile time without bundling posthog-js
@@ -89,10 +89,7 @@ function getBrowserPostHogClient(): Promise<BrowserPostHogClient | null> {
             maskAllInputs: true,
             maskTextSelector: "[data-ph-mask], .ph-mask",
             maskCapturedNetworkRequestFn(request) {
-              return {
-                ...request,
-                name: sanitizePostHogUrl(request.name),
-              };
+              return sanitizePostHogCapturedNetworkRequest(request);
             },
           },
           sanitize_properties(properties) {


### PR DESCRIPTION
## Summary
- Mask the one-time plaintext MCP API key reveal in Settings (`data-ph-mask` / `ph-mask`) so PostHog session replay cannot capture it from the DOM.
- Sanitize captured network requests: drop request/response bodies for Better Auth `/api/auth/api-key*` routes, and redact full `oseo_…` keys elsewhere.
- Fixes #233.

## Test plan
- [x] `pnpm test -- src/client/lib/posthog-sanitize.test.ts`
- [ ] In a hosted (or PostHog-enabled) build, create an API key in Settings and confirm the reveal still works for the user
- [ ] Confirm a session recording of that create flow does not include the plaintext key in the DOM or network payload