### PR TITLE
Automate Paseo worktree setup

### DIFF
--- a/paseo.json
+++ b/paseo.json
@@ -1,0 +1,10 @@
+{
+  "worktree": {
+    "setup": [
+      "corepack enable",
+      "pnpm install --frozen-lockfile",
+      "if [ ! -f .env.local ]; then main_root=\"$(dirname \"$(git rev-parse --path-format=absolute --git-common-dir)\")\"; if [ -f \"$main_root/.env.local\" ]; then cp \"$main_root/.env.local\" .env.local; else cp .env.example .env.local; fi; fi; if ! grep -q '^AUTH_MODE=' .env.local; then printf '\\nAUTH_MODE=local_noauth\\n' >> .env.local; fi",
+      "pnpm run db:migrate:local"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- add committed Paseo worktree lifecycle configuration
- activate the repository-pinned pnpm version and install from the frozen lockfile
- prepare `.env.local` without overwriting an existing worktree file, copying the main checkout configuration when available or falling back to `.env.example`
- default fresh local worktrees to `AUTH_MODE=local_noauth`
- initialize the worktree-local D1 database migrations

## Verification

- parsed `paseo.json` successfully with Paseo 0.5.2's installed configuration parser
- exercised all setup commands in a disposable detached worktree
- installed 983 packages from the local pnpm store with zero downloads
- applied all 43 local D1 migrations
- verified Vite 7.3.6 and Wrangler 4.105.0 launch successfully

No credentials or generated environment/database files are committed.
