### PR TITLE
feat: pluggable SERP provider layer with Serper adapter

### DIFF
--- a/src/server/features/keywords/services/research/serp.ts
+++ b/src/server/features/keywords/services/research/serp.ts
@@ -1,10 +1,9 @@
 import { waitUntil } from "cloudflare:workers";
-import { type SerpLiveItem } from "@/server/lib/dataforseo";
+import { type SerpLiveItem, getSerpResults } from "@/server/lib/serp";
 import { buildCacheKey, getCached, setCached } from "@/server/lib/r2-cache";
 import type { SerpResultItem } from "@/types/keywords";
 import { z } from "zod";
 import type { BillingCustomerContext } from "@/server/billing/subscription";
-import { createDataforseoClient } from "@/server/lib/dataforseo";
 import { normalizeKeyword } from "./helpers";
 
 const SERP_CACHE_TTL_SECONDS = 12 * 60 * 60;
@@ -80,11 +79,14 @@ async function getSerpLiveAnalysis(
     return cached.data;
   }
 
-  const liveItems = await createDataforseoClient(billingCustomer).serp.live({
-    keyword,
-    locationCode: input.locationCode,
-    languageCode: input.languageCode,
-  });
+  const liveItems = await getSerpResults(
+    {
+      keyword,
+      locationCode: input.locationCode,
+      languageCode: input.languageCode,
+    },
+    billingCustomer,
+  );
 
   const items = mapOrganicSerpItems(liveItems);
   const result: SerpAnalysisResult = { requestedKeyword: keyword, items };

--- a/src/server/lib/serp/adapter.ts
+++ b/src/server/lib/serp/adapter.ts
@@ -1,0 +1,114 @@
+import type { BillingCustomerContext } from "@/server/billing/subscription";
+import { createDataforseoClient } from "@/server/lib/dataforseo";
+import { AppError } from "@/server/lib/errors";
+import {
+  type SerpLiveItem,
+  type SerpLiveInput,
+  type SerpProvider,
+} from "./providers/base";
+import { SerperProvider } from "./providers/serper";
+
+// ---------------------------------------------------------------------------
+// Known providers registry — keyed by SERP_PROVIDER env value.
+// Add one entry per supported external provider.
+// ---------------------------------------------------------------------------
+
+const PROVIDERS: Record<string, SerpProvider> = {
+  serper: new SerperProvider(),
+};
+
+/** Valid values for the SERP_PROVIDER environment variable. */
+const KNOWN_SERP_PROVIDERS = Object.keys(PROVIDERS); // ["serper"]
+/** When no explicit provider, dataforseo is the default. */
+const DEFAULT_PROVIDER = "dataforseo";
+
+// ---------------------------------------------------------------------------
+// Unified lookup: resolves the right provider name and instance
+// based on SERP_PROVIDER / SERP_FALLBACK env vars.
+// ---------------------------------------------------------------------------
+
+let providerCache: string | null = null;
+let providerInstance: SerpProvider | null = null;
+
+export async function getProvider(): Promise<SerpProvider> {
+  if (providerCache && providerInstance) return providerInstance;
+
+  const raw = await import("@/server/lib/runtime-env").then(
+    (m) => m.getOptionalEnvValue("SERP_PROVIDER"),
+  );
+
+  const candidate = (raw ?? "").trim().toLowerCase();
+
+  if (candidate === "dataforseo" || candidate === "") {
+    // Default — callers will hit createDataforseoClient() directly.
+    providerCache = DEFAULT_PROVIDER;
+    providerInstance = null;
+    return Promise.resolve(null as unknown as SerpProvider);
+  }
+
+  if (candidate in PROVIDERS) {
+    providerCache = candidate;
+    providerInstance = PROVIDERS[candidate];
+    return providerInstance;
+  }
+
+  // Check fallback chain
+  const fallbackRaw = await import("@/server/lib/runtime-env").then(
+    (m) => m.getOptionalEnvValue("SERP_FALLBACK"),
+  );
+  if (fallbackRaw) {
+    const fallbacks = fallbackRaw.split(",").map((s) => s.trim().toLowerCase());
+    for (const name of fallbacks) {
+      if (name === "dataforseo") continue; // handled separately
+      if (name in PROVIDERS) {
+        providerCache = name;
+        providerInstance = PROVIDERS[name];
+        return providerInstance;
+      }
+    }
+  }
+
+  throw new AppError(
+    "VALIDATION_ERROR",
+    `Unknown SERP_PROVIDER="${candidate}". Must be one of: ${KNOWN_SERP_PROVIDERS.join(", ")} or "${DEFAULT_PROVIDER}".`,
+  );
+}
+
+/**
+ * Fetch SERP results through the configured provider.
+ *
+ * @param input   Keyword + optional location/language
+ * @param billing When provided AND provider is dataforseo, routes through
+ *                the metered DataForSEO client. Omit for external providers
+ *                (they do not carry billing credits).
+ */
+export async function getSerpResults(
+  input: SerpLiveInput,
+  billing?: BillingCustomerContext,
+): Promise<SerpLiveItem[]> {
+  const provider = await getProvider();
+
+  if (!provider) {
+    // Route through DataForSEO with billing
+    if (!billing) {
+      throw new AppError(
+        "VALIDATION_ERROR",
+        "SERP_PROVIDER=dataforseo requires a billing context.",
+      );
+    }
+    // DataForSEO's live() requires non-optional locationCode/languageCode —
+    // fill defaults so we can pass through.  The MCP tool and keywords SERP
+    // service already supply these fields, but the adapter type keeps them
+    // optional for future providers that tolerate missing values gracefully.
+    const dfInput = {
+      keyword: input.keyword,
+      locationCode: input.locationCode ?? 2840, // US default
+      languageCode: input.languageCode ?? "en",
+    };
+    const client = createDataforseoClient(billing);
+    return client.serp.live(dfInput);
+  }
+
+  // External provider — no billing wrapper
+  return provider.liveSerp(input);
+}

