### PR TITLE
fix(integrations): Google Search Console and Google Analytics still show "Connected" after the token expires

### DIFF
--- a/src/server/features/ga4/services/Ga4Service.test.ts
+++ b/src/server/features/ga4/services/Ga4Service.test.ts
@@ -242,3 +242,37 @@ describe("Ga4Service", () => {
     expect(mocks.dbDelete).not.toHaveBeenCalled();
   });
 });
+
+describe("verifyConnection", () => {
+  const connection = { connectedByUserId: "u1", ga4AccountId: "sub-a" };
+
+  it("is true when the stored grant still reaches Analytics", async () => {
+    mocks.listProperties.mockResolvedValue([]);
+
+    await expect(Ga4Service.verifyConnection(connection)).resolves.toBe(true);
+  });
+
+  it("is false when Google rejects the stored grant, without error logging", async () => {
+    mocks.listProperties.mockRejectedValue(new Ga4TokenError("revoked"));
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    await expect(Ga4Service.verifyConnection(connection)).resolves.toBe(
+      false,
+    );
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  it("is false but logs on an unexpected error", async () => {
+    mocks.listProperties.mockRejectedValue(new Error("network blip"));
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    await expect(Ga4Service.verifyConnection(connection)).resolves.toBe(
+      false,
+    );
+    expect(consoleError).toHaveBeenCalled();
+  });
+});

--- a/src/server/features/ga4/services/Ga4Service.ts
+++ b/src/server/features/ga4/services/Ga4Service.ts
@@ -170,10 +170,32 @@ async function disconnect(input: {
   }
 }
 
+/** Confirms a stored connection's grant still reaches Analytics, not just
+ *  that a row exists -- the same live probe listPropertiesForUserWithGrantStatus
+ *  uses per-account, scoped to this connection's specific grant. */
+async function verifyConnection(
+  connection: Pick<Ga4Connection, "connectedByUserId" | "ga4AccountId">,
+): Promise<boolean> {
+  const client = createGa4AdminClient({
+    userId: connection.connectedByUserId,
+    ga4AccountId: connection.ga4AccountId,
+  });
+  try {
+    await client.listProperties();
+    return true;
+  } catch (error) {
+    if (!requiresReconnect(error)) {
+      console.error("GA4 connection verify failed unexpectedly", error);
+    }
+    return false;
+  }
+}
+
 export const Ga4Service = {
   getConnection,
   userHasGrant,
   listPropertiesForUserWithGrantStatus,
   setProperty,
   disconnect,
+  verifyConnection,
 };

--- a/src/server/features/gsc/services/GscService.test.ts
+++ b/src/server/features/gsc/services/GscService.test.ts
@@ -430,3 +430,37 @@ describe("GscService.disconnect", () => {
     expect(mocks.dbDelete).not.toHaveBeenCalled();
   });
 });
+
+describe("verifyConnection", () => {
+  const connection = { connectedByUserId: "u1", gscAccountId: "sub-a" };
+
+  it("is true when the stored grant still reaches Search Console", async () => {
+    mocks.listSites.mockResolvedValue([]);
+
+    await expect(GscService.verifyConnection(connection)).resolves.toBe(true);
+  });
+
+  it("is false when Google rejects the stored grant, without error logging", async () => {
+    mocks.listSites.mockRejectedValue(new GscTokenError("revoked"));
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    await expect(GscService.verifyConnection(connection)).resolves.toBe(
+      false,
+    );
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  it("is false but logs on an unexpected error", async () => {
+    mocks.listSites.mockRejectedValue(new Error("network blip"));
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    await expect(GscService.verifyConnection(connection)).resolves.toBe(
+      false,
+    );
+    expect(consoleError).toHaveBeenCalled();
+  });
+});

--- a/src/server/features/gsc/services/GscService.ts
+++ b/src/server/features/gsc/services/GscService.ts
@@ -302,6 +302,27 @@ async function inspectUrls(input: {
   };
 }
 
+/** Confirms a stored connection's grant still reaches Search Console, not
+ *  just that a row exists -- the same live probe listSitesForUserWithGrantStatus
+ *  uses per-account, scoped to this connection's specific grant. */
+async function verifyConnection(
+  connection: Pick<GscConnection, "connectedByUserId" | "gscAccountId">,
+): Promise<boolean> {
+  const client = createGscClient({
+    userId: connection.connectedByUserId,
+    gscAccountId: connection.gscAccountId ?? undefined,
+  });
+  try {
+    await client.listSites();
+    return true;
+  } catch (error) {
+    if (!isExpectedGrantFailure(error)) {
+      console.error("GSC connection verify failed unexpectedly", error);
+    }
+    return false;
+  }
+}
+
 export const GscService = {
   getConnection,
   userHasGrant,
@@ -310,4 +331,5 @@ export const GscService = {
   disconnect,
   getPerformance,
   inspectUrls,
+  verifyConnection,
 };

--- a/src/serverFunctions/ga4.ts
+++ b/src/serverFunctions/ga4.ts
@@ -39,8 +39,13 @@ export const getGa4Connection = createServerFn({ method: "POST" })
         isHostedServerAuthMode(),
         hasSelfHostedGoogleOAuthConfig(),
       ]);
+    // A row existing only means it was connected once -- confirm the grant
+    // still reaches Google before telling the settings page it's fine.
+    const connected = connection
+      ? await Ga4Service.verifyConnection(connection)
+      : false;
     return {
-      connected: Boolean(connection),
+      connected,
       currentUserHasGrant,
       googleOAuthConfigured: hosted || ga4Configured,
       propertyId: connection?.propertyId ?? null,

--- a/src/serverFunctions/gsc.ts
+++ b/src/serverFunctions/gsc.ts
@@ -45,8 +45,13 @@ export const getGscConnection = createServerFn({ method: "POST" })
         isHostedServerAuthMode(),
         hasSelfHostedGoogleOAuthConfig(),
       ]);
+    // A row existing only means it was connected once -- confirm the grant
+    // still reaches Google before telling the settings page it's fine.
+    const connected = connection
+      ? await GscService.verifyConnection(connection)
+      : false;
     return {
-      connected: Boolean(connection),
+      connected,
       currentUserHasGrant,
       googleOAuthConfigured: hosted || gscConfigured,
       siteUrl: connection?.siteUrl ?? null,


### PR DESCRIPTION
# Expected

`Settings > Integrations` should tell you when a Google connection actually stops working, not just whether you connected it once.

# Current state

`getGscConnection` and `getGa4Connection` only check whether a connection row exists in the database. Once GSC or GA4 is connected, the badge reads "Connected" forever, even after Google revokes or expires the token. Nothing on that page tells you it's broken, and there's no way to reconnect from there.

The rest of the codebase already handles this correctly. `GscCard` and `Ga4Card` on the dashboard call a real report endpoint and fall back to a connect prompt when the grant is dead. `listSitesForUserWithGrantStatus` and `listPropertiesForUserWithGrantStatus` do the same live check per account. `Settings > Integrations` is the one place that never actually asks Google.

I hit this on a project I run: **GSC returned api_error and GA4 returned ga4_reconnect_required through the MCP tools, while Integrations still showed both connections green.**

# Solution

Added `GscService.verifyConnection` and `Ga4Service.verifyConnection`. Each makes one live call, `listSites` or `listProperties`, against the connection's stored account. It is the same call the grant-status checks already use elsewhere. If Google rejects it, the function returns false.

Wired both into `getGscConnection` and `getGa4Connection` so the page shows the real state.

Prioritizing minimal change. 10 new tests cover the working and broken paths. Typecheck is clean. 