### PR TITLE
selfhost: optional SELFHOST_DOMAIN for a custom hostname

### DIFF
--- a/.env.selfhost.example
+++ b/.env.selfhost.example
@@ -10,6 +10,11 @@ ACCESS_ALLOWED_EMAILS=
 
 # ---------- Optional — uncomment to use ----------
 
+# Serve on your own hostname instead of open-seo-selfhost.<account>.workers.dev.
+# The zone must be in the same Cloudflare account; the DNS record and the
+# Cloudflare Access application are provisioned for this hostname.
+# SELFHOST_DOMAIN=seo.example.com
+
 # Google Search Console (all three together) — docs/SELF_HOSTING_GOOGLE_SEARCH_CONSOLE.md
 # GOOGLE_CLIENT_ID=
 # GOOGLE_CLIENT_SECRET=

--- a/alchemy.run.ts
+++ b/alchemy.run.ts
@@ -172,6 +172,7 @@ const resolveSelfHostAccess = (
   stage: string,
   provision: boolean,
   workersSubdomain: string,
+  selfHostDomain: string,
 ) =>
   Effect.gen(function* () {
     let teamDomain = yield* optionalVar("TEAM_DOMAIN");
@@ -246,7 +247,9 @@ const resolveSelfHostAccess = (
         applicationId: "SelfHostAccess",
         policyName: `open-seo ${stage} self-host users`,
         applicationName: `open-seo ${stage}`,
-        domain: `${workerName(stage)}.${subdomain}`,
+        // SELFHOST_DOMAIN puts the Access gate on the custom hostname the
+        // worker serves; otherwise it guards the workers.dev preview URL.
+        domain: selfHostDomain || `${workerName(stage)}.${subdomain}`,
         emails: allowedEmails,
       });
       policyAud = application.aud;
@@ -308,6 +311,10 @@ export default Alchemy.Stack(
     );
     const databaseProvider = yield* optionalVar("DATABASE_PROVIDER");
     const workersSubdomain = yield* readWorkersSubdomain({ required: false });
+    // Optional custom hostname for self-host deploys (e.g. seo.example.com).
+    // The zone must live in the same Cloudflare account; alchemy infers it
+    // from the hostname and manages the DNS record.
+    const selfHostDomain = yield* optionalVar("SELFHOST_DOMAIN");
 
     // Auth needs an absolute BETTER_AUTH_URL. Prod sets it explicitly;
     // previews always derive it from the deterministic worker name — a wrong
@@ -349,12 +356,17 @@ export default Alchemy.Stack(
       stage,
       authMode === "cloudflare_access" && !prod,
       workersSubdomain,
+      selfHostDomain,
     );
 
     const app = yield* Cloudflare.Worker("open-seo", {
       name: workerName(stage),
       // Prod serves the real domains; the zone is inferred from the hostname.
-      domain: prod ? ["app.openseo.so", "www.app.openseo.so"] : undefined,
+      domain: prod
+        ? ["app.openseo.so", "www.app.openseo.so"]
+        : selfHostDomain
+          ? [selfHostDomain]
+          : undefined,
       // Prebuilt worker from `vite build` (@cloudflare/vite-plugin). The entry
       // exports the DO + WorkflowEntrypoint classes (re-exported by
       // src/server.ts), which `bundle: false` requires. Sibling chunks under

--- a/docs/SELF_HOSTING_CLOUDFLARE.md
+++ b/docs/SELF_HOSTING_CLOUDFLARE.md
@@ -50,6 +50,8 @@ Copy the template and fill in the required values:
 cp .env.selfhost.example .env.selfhost
 ```
 
+To serve OpenSEO on your own hostname (for example `seo.example.com`) instead of the default `open-seo-selfhost.<account>.workers.dev`, set `SELFHOST_DOMAIN=seo.example.com`. The zone must be in the same Cloudflare account; the deploy creates the DNS record and puts the Cloudflare Access application on that hostname.
+
 ## 4) Deploy
 
 ```bash


### PR DESCRIPTION
## What

Self-host deploys are currently pinned to the `open-seo-selfhost.<account>.workers.dev` preview URL — the worker `domain` and the Access application hostname are only wired up for the hosted-prod stage. This PR adds an optional `SELFHOST_DOMAIN` env var so self-hosters can serve OpenSEO on their own hostname (e.g. `seo.example.com`):

- `alchemy.run.ts`: worker gets `domain: [SELFHOST_DOMAIN]` on non-prod stages when set (zone inferred from the hostname, DNS record managed by alchemy as usual), and `resolveSelfHostAccess` puts the auto-provisioned Access application on that hostname instead of the workers.dev URL.
- `.env.selfhost.example` + `docs/SELF_HOSTING_CLOUDFLARE.md`: documented.

Unset, nothing changes — the workers.dev flow behaves exactly as before.

## Why

Serving on a real hostname matters for self-hosters: the GSC OAuth redirect URI stays stable, the Cloudflare Access gate covers the URL people actually use, and the workers.dev URL stops being the front door.

## Tested

Running in production on my own deployment (Cloudflare free plan): deploy provisioned the DNS record and the Access app on the custom hostname on the first run; unauthenticated requests are redirected to the Access login; the workers.dev host serves only the shell and every server function rejects without the Access JWT (`AUTH_CONFIG_MISSING`), as before. Redeploys are idempotent.

Happy to file this as an issue instead if that fits your workflow better — the diff is small (+21/−2) and meant as a proof of concept per CONTRIBUTING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ke3UYsNyfsWEN2aG2NCbZQ
