### PR TITLE
fix(mcp): align GSC setup response schema

### DIFF
--- a/src/server/mcp/tools/search-console-tools.test.ts
+++ b/src/server/mcp/tools/search-console-tools.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GscApiError, GscNotConnectedError } from "@/server/lib/gscErrors";
+import { objectSchema } from "@/server/mcp/output-schemas";
 import * as searchConsoleTools from "./search-console-tools";
 import { makeToolContext } from "./tool-test-support";
 
@@ -187,6 +188,11 @@ describe("search console MCP tools", () => {
     expect(result.structuredContent).toMatchObject({
       reason: "gsc_oauth_not_configured",
     });
+    await expect(
+      objectSchema(
+        getSearchConsolePerformanceTool.config.outputSchema,
+      ).safeParseAsync(result.structuredContent),
+    ).resolves.toMatchObject({ success: true });
     expect(mocks.GscService.getPerformance).not.toHaveBeenCalled();
   });
 
@@ -290,6 +296,11 @@ describe("search console MCP tools", () => {
     expect(result.structuredContent).toMatchObject({
       reason: "gsc_oauth_not_configured",
     });
+    await expect(
+      objectSchema(inspectUrlsTool.config.outputSchema).safeParseAsync(
+        result.structuredContent,
+      ),
+    ).resolves.toMatchObject({ success: true });
     expect(mocks.GscService.inspectUrls).not.toHaveBeenCalled();
   });
 });

--- a/src/server/mcp/tools/search-console-tools.ts
+++ b/src/server/mcp/tools/search-console-tools.ts
@@ -82,7 +82,6 @@ async function missingSelfHostedGoogleClientResponse(
     meta: buildProjectMeta(context, projectId),
     structuredContent: {
       ok: false,
-      connected: false,
       reason: "gsc_oauth_not_configured",
       setupDocsUrl: GSC_SELF_HOSTED_SETUP_DOCS_URL,
     },


### PR DESCRIPTION
## Summary

Fixes the self-hosted Google Search Console setup response so its `structuredContent` matches the declared MCP output schema. The setup response already carries `ok: false`, `reason: "gsc_oauth_not_configured"`, and `setupDocsUrl`, so the undeclared `connected` field is removed.

This PR is AI-assisted and focused as a proof-of-concept fix.

## Related Issues

Fixes #261

## Changes

- Remove the undeclared `connected` property from the shared self-hosted GSC setup MCP response.
- Add schema-validation assertions for the self-hosted setup path on both `get_search_console_performance` and `inspect_urls`, since both use the same response helper.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### Steps to reproduce / test

1. `pnpm install --frozen-lockfile`
2. `pnpm vitest run src/server/mcp/tools/search-console-tools.test.ts`
3. `pnpm exec prettier --check src/server/mcp/tools/search-console-tools.ts src/server/mcp/tools/search-console-tools.test.ts`
4. `git diff --check`

### What you personally verified

- The focused Search Console MCP tool test file passes: 10 tests passed.
- The self-hosted setup response for `get_search_console_performance` validates against that tool's declared output schema.
- The same shared setup response also validates against `inspect_urls` output schema.
- Formatting and whitespace checks pass.

### Evidence

- [ ] CI passes (`pnpm check && pnpm lint && npx tsc --noEmit`)
- [x] Manually tested locally
- [ ] Screenshots / recordings attached (if UI changes)

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings
