### PR TITLE
fix: add self-hosted rank scheduler endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,10 @@
 # Optional image tag override for Docker self-hosting
 # OPEN_SEO_IMAGE=ghcr.io/every-app/open-seo:latest
 
+# Required to enable the Docker/self-host scheduled rank-check endpoint. Generate
+# a long random value and send it as a Bearer token from an external scheduler.
+# RANK_CHECK_SCHEDULER_SECRET=
+
 # -----------------------------------------------------------------------------
 # Auth mode
 # -----------------------------------------------------------------------------

--- a/compose.yaml
+++ b/compose.yaml
@@ -19,6 +19,8 @@ services:
       - OPENSEO_TELEMETRY_DISABLED=${OPENSEO_TELEMETRY_DISABLED:-}
       - DO_NOT_TRACK=${DO_NOT_TRACK:-}
       - DATAFORSEO_API_KEY=${DATAFORSEO_API_KEY}
+      # Optional: enables authenticated external scheduling of due rank checks.
+      - RANK_CHECK_SCHEDULER_SECRET=${RANK_CHECK_SCHEDULER_SECRET:-}
       # Optional: AI features (SAM, onboarding chat). Without this the setup
       # gate in the app asks for the key, but nothing here would forward it.
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}

--- a/docs/SELF_HOSTING_DOCKER.md
+++ b/docs/SELF_HOSTING_DOCKER.md
@@ -33,6 +33,24 @@ Optional env values:
 - `ALLOWED_HOST` (single reverse-proxy hostname to allow in Vite preview)
 - `AUTH_MODE=local_noauth` (already set in compose)
 - `OPEN_SEO_IMAGE` (defaults to `ghcr.io/every-app/open-seo:latest`)
