### PR TITLE
fix(access): accept Cloudflare Access service tokens as a service identity

### DIFF
--- a/src/middleware/ensure-user/accessIdentity.test.ts
+++ b/src/middleware/ensure-user/accessIdentity.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { resolveAccessIdentity } from "./accessIdentity";
+
+/**
+ * Which Cloudflare Access JWTs are allowed to become a user, and as whom.
+ *
+ * This is an authentication boundary, so the cases that must FAIL matter more than the ones
+ * that must pass: a payload with neither a human identity nor a service identity has to be
+ * rejected rather than quietly resolved to something.
+ */
+describe("resolveAccessIdentity", () => {
+  it("accepts a user token and uses its own sub and email", () => {
+    expect(
+      resolveAccessIdentity({ sub: "user-123", email: "drew@example.com" }),
+    ).toEqual({ userId: "user-123", userEmail: "drew@example.com" });
+  });
+
+  it("accepts a service token by common_name when sub and email are absent", () => {
+    expect(resolveAccessIdentity({ common_name: "abc123.access" })).toEqual({
+      userId: "cf-service-token:abc123.access",
+      userEmail: "abc123.access@service.invalid",
+    });
+  });
+
+  it("prefers the human identity when a token somehow carries both", () => {
+    expect(
+      resolveAccessIdentity({
+        sub: "user-123",
+        email: "drew@example.com",
+        common_name: "abc123.access",
+      }),
+    ).toEqual({ userId: "user-123", userEmail: "drew@example.com" });
+  });
+
+  it("rejects a payload with no identity of either kind", () => {
+    expect(resolveAccessIdentity({})).toBeNull();
+  });
+
+  it("rejects a user token missing its email rather than inventing one", () => {
+    // The pre-existing contract: half a human identity is not an identity.
+    expect(resolveAccessIdentity({ sub: "user-123" })).toBeNull();
+  });
+
+  it("rejects a blank or whitespace common_name", () => {
+    expect(resolveAccessIdentity({ common_name: "   " })).toBeNull();
+  });
+
+  it("ignores non-string claims", () => {
+    expect(
+      resolveAccessIdentity({ sub: 1 as unknown as string, common_name: 2 as unknown as string }),
+    ).toBeNull();
+  });
+
+  it("namespaces the service id so it cannot collide with a user's sub", () => {
+    const service = resolveAccessIdentity({ common_name: "user-123" });
+    const human = resolveAccessIdentity({ sub: "user-123", email: "a@b.com" });
+
+    expect(service?.userId).not.toEqual(human?.userId);
+  });
+});

--- a/src/middleware/ensure-user/accessIdentity.ts
+++ b/src/middleware/ensure-user/accessIdentity.ts
@@ -1,0 +1,56 @@
+import type { JWTPayload } from "jose";
+
+/**
+ * Which Cloudflare Access JWT becomes which user.
+ *
+ * Access issues two shapes of token and only one of them describes a person. A user token
+ * carries `sub` and `email`. A **service token** — admitted by a Service Auth policy, which is
+ * the only way anything headless gets through Access — carries neither: it identifies a machine
+ * by `common_name`, the token's Client ID.
+ *
+ * Requiring an email therefore rejected every non-interactive caller. Access would authenticate
+ * the request and mint a valid JWT, and the app would throw UNAUTHENTICATED at a token it had
+ * just cryptographically verified. That blocks cron, CI, and any MCP client that can only send
+ * static headers.
+ *
+ * A service token gets a stable synthetic identity instead, mirroring what `local_noauth`
+ * already does with `local-admin`: an externally-trusted principal that is not a person still
+ * needs a row in `user`, because every workspace table is keyed on one. The address uses the
+ * reserved `.invalid` TLD (RFC 2606) so it can never be mistaken for something deliverable.
+ *
+ * Authorization is unchanged and stays where it belongs — a service token only reaches this
+ * function if an operator wrote a policy admitting it.
+ *
+ * Kept free of `cloudflare:workers` imports so it is unit-testable outside the Workers runtime.
+ */
+export type AccessIdentity = { userId: string; userEmail: string };
+
+/** Namespaced so a service id can never collide with a user's `sub`. */
+export const SERVICE_TOKEN_ID_PREFIX = "cf-service-token:";
+/** RFC 2606 reserves `.invalid`; nothing here is a routable address. */
+export const SERVICE_TOKEN_EMAIL_DOMAIN = "service.invalid";
+
+export function resolveAccessIdentity(
+  payload: JWTPayload,
+): AccessIdentity | null {
+  const userId = typeof payload.sub === "string" ? payload.sub : null;
+  const userEmail = typeof payload.email === "string" ? payload.email : null;
+
+  if (userId && userEmail) {
+    return { userId, userEmail };
+  }
+
+  const commonName =
+    typeof payload.common_name === "string" ? payload.common_name.trim() : "";
+
+  if (commonName) {
+    // `sub` is absent or empty on a service-token assertion, so the Client ID is the only
+    // stable handle the token offers.
+    return {
+      userId: `${SERVICE_TOKEN_ID_PREFIX}${commonName}`,
+      userEmail: `${commonName}@${SERVICE_TOKEN_EMAIL_DOMAIN}`,
+    };
+  }
+
+  return null;
+}

--- a/src/middleware/ensure-user/cloudflareAccess.ts
+++ b/src/middleware/ensure-user/cloudflareAccess.ts
@@ -3,6 +3,7 @@ import { createRemoteJWKSet, jwtVerify, type JWTPayload } from "jose";
 import { AppError } from "@/server/lib/errors";
 import { validateTeamDomain } from "@/shared/selfhost-checks";
 import { classifyAccessVerificationError } from "./accessTokenErrors";
+import { resolveAccessIdentity } from "./accessIdentity";
 import { resolveSharedWorkspaceContext } from "./delegated";
 import type { EnsuredUserContext } from "./types";
 
@@ -87,12 +88,11 @@ export async function resolveCloudflareAccessContext(
     throw classifyAccessVerificationError(error);
   }
 
-  const userId = typeof payload.sub === "string" ? payload.sub : null;
-  const userEmail = typeof payload.email === "string" ? payload.email : null;
+  const identity = resolveAccessIdentity(payload);
 
-  if (!userId || !userEmail) {
+  if (!identity) {
     throw new AppError("UNAUTHENTICATED");
   }
 
-  return resolveSharedWorkspaceContext(userId, userEmail);
+  return resolveSharedWorkspaceContext(identity.userId, identity.userEmail);
 }


### PR DESCRIPTION
## The problem

Cloudflare Access issues two shapes of JWT, and only one of them describes a person.

A **user token** carries `sub` and `email`. A **service token** — admitted by a Service Auth policy, which is the only way anything headless gets through Access — carries neither. It identifies a machine by `common_name`, the token's Client ID.

`resolveCloudflareAccessContext` required both `sub` and `email`, so every non-interactive caller was rejected *after* Access had already authenticated it. The JWT verifies against the team JWKS and the configured AUD, and the app then throws `UNAUTHENTICATED` at a token it just verified.

That blocks cron, CI, and any MCP client that can only send static headers.

## Reproduction

Self-hosted deployment, `AUTH_MODE=cloudflare_access`, with a valid Service Auth policy on the Access application:

```
GET  /            + CF-Access-Client-Id/Secret  -> 200
GET  /api/health  + CF-Access-Client-Id/Secret  -> 200
POST /mcp         + CF-Access-Client-Id/Secret  -> 500
```

Only `/mcp` fails, because it is the only one of the three that resolves a user. `wrangler tail`:

```
AppError: UNAUTHENTICATED
    at resolveCloudflareAccessContext
    at async handleSelfHostedOpenSeoMcpRequest
```

The request carried a valid `cf-access-jwt-assertion` — `jwtVerify` passed on both issuer and audience. The throw is the `!userId || !userEmail` check immediately after.

## The change

A service token now resolves to a stable synthetic identity, mirroring what `local_noauth` already does with `local-admin`: an externally-trusted principal that is not a person still needs a row in `user`, because every workspace table is keyed on one.

```
common_name "abc123.access"
  -> userId    "cf-service-token:abc123.access"
  -> userEmail "abc123.access@service.invalid"
```

- Ids are namespaced `cf-service-token:` so they can never collide with a user's `sub`.
- The address uses the reserved `.invalid` TLD (RFC 2606), so it cannot be mistaken for something deliverable.
- A human identity still wins when a token somehow carries both.

**Authorization is unchanged** and stays where it belongs: a service token only reaches this code if an operator wrote a policy admitting it. This changes who the app *recognises*, not who Access *admits*.

## Why a new module

The rules move to `accessIdentity.ts` so they are unit-testable. `cloudflareAccess.ts` imports `cloudflare:workers`, which vitest cannot load — that is why there was no test around this logic before.

8 tests, weighted toward the cases that must **fail**: no identity of either kind, a user token missing its email, a blank/whitespace `common_name`, non-string claims, and a check that a service id cannot collide with a user's `sub`.

```
✓ src/middleware/ensure-user/accessIdentity.test.ts   (8 tests)
✓ src/middleware/ensure-user/accessTokenErrors.test.ts (7 tests)
```

`tsc --noEmit` clean.

## Note for reviewers

I considered gating this behind an env flag. It seemed wrong: the operator has already made the decision by writing the Service Auth policy, and a second switch would mean a token Access admits still failing for a reason not visible anywhere in Cloudflare's UI — which is exactly the confusing failure this fixes.

Happy to add one if you would rather it be opt-in.