### PR TITLE
docs: add RepoCloud one-click deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ OpenSEO supports two self-hosting paths:
 
 Either way, you need a DataForSEO API key to get SEO data. See [`docs/DATAFORSEO_API_KEY.md`](./docs/DATAFORSEO_API_KEY.md).
 
+## ☁️ One-Click Deploy
+
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/Open%20SEO/)
+
 ## Costs
 
 OpenSEO needs a [DataForSEO](https://dataforseo.com/?aff=255379) API key so that you can get SEO data. You pay them directly when self hosting.


### PR DESCRIPTION
Adds a RepoCloud one-click deploy button in a new "☁️ One-Click Deploy" section between the Self-Hosting and Costs sections.

 - New `## ☁️ One-Click Deploy` section added after Self-Hosting
 - Button links to https://repocloud.io/details/Open%20SEO/