### PR TITLE
Let self-hosted deployments use Access service tokens and declare a custom domain

### DIFF
--- a/.env.selfhost.example
+++ b/.env.selfhost.example
@@ -8,6 +8,19 @@ DATAFORSEO_API_KEY=
 # Who may sign in through Cloudflare Access, comma-separated
 ACCESS_ALLOWED_EMAILS=
 
+# Custom domain(s) bound to the worker, comma-separated. Set this if you've
+# added a Cloudflare Custom Domain by hand — otherwise it gets removed on the
+# next deploy.
+# CUSTOM_DOMAIN=
+
+# Cloudflare Access service tokens allowed in without an interactive login,
+# comma-separated. Use for headless callers (an agent, CI) hitting /mcp: they
+# cannot complete the email login the allow-list above requires. Create the
+# token under Zero Trust > Access > Service Auth and put its ID here — the
+# UUID, not the Client ID. Each token gets its own user in the shared
+# workspace, so treat one as equivalent to a listed email.
+# ACCESS_SERVICE_TOKEN_IDS=
+
 # ---------- Optional — uncomment to use ----------
 
 # Google Search Console (all three together) — docs/SELF_HOSTING_GOOGLE_SEARCH_CONSOLE.md

--- a/alchemy.access.ts
+++ b/alchemy.access.ts
@@ -57,25 +57,75 @@ export const requireAllowedEmails = (remedy: string) =>
     return emails;
   });
 
-/** The gate itself: an email allow-policy on a self-hosted Access application. */
+/**
+ * Reads ACCESS_SERVICE_TOKEN_IDS: the Access service tokens (UUIDs, not Client
+ * IDs) allowed through the gate without an interactive login. Optional — an
+ * empty list leaves the gate email-only.
+ */
+export const readServiceTokenIds = () =>
+  Effect.gen(function* () {
+    return (yield* Config.string("ACCESS_SERVICE_TOKEN_IDS").pipe(
+      Config.withDefault(""),
+    ))
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+  });
+
+/**
+ * The gate itself: an email allow-policy on a self-hosted Access application,
+ * plus an optional Service Auth policy for machine callers.
+ *
+ * `domains` is the full set of hostnames the gate covers. Every hostname the
+ * worker answers on must be listed — Cloudflare reconciles this app's
+ * destinations on each deploy, so a hostname missing here is a hostname that
+ * silently loses its Access gate and starts serving unauthenticated requests
+ * to the worker.
+ */
 export const emailAccessGate = (options: {
   policyId: string;
+  serviceTokenPolicyId: string;
   applicationId: string;
   policyName: string;
+  serviceTokenPolicyName: string;
   applicationName: string;
-  domain: string;
+  domains: readonly [string, ...string[]];
   emails: string[];
+  serviceTokenIds?: readonly string[];
 }) =>
   Effect.gen(function* () {
+    const [primaryDomain] = options.domains;
     const allow = yield* Cloudflare.Access.Policy(options.policyId, {
       name: options.policyName,
       decision: "allow",
       include: options.emails.map((email) => ({ email: { email } })),
     });
+
+    // `non_identity` is the API spelling of the dashboard's "Service Auth"
+    // action: match on the token alone and skip the IdP round-trip that a
+    // headless client cannot complete.
+    const serviceTokenIds = options.serviceTokenIds ?? [];
+    const serviceTokens =
+      serviceTokenIds.length > 0
+        ? yield* Cloudflare.Access.Policy(options.serviceTokenPolicyId, {
+            name: options.serviceTokenPolicyName,
+            decision: "non_identity",
+            include: serviceTokenIds.map((tokenId) => ({
+              serviceToken: { tokenId },
+            })),
+          })
+        : null;
+
     return yield* Cloudflare.Access.Application(options.applicationId, {
       type: "self_hosted",
       name: options.applicationName,
-      domain: options.domain,
-      policies: [allow.policyId],
+      domain: primaryDomain,
+      destinations: options.domains.map((uri) => ({
+        type: "public" as const,
+        uri,
+      })),
+      policies: serviceTokens
+        ? [allow.policyId, serviceTokens.policyId]
+        : [allow.policyId],
     });
   });

