### PR TITLE
fix(ai-search): add Türkiye to Prompt Explorer

### DIFF
--- a/src/client/features/ai-search/platformLabels.test.ts
+++ b/src/client/features/ai-search/platformLabels.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { formatCountryLabel } from "./platformLabels";
+import {
+  WEB_SEARCH_COUNTRY_CODES,
+  webSearchCountryCodeSchema,
+} from "@/types/schemas/ai-search";
+
+describe("Prompt Explorer country labels", () => {
+  it("supports Türkiye for localized web search", () => {
+    expect(WEB_SEARCH_COUNTRY_CODES).toContain("TR");
+    const countryCode = webSearchCountryCodeSchema.parse("TR");
+    expect(formatCountryLabel(countryCode)).toBe("Türkiye");
+  });
+});

--- a/src/client/features/ai-search/platformLabels.ts
+++ b/src/client/features/ai-search/platformLabels.ts
@@ -80,6 +80,7 @@ const COUNTRY_LABELS: Record<WebSearchCountryCode, string> = {
   NL: "Netherlands",
   PT: "Portugal",
   PL: "Poland",
+  TR: "Türkiye",
   SE: "Sweden",
   NO: "Norway",
   DK: "Denmark",

--- a/src/types/schemas/ai-search.ts
+++ b/src/types/schemas/ai-search.ts
@@ -185,6 +185,7 @@ export const WEB_SEARCH_COUNTRY_CODES = [
   "NL",
   "PT",
   "PL",
+  "TR",
   "SE",
   "NO",
   "DK",


### PR DESCRIPTION
## Problem

Prompt Explorer does not offer Türkiye as a web-search location, although DataForSEO supports the `TR` ISO country code.

## Change

- Add `TR` to the Prompt Explorer country schema and selector options.
- Display the country using its official short name, `Türkiye`.
- Add a regression test covering the country code, schema, and label.

## Validation

- `pnpm test` — 1,114 tests passed
- `pnpm exec tsc --noEmit`
- Oxlint on changed files
- Prettier check on changed files
- `pnpm run build`