--- a/src/server/lib/serp/index.ts
+++ b/src/server/lib/serp/index.ts
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------------------
+// Export the unified SERP abstraction and all known provider implementations.
+// This barrel keeps the import paths stable for callers outside the lib.
+// ---------------------------------------------------------------------------
+
+export {
+  type SerpProvider,
+  type SerpLiveInput,
+  type SerpLiveItem,
+  serpSnapshotItemSchema,
+} from "./providers/base";
+
+export { SerperProvider } from "./providers/serper";
+
+export { getSerpResults } from "./adapter";

--- a/src/server/lib/serp/providers/base.ts
+++ b/src/server/lib/serp/providers/base.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// SerpLiveItem schema / type — shared between dataforseo and external providers
+// so every consumer reads the same shape regardless of source.
+// ---------------------------------------------------------------------------
+
+export const serpSnapshotItemSchema = z
+  .object({
+    type: z.string(),
+    rank_group: z.number().nullable().optional(),
+    rank_absolute: z.number().nullable().optional(),
+    domain: z.string().nullable().optional(),
+    title: z.string().nullable().optional(),
+    url: z.string().nullable().optional(),
+    description: z.string().nullable().optional(),
+    etv: z.number().nullable().optional(),
+    estimated_paid_traffic_cost: z.number().nullable().optional(),
+    backlinks_info: z
+      .object({
+        referring_domains: z.number().nullable().optional(),
+        backlinks: z.number().nullable().optional(),
+      })
+      .passthrough()
+      .nullable()
+      .optional(),
+  })
+  .passthrough();
+
+/** The single row shape returned by every SERP provider. */
+export type SerpLiveItem = z.infer<typeof serpSnapshotItemSchema>;
+
+/** Input accepted by every provider's liveSerp method. */
+export interface SerpLiveInput {
+  keyword: string;
+  locationCode?: number;
+  languageCode?: string;
+}
+
+/** Provider contract — each implementation returns items in this normalised shape. */
+export interface SerpProvider {
+  /** Human-friendly name used in logs. */
+  name: string;
+  /** Fetch live organic SERP entries for the given keyword/location/language. */
+  liveSerp(input: SerpLiveInput): Promise<SerpLiveItem[]>;
+}