--- a/alchemy.preview-access.run.ts
+++ b/alchemy.preview-access.run.ts
@@ -4,6 +4,7 @@ import * as Effect from "effect/Effect";
 import {
   emailAccessGate,
   previewWildcard,
+  readServiceTokenIds,
   readWorkersSubdomain,
   requireAllowedEmails,
 } from "./alchemy.access.ts";
@@ -33,11 +34,14 @@ export default Alchemy.Stack(
     const hostname = previewWildcard(subdomain);
     const application = yield* emailAccessGate({
       policyId: "PreviewAllowTeam",
+      serviceTokenPolicyId: "PreviewAllowServiceTokens",
       applicationId: "PreviewAccess",
       policyName: "open-seo preview team",
+      serviceTokenPolicyName: "open-seo preview service tokens",
       applicationName: "open-seo preview environments",
-      domain: hostname,
+      domains: [hostname],
       emails: allowedEmails,
+      serviceTokenIds: yield* readServiceTokenIds(),
     });
 
     return {

--- a/alchemy.run.ts
+++ b/alchemy.run.ts
@@ -11,6 +11,7 @@ import { z } from "zod";
 import {
   emailAccessGate,
   HOSTED_PROD_STAGE,
+  readServiceTokenIds,
   readWorkersSubdomain,
   requireAllowedEmails,
   workerName,
@@ -241,13 +242,23 @@ const resolveSelfHostAccess = (
       const allowedEmails = yield* requireAllowedEmails(
         "Set ACCESS_ALLOWED_EMAILS to the comma-separated emails allowed through Cloudflare Access — or set TEAM_DOMAIN and POLICY_AUD to manage the Access application yourself.",
       );
+      // CUSTOM_DOMAIN hostnames are routed to the worker, so they must be
+      // gated too — the workers.dev hostname alone would leave the custom
+      // domain reachable without Access.
+      const customDomains = (yield* optionalVar("CUSTOM_DOMAIN"))
+        .split(",")
+        .map((domain) => domain.trim())
+        .filter(Boolean);
       const application = yield* emailAccessGate({
         policyId: "SelfHostAllowUsers",
+        serviceTokenPolicyId: "SelfHostAllowServiceTokens",
         applicationId: "SelfHostAccess",
         policyName: `open-seo ${stage} self-host users`,
+        serviceTokenPolicyName: `open-seo ${stage} service tokens`,
         applicationName: `open-seo ${stage}`,
-        domain: `${workerName(stage)}.${subdomain}`,
+        domains: [`${workerName(stage)}.${subdomain}`, ...customDomains],
         emails: allowedEmails,
+        serviceTokenIds: yield* readServiceTokenIds(),
       });
       policyAud = application.aud;
     }
@@ -351,10 +362,23 @@ export default Alchemy.Stack(
       workersSubdomain,
     );
 
+    // Self-hosters binding their own domain (e.g. a Cloudflare Custom Domain
+    // set up by hand) set CUSTOM_DOMAIN so alchemy's reconciliation doesn't
+    // treat "no domain configured" as the desired state and tear it down on
+    // the next deploy.
+    const customDomain = yield* optionalVar("CUSTOM_DOMAIN");
+
     const app = yield* Cloudflare.Worker("open-seo", {
       name: workerName(stage),
       // Prod serves the real domains; the zone is inferred from the hostname.
-      domain: prod ? ["app.openseo.so", "www.app.openseo.so"] : undefined,
+      domain: prod
+        ? ["app.openseo.so", "www.app.openseo.so"]
+        : customDomain
+          ? customDomain
+              .split(",")
+              .map((d) => d.trim())
+              .filter(Boolean)
+          : undefined,
       // Prebuilt worker from `vite build` (@cloudflare/vite-plugin). The entry
       // exports the DO + WorkflowEntrypoint classes (re-exported by
       // src/server.ts), which `bundle: false` requires. Sibling chunks under

--- a/docs/SELF_HOSTING_CLOUDFLARE.md
+++ b/docs/SELF_HOSTING_CLOUDFLARE.md
@@ -4,7 +4,7 @@ Host OpenSEO on Cloudflare for internet-facing self-hosting across multiple devi
 
 Related guides:
 
-- [Operations](./SELF_HOSTING_CLOUDFLARE_OPERATIONS.md): connect the MCP server, telemetry.
+- [Operations](./SELF_HOSTING_CLOUDFLARE_OPERATIONS.md): connect the MCP server, headless access for agents and CI, telemetry.
 - [Legacy deployments](./SELF_HOSTING_CLOUDFLARE_LEGACY.md): maintenance for installs created with the retired Deploy-button or manual Wrangler flows.
 
 ## Prerequisites
@@ -75,6 +75,26 @@ git pull        # or: git fetch upstream && git merge upstream/main, if you fork
 pnpm install
 pnpm deploy:selfhost --yes
 ```
+
+## Using your own domain
+
+Bind the domain in `.env.selfhost` rather than in the Cloudflare dashboard:
+
+```bash
+CUSTOM_DOMAIN=openseo.example.com
+```
+
+The zone is inferred from the hostname, so it must already be a zone on the
+same Cloudflare account. Redeploy and the domain is routed to the Worker *and*
+added to the Access application, so it is gated exactly like the workers.dev
+hostname.
+
+**A Custom Domain added by hand in the dashboard does not survive a deploy.**
+Each `pnpm deploy:selfhost` reconciles the Worker's routes and the Access
+application's destinations against what the code declares: an unset
+`CUSTOM_DOMAIN` reads as "no custom domain wanted", so the deploy removes the
+one you added. Setting the variable is what makes it stick. Comma-separate to
+bind more than one.
 
 ## Giving teammates access
 

--- a/docs/SELF_HOSTING_CLOUDFLARE_OPERATIONS.md
+++ b/docs/SELF_HOSTING_CLOUDFLARE_OPERATIONS.md
@@ -1,6 +1,6 @@
 # Cloudflare Self-Hosting: Operations
 
-Day-to-day tasks after [initial setup](./SELF_HOSTING_CLOUDFLARE.md): connect the MCP server and manage telemetry. Updating and teammate access are covered in the [deploy guide](./SELF_HOSTING_CLOUDFLARE.md) (or the [legacy page](./SELF_HOSTING_CLOUDFLARE_LEGACY.md) for pre-alchemy deployments).
+Day-to-day tasks after [initial setup](./SELF_HOSTING_CLOUDFLARE.md): connect the MCP server, let agents and CI in without a human login, and manage telemetry. Updating and teammate access are covered in the [deploy guide](./SELF_HOSTING_CLOUDFLARE.md) (or the [legacy page](./SELF_HOSTING_CLOUDFLARE_LEGACY.md) for pre-alchemy deployments).
 
 ## Connect the MCP server through Cloudflare Access
 
@@ -25,6 +25,42 @@ MCP clients should connect to:
 ```text
 https://YOUR_WORKER_HOSTNAME/mcp
 ```
+
+## Let an agent or CI in without a human login
+
+Managed OAuth above covers MCP clients that can open a browser. A fully
+headless caller — a self-hosted agent, a scheduled job, CI — cannot complete
+the email one-time-code that `ACCESS_ALLOWED_EMAILS` requires, so every request
+it makes stops at the Access gate. Give it a **service token** instead.
+
+1. In Cloudflare Zero Trust, go to `Access controls` -> `Service auth` and
+   create a service token. Save the Client ID and Client Secret — the secret is
+   shown once.
+2. Put the token's **ID** (the UUID in the token's URL, *not* the Client ID) in
+   `.env.selfhost`, comma-separating several:
+
+   ```bash
+   ACCESS_SERVICE_TOKEN_IDS=00000000-0000-0000-0000-000000000000
+   ```
+
+3. Redeploy. This adds a Service Auth policy to the Access application
+   admitting exactly those tokens.
+4. The caller sends the credentials as headers on every request:
+
+   ```bash
+   curl https://YOUR_WORKER_HOSTNAME/mcp \
+     -H "CF-Access-Client-Id: <client id>" \
+     -H "CF-Access-Client-Secret: <client secret>"
+   ```
+
+Add the policy in `.env.selfhost`, not in the dashboard — like the email
+allow-list, a policy added by hand is overwritten on the next deploy.
+
+**Treat a service token as equivalent to a listed email.** Access issues these
+tokens with no `sub` and no `email`, so OpenSEO maps each one to a synthetic
+user in the same shared workspace everyone else uses. The token holder reads
+and writes your real projects, and its actions are attributed to the token's
+name rather than to a person.
 
 ## Telemetry
 

--- a/src/middleware/ensure-user/cloudflareAccess.test.ts
+++ b/src/middleware/ensure-user/cloudflareAccess.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type * as CloudflareAccessModule from "./cloudflareAccess";
+
+// Identity derivation is the whole security surface of this module: which
+// claims become which user. Cloudflare Access token verification and the
+// database are mocked so each case asserts only that mapping.
+
+const mockEnv = vi.hoisted(() => ({
+  TEAM_DOMAIN: "https://example.cloudflareaccess.com",
+  POLICY_AUD: "test-aud",
+}));
+
+const jwtVerify = vi.hoisted(() => vi.fn());
+const resolveSharedWorkspaceContext = vi.hoisted(() => vi.fn());
+
+vi.mock("cloudflare:workers", () => ({ env: mockEnv }));
+vi.mock("jose", () => ({
+  createRemoteJWKSet: () => ({}),
+  jwtVerify,
+}));
+vi.mock("./delegated", () => ({ resolveSharedWorkspaceContext }));
+
+let resolveCloudflareAccessContext: typeof CloudflareAccessModule.resolveCloudflareAccessContext;
+
+beforeEach(async () => {
+  resolveSharedWorkspaceContext.mockImplementation(
+    async (userId: string, userEmail: string) => ({
+      userId,
+      userEmail,
+      emailVerified: true,
+      organizationId: "org_shared",
+    }),
+  );
+  ({ resolveCloudflareAccessContext } = await import("./cloudflareAccess"));
+});
+
+function headers() {
+  return new Headers({ "cf-access-jwt-assertion": "token" });
+}
+
+describe("resolveCloudflareAccessContext", () => {
+  it("maps a human Access token to its own identity", async () => {
+    jwtVerify.mockResolvedValue({
+      payload: { sub: "user-sub", email: "danny@example.com" },
+    });
+
+    await expect(resolveCloudflareAccessContext(headers())).resolves.toEqual({
+      userId: "user-sub",
+      userEmail: "danny@example.com",
+      emailVerified: true,
+      organizationId: "org_shared",
+    });
+  });
+
+  it("maps a service token to a stable synthetic user in the shared workspace", async () => {
+    // Exactly what Access issues for a Service Auth policy: empty sub, no
+    // email, the token's Client ID in common_name.
+    jwtVerify.mockResolvedValue({
+      payload: { sub: "", common_name: "abc123.access" },
+    });
+
+    await expect(resolveCloudflareAccessContext(headers())).resolves.toEqual({
+      userId: "access-service-token:abc123.access",
+      userEmail: "abc123.access@service-token.invalid",
+      emailVerified: true,
+      organizationId: "org_shared",
+    });
+  });
+
+  it("rejects a token carrying neither an email nor a service token name", async () => {
+    jwtVerify.mockResolvedValue({ payload: { sub: "" } });
+
+    await expect(resolveCloudflareAccessContext(headers())).rejects.toThrow();
+    expect(resolveSharedWorkspaceContext).not.toHaveBeenCalled();
+  });
+});

--- a/src/middleware/ensure-user/cloudflareAccess.ts
+++ b/src/middleware/ensure-user/cloudflareAccess.ts
@@ -36,6 +36,13 @@ function getValidatedTeamDomain(teamDomain: string) {
   return result.origin;
 }
 
+// Identity for Cloudflare Access service tokens. The prefix keeps a token's
+// synthetic user id from ever colliding with an IdP `sub`, and the RFC 2606
+// `.invalid` domain guarantees the synthetic address is unroutable, so nothing
+// downstream can email it.
+const SERVICE_TOKEN_USER_PREFIX = "access-service-token:";
+const SERVICE_TOKEN_EMAIL_DOMAIN = "service-token.invalid";
+
 export async function resolveCloudflareAccessContext(
   headers: Headers,
 ): Promise<EnsuredUserContext> {
@@ -91,6 +98,22 @@ export async function resolveCloudflareAccessContext(
   const userEmail = typeof payload.email === "string" ? payload.email : null;
 
   if (!userId || !userEmail) {
+    // Service-token requests carry no human identity: Access issues them with
+    // an empty `sub` and no `email`, only `common_name` (the token's Client
+    // ID). Machine callers — a self-hosted agent, CI — have no other way in,
+    // so map the token to a stable synthetic user. Reaching this point already
+    // means an operator wrote a Service Auth policy admitting this exact
+    // token, so the token IS the authorization.
+    const serviceTokenName =
+      typeof payload.common_name === "string" ? payload.common_name.trim() : "";
+
+    if (serviceTokenName) {
+      return resolveSharedWorkspaceContext(
+        `${SERVICE_TOKEN_USER_PREFIX}${serviceTokenName}`,
+        `${serviceTokenName}@${SERVICE_TOKEN_EMAIL_DOMAIN}`,
+      );
+    }
+
     throw new AppError("UNAUTHENTICATED");
   }
 


### PR DESCRIPTION
## The problem

Two things bit me setting up a self-hosted instance on a custom domain.

**1. A headless client can't get in at all.**

`ACCESS_ALLOWED_EMAILS` is an interactive email one-time-code gate. An agent or a CI job can't complete it. `oseo_` API keys would be the way around that, but those are hosted-mode only (`isHostedClientAuthMode()` gates the whole Settings section), so on a self-hosted instance there is no machine credential of any kind and `/mcp` is unreachable.

A Cloudflare Access **service token** is the obvious answer, and it half-works: Access lets the token through, then the app rejects it. Those JWTs carry `sub: ""` and no `email`, only `common_name`, and `resolveCloudflareAccessContext` throws when either is missing. It surfaces as Worker error 1101, which is not a helpful thing to debug.

**2. A custom domain silently disappears on the next deploy.**

If you add a Custom Domain in the Cloudflare dashboard, the next `pnpm deploy:selfhost` removes it — an unset domain reads as "no domain wanted" and reconciliation tears it down, *and* drops the hostname from the Access application on the way out. There was no way to declare one, so there was no way to keep one.

This one is worth a look even if you skip the rest. A hostname routed to the worker but missing from the Access app's `destinations` reaches the worker without an Access check.

## What this does

Two env vars in `.env.selfhost`:

- `ACCESS_SERVICE_TOKEN_IDS` — comma-separated Access service token IDs. Adds a Service Auth (`non_identity`) policy admitting them, and maps a `common_name`-only JWT to a synthetic user in the shared workspace. Getting that far already means an operator wrote a policy admitting that exact token, so the token is the authorization.
- `CUSTOM_DOMAIN` — comma-separated hostnames. Routed to the worker *and* added to the Access application's destinations, so a custom domain is gated exactly like the workers.dev one.

Both default to empty and change nothing if unset.

Docs in `SELF_HOSTING_CLOUDFLARE.md` ("Using your own domain") and `SELF_HOSTING_CLOUDFLARE_OPERATIONS.md` ("Let an agent or CI in without a human login"), including the warning that a service token reads and writes real projects in the shared workspace and should be treated like a listed email.

New unit tests cover the three identity cases: human token, service token, neither.

## Testing

Running on my own instance since 27 Aug. `curl` with the token headers gets `200` and a working `/mcp` (46 tools, live SERP results); without them still `302` to the Access login. My own email login is unaffected. Custom domain survived the redeploy that previously removed it.

`tsc --noEmit` clean, `vitest` 134 files / 1116 tests passing on this branch.

## On your PR policy

I read CONTRIBUTING — I know you're not merging external PRs. Posting it as a proof of concept rather than asking you to take it. Happy to write it up as an issue instead if that's more useful, and equally happy for you to have your own agent build it differently.

Written with Claude Code, tested by hand against a real deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