+
+## Scheduled rank checks
+
+Docker does not emit Cloudflare Worker scheduled events. To run due rank checks,
+set a long random `RANK_CHECK_SCHEDULER_SECRET` in `.env`, recreate the container,
+and configure Coolify or another external scheduler to send an authenticated
+`POST` request on your desired cadence:
+
+```bash
+curl --fail-with-body --request POST \
+  --header "Authorization: Bearer $RANK_CHECK_SCHEDULER_SECRET" \
+  https://your-open-seo.example/api/internal/scheduled-rank-checks
+```
+
+The endpoint is disabled when the secret is unset, accepts `POST` only, and uses
+the same due-date, budget, deadline, and active-run guards as the Cloudflare
+scheduled handler. Keep the token in your scheduler's secret store and never put
+it in a URL or logs.
 - `OPENROUTER_API_KEY` (required for AI features such as SAM; see [OpenRouter](https://openrouter.ai/settings/keys))
 
 If you are putting Docker behind a reverse proxy or a temporary tunnel, remember that Docker self-hosting runs with app auth disabled. Only expose it behind your own auth-protected reverse proxy, tunnel, or private network, and add the public hostname before restarting:

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -37,6 +37,8 @@ declare namespace Cloudflare {
     AUTUMN_WEBHOOK_SECRET?: string;
     // HMAC secret for the operator-only GDPR storage-erasure endpoint.
     GDPR_ERASURE_SECRET?: string;
+    // Bearer secret for the self-hosted rank scheduler endpoint.
+    RANK_CHECK_SCHEDULER_SECRET?: string;
 
     // Cloudflare Turnstile — signup captcha (hosted only). Secret verifies
     // tokens server-side; site key is public and inlined into the client build.

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,10 @@ import { resolveUserContextFromHeaders } from "@/middleware/ensure-user/resolve"
 import { ProjectRepository } from "@/server/features/projects/repositories/ProjectRepository";
 import { SamSessionRepository } from "@/server/features/sam/SamSessionRepository";
 import { runScheduledRankChecks } from "@/server/features/rank-tracking/services/scheduledRankChecks";
+import {
+  SCHEDULED_RANK_CHECKS_PATH,
+  handleScheduledRankChecksRequest,
+} from "@/server/features/rank-tracking/services/scheduledRankChecksHttp";
 import { reconcileStaleAudits } from "@/server/features/audit/services/auditReconciler";
 import { getOrCreateOrganizationCustomer } from "@/server/billing/subscription";
 import { isHostedServerAuthMode } from "@/server/lib/runtime-env";
@@ -149,6 +153,12 @@ function handleFetch(
 
   if (pathname === GDPR_STORAGE_ERASURE_PATH) {
     return handleGdprStorageErasure(publicRequest, env);
+  }
+
+  if (pathname === SCHEDULED_RANK_CHECKS_PATH) {
+    return handleScheduledRankChecksRequest(publicRequest, env, () =>
+      withPgClient(() => runScheduledRankChecks(env)),
+    );
   }
 
   if (pathname.startsWith("/agents/")) {

--- a/src/server/features/rank-tracking/services/scheduledRankChecksHttp.test.ts
+++ b/src/server/features/rank-tracking/services/scheduledRankChecksHttp.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  SCHEDULED_RANK_CHECKS_PATH,
+  handleScheduledRankChecksRequest,
+} from "./scheduledRankChecksHttp";
+
+const url = `https://open-seo.example${SCHEDULED_RANK_CHECKS_PATH}`;
+
+function request(method = "POST", authorization?: string) {
+  return new Request(url, {
+    method,
+    headers: authorization ? { Authorization: authorization } : undefined,
+  });
+}
+
+describe("handleScheduledRankChecksRequest", () => {
+  it("fails closed when the scheduler secret is not configured", async () => {
+    const run = vi.fn();
+
+    const response = await handleScheduledRankChecksRequest(
+      request("POST", "Bearer anything"),
+      {},
+      run,
+    );
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({
+      ok: false,
+      status: "not_configured",
+    });
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["missing", undefined],
+    ["wrong", "Bearer wrong-secret"],
+    ["wrong scheme", "Basic configured-secret"],
+  ])("rejects %s authorization", async (_case, authorization) => {
+    const run = vi.fn();
+
+    const response = await handleScheduledRankChecksRequest(
+      request("POST", authorization),
+      { RANK_CHECK_SCHEDULER_SECRET: "configured-secret" },
+      run,
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      ok: false,
+      status: "unauthorized",
+    });
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-POST requests without invoking the scheduler", async () => {
+    const run = vi.fn();
+
+    const response = await handleScheduledRankChecksRequest(
+      request("GET", "Bearer configured-secret"),
+      { RANK_CHECK_SCHEDULER_SECRET: "configured-secret" },
+      run,
+    );
+
+    expect(response.status).toBe(405);
+    expect(response.headers.get("Allow")).toBe("POST");
+    expect(await response.json()).toEqual({
+      ok: false,
+      status: "method_not_allowed",
+    });
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("invokes the queued scheduled path and returns bounded counts", async () => {
+    const run = vi.fn().mockResolvedValue(undefined);
+    const env = {
+      RANK_CHECK_SCHEDULER_SECRET: "configured-secret",
+    };
+
+    const response = await handleScheduledRankChecksRequest(
+      request("POST", "Bearer configured-secret"),
+      env,
+      run,
+    );
+
+    expect(run).toHaveBeenCalledOnce();
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      ok: true,
+      status: "completed",
+    });
+  });
+
+  it("returns a generic error without exposing scheduler failures", async () => {
+    const run = vi
+      .fn()
+      .mockRejectedValue(new Error("database password leaked"));
+
+    const response = await handleScheduledRankChecksRequest(
+      request("POST", "Bearer configured-secret"),
+      { RANK_CHECK_SCHEDULER_SECRET: "configured-secret" },
+      run,
+    );
+
+    expect(response.status).toBe(500);
+    const responseText = await response.text();
+    expect(JSON.parse(responseText)).toEqual({
+      ok: false,
+      status: "error",
+    });
+    expect(responseText).not.toContain("database password leaked");
+  });
+});

--- a/src/server/features/rank-tracking/services/scheduledRankChecksHttp.ts
+++ b/src/server/features/rank-tracking/services/scheduledRankChecksHttp.ts
@@ -1,0 +1,62 @@
+export const SCHEDULED_RANK_CHECKS_PATH = "/api/internal/scheduled-rank-checks";
+
+type SchedulerAuthEnv = Pick<Env, "RANK_CHECK_SCHEDULER_SECRET">;
+type ScheduledRankChecksRunner = () => Promise<void>;
+
+function jsonResponse(body: unknown, status: number, headers?: HeadersInit) {
+  const responseHeaders = new Headers(headers);
+  responseHeaders.set("Cache-Control", "no-store");
+  return Response.json(body, {
+    status,
+    headers: responseHeaders,
+  });
+}
+
+async function constantTimeEqual(left: string, right: string) {
+  const encoder = new TextEncoder();
+  const [leftDigest, rightDigest] = await Promise.all([
+    crypto.subtle.digest("SHA-256", encoder.encode(left)),
+    crypto.subtle.digest("SHA-256", encoder.encode(right)),
+  ]);
+  const leftBytes = new Uint8Array(leftDigest);
+  const rightBytes = new Uint8Array(rightDigest);
+  let difference = 0;
+  for (let index = 0; index < leftBytes.length; index++) {
+    difference |= leftBytes[index] ^ rightBytes[index];
+  }
+  return difference === 0;
+}
+
+export async function handleScheduledRankChecksRequest(
+  request: Request,
+  env: SchedulerAuthEnv,
+  runScheduledRankChecks: ScheduledRankChecksRunner,
+): Promise<Response> {
+  if (request.method !== "POST") {
+    return jsonResponse({ ok: false, status: "method_not_allowed" }, 405, {
+      Allow: "POST",
+    });
+  }
+
+  const secret = env.RANK_CHECK_SCHEDULER_SECRET;
+  if (!secret) {
+    return jsonResponse({ ok: false, status: "not_configured" }, 503);
+  }
+
+  const authorization = request.headers.get("Authorization");
+  const expectedAuthorization = `Bearer ${secret}`;
+  if (
+    !authorization ||
+    !(await constantTimeEqual(authorization, expectedAuthorization))
+  ) {
+    return jsonResponse({ ok: false, status: "unauthorized" }, 401);
+  }
+
+  try {
+    await runScheduledRankChecks();
+    return jsonResponse({ ok: true, status: "completed" }, 200);
+  } catch {
+    console.error("[cron-http] Scheduled rank check invocation failed");
+    return jsonResponse({ ok: false, status: "error" }, 500);
+  }
+}

--- a/web/content/docs/self-hosting/docker.md
+++ b/web/content/docs/self-hosting/docker.md
@@ -41,6 +41,24 @@ Optional env values:
 - `AUTH_MODE=local_noauth` (already set in compose)
 - `OPEN_SEO_IMAGE` (defaults to `ghcr.io/every-app/open-seo:latest`)
 
+## Scheduled rank checks
+
+Docker does not emit Cloudflare Worker scheduled events. To run due rank checks,
+set a long random `RANK_CHECK_SCHEDULER_SECRET` in `.env`, recreate the container,
+and configure Coolify or another external scheduler to send an authenticated
+`POST` request on your desired cadence:
+
+```bash
+curl --fail-with-body --request POST \
+  --header "Authorization: Bearer $RANK_CHECK_SCHEDULER_SECRET" \
+  https://your-open-seo.example/api/internal/scheduled-rank-checks
+```
+
+The endpoint is disabled when the secret is unset, accepts `POST` only, and uses
+the same due-date, budget, deadline, and active-run guards as the Cloudflare
+scheduled handler. Keep the token in your scheduler's secret store and never put
+it in a URL or logs.
+
 If you are putting Docker behind a reverse proxy or a temporary tunnel, remember that Docker self-hosting runs with app auth disabled. Only expose it behind your own auth-protected reverse proxy, tunnel, or private network, and add the public hostname before restarting:
 
 ```bash


### PR DESCRIPTION
## Summary
- add a fail-closed bearer-authenticated internal endpoint for Docker/self-host due rank checks
- reuse the existing due-date and active-run guards and return bounded outcome counts
- document the required scheduler secret and external invocation pattern

## Verification
- 742 Vitest tests pass
- TypeScript check passes
- targeted type-aware oxlint passes
- diff check passes

## Motivation
Docker self-hosting starts Vite preview and does not emit Cloudflare Worker scheduled events, so configured rank trackers never run unattended.