### PR TITLE
Fix billing:usage TDZ crash in dataforseo-account-usage

### DIFF
--- a/scripts/dataforseo-account-usage.ts
+++ b/scripts/dataforseo-account-usage.ts
@@ -7,8 +7,6 @@ loadLocalEnv();
 
 const args = parseArgs(process.argv.slice(2));
 
-await main();
-
 /**
  * Inspect real DataForSEO account spend via the FREE GET
  * /v3/appendix/user_data endpoint. Unlike the other billing:* scripts, this
@@ -114,3 +112,5 @@ function printUsageAndExit(message: string): never {
   console.error("Usage: pnpm billing:usage [--json=true]");
   process.exit(1);
 }
+
+await main();


### PR DESCRIPTION
## Problem

`pnpm billing:usage` authenticates and prints the account balance, then crashes:

```
ReferenceError: Cannot access 'FUNCTION_TOTALS' before initialization
    at printFunctionTable (scripts/dataforseo-account-usage.ts:84)
```

## Cause

The script invokes `await main()` at module top level (line 10) *above* the module-level `const FUNCTION_TOTALS` declaration. Top-level await suspends module evaluation at that statement, so when `main()` resumes after the `fetchUserData()` call, the rest of the module body — including the `FUNCTION_TOTALS` initializer — has still never run, and `printFunctionTable` hits the temporal dead zone.

## Fix

Move the `await main()` invocation to the end of the file, after all module-level declarations — the same pattern `seed-rank-tracking.ts` and `d1-default-project-cleanup.ts` already use. Pure statement move, no behavior change otherwise.

## Verification

- `pnpm billing:usage` against the real (free) `GET /v3/appendix/user_data` endpoint now prints the balance and both rolling-window spend tables with no crash.
- `tsc --noEmit` and `oxlint --type-aware` pass.
- Checked the other top-invoking scripts (`backlinks-cost-profile.ts`, `brand-lookup-cost-profile.ts`): they declare all module consts *before* their `await main()`, so they are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)