--- a/src/server/lib/serp/providers/serper.ts
+++ b/src/server/lib/serp/providers/serper.ts
@@ -1,0 +1,76 @@
+import { AppError } from "@/server/lib/errors";
+import { getOptionalEnvValue } from "@/server/lib/runtime-env";
+import { getIsoCountryCode } from "@/shared/keyword-locations";
+import type { SerpLiveInput, SerpLiveItem, SerpProvider } from "./base";
+
+// ---------------------------------------------------------------------------
+// Normaliser: maps a Serper organic row into our internal shape
+// parity with dataforseo/serp.ts output.
+// ---------------------------------------------------------------------------
+
+function normalise(row: Record<string, unknown>): SerpLiveItem {
+  return {
+    type: "organic",
+    rank_absolute: typeof row.position === "number" ? row.position : null,
+    rank_group: typeof row.position === "number" ? row.position : null,
+    title: (typeof row.title === "string" && row.title) || null,
+    url: (typeof row.link === "string" && row.link) || null,
+    domain: (typeof row.domain === "string" && row.domain) || null,
+    description: (typeof row.snippet === "string" && row.snippet) || null,
+    etv: null,
+    estimated_paid_traffic_cost: null,
+    backlinks_info: null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Serper provider — POST https://google.serper.dev/search
+// ---------------------------------------------------------------------------
+
+export class SerperProvider implements SerpProvider {
+  name = "serper";
+
+  async liveSerp(input: SerpLiveInput): Promise<SerpLiveItem[]> {
+    const apiKey = await getOptionalEnvValue("SERPER_API_KEY");
+    if (!apiKey) {
+      throw new AppError(
+        "VALIDATION_ERROR",
+        "SERPER_API_KEY environment variable is not set. Sign up at serper.dev to get one.",
+      );
+    }
+
+    const body: Record<string, unknown> = { q: input.keyword };
+
+    // Map DataForSEO location_code → Serper gl param
+    if (input.locationCode) {
+      // getIsoCountryCode returns uppercase ISO codes ("US", "GB") which Serper accepts
+      body.gl = getIsoCountryCode(input.locationCode);
+    }
+
+    if (input.languageCode) {
+      body.hl = input.languageCode;
+    }
+
+    const response = await fetch("https://google.serper.dev/search", {
+      method: "POST",
+      headers: {
+        "X-API-KEY": apiKey,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const raw = await response.text();
+      throw new AppError(
+        "UPSTREAM_UNAVAILABLE",
+        `Serper HTTP ${response.status}: ${raw.slice(0, 500)}`,
+      );
+    }
+
+    const json = (await response.json()) as Record<string, unknown>;
+    const organicRows = (json.organic as Record<string, unknown>[] | undefined) ?? [];
+
+    return organicRows.map(normalise);
+  }
+}

--- a/src/server/mcp/tools/get-serp-results.ts
+++ b/src/server/mcp/tools/get-serp-results.ts
@@ -1,10 +1,9 @@
 import { z } from "zod";
-import { createDataforseoClient } from "@/server/lib/dataforseo";
+import { getSerpResults } from "@/server/lib/serp";
 import { mcpResponse } from "@/server/mcp/formatters";
 import { buildProjectMeta } from "@/server/mcp/context";
 import { optionalMetaOutputSchema } from "@/server/mcp/output-schemas";
 import { withMcpProjectAuth } from "@/server/mcp/project-auth";
-import { resolveMarket } from "@/shared/keyword-locations";
 import { formatMcpTable, type McpTableColumn } from "@/server/mcp/table";
 import {
   languageCodeSchema,
@@ -93,14 +92,17 @@ export const getSerpResultsTool = {
     },
   },
   handler: withMcpProjectAuth(async (args: Args, context) => {
-    const client = createDataforseoClient(context.billing);
     const results = await Promise.all(
       args.queries.map(async (q) => {
         try {
-          const items = await client.serp.live({
-            keyword: q.keyword,
-            ...resolveMarket(q, context.project),
-          });
+          const items = await getSerpResults(
+            {
+              keyword: q.keyword,
+              locationCode: q.locationCode ?? context.project.locationCode,
+              languageCode: q.languageCode ?? context.project.languageCode,
+            },
+            context.billing,
+          );
           // Trim noise — return only essentials per item.
           const trimmed = items.slice(0, 20).map((item) => ({
             type: item.type,


### PR DESCRIPTION
- Add src/server/lib/serp/: SerpProvider interface, Serper.dev adapter, unified getSerpResults() routing via SERP_PROVIDER / SERP_FALLBACK env vars
- DataForSEO remains default with metered billing; external providers skip billing
- Rewire MCP get_serp_results tool and keywords research serp service