### PR TITLE
fix(audit): count CJK words with Intl.Segmenter instead of whitespace split

### DIFF
--- a/src/server/lib/audit/page-analyzer.test.ts
+++ b/src/server/lib/audit/page-analyzer.test.ts
@@ -5,7 +5,7 @@
  */
 import * as cheerio from "cheerio";
 import { describe, expect, it } from "vitest";
-import { analyzeHtml } from "@/server/lib/audit/page-analyzer";
+import { analyzeHtml, countWords } from "@/server/lib/audit/page-analyzer";
 import { normalizeUrl, isSameOrigin } from "@/server/lib/audit/url-utils";
 import type { PageAnalysis, PageLink } from "@/server/lib/audit/types";
 
@@ -45,7 +45,7 @@ function analyzeHtmlWithCheerio(html: string, pageUrl: string): PageAnalysis {
   const bodyClone = $("body").clone();
   bodyClone.find("script, style, noscript, svg").remove();
   const bodyText = bodyClone.text().replace(/\s+/g, " ").trim();
-  const wordCount = bodyText ? bodyText.split(/\s+/).length : 0;
+  const wordCount = bodyText ? countWords(bodyText) : 0;
 
   const images: Array<{ src: string | null; alt: string | null }> = [];
   $("img").each((_, el) => {
@@ -204,6 +204,32 @@ describe("analyzeHtml parity with the DOM reference", () => {
       </p>
       <ul><li>four</li><li>five</li></ul>
     </body>`);
+  });
+
+  it("counts CJK text that carries no inter-word spaces", () => {
+    const analysis = analyzeHtml(
+      `<html><body>
+        <h1>ウイスキーの添加剂表記について</h1>
+        <p>グレーンウイスキーの添加剂表記について、近年の法改正と表示の変化を解説する。シングルモルトとブレンデッドの違い、熟成年数が風味に与える影響、そしてラベルの読み方を実例とともに説明する。ウイスキー好きの読者にとって、ボトル選びの参考になる情報をまとめた。海外の蒸留所では、樽詰め前のろ過方法が香りの残り方を大きく左右する。冷却ろ過を行わないノンチルフィルタードの製品は、味わいに厚みが出る一方で、低温で濁りが生じやすくなる。この濁りは品質上の問題ではないが、見た目を気にする消費者向けに説明が必要となる。また、焦げた樽の内側で熟成させる過程で、原酒は琥珀色へと変化していく。色の濃さと品質は必ずしも比例しないことも、知っておくと良い。カラメル色素による色調調整が認められている地域では、ラベルだけでは熟成期間を判断できない。だからこそ、蒸留所が公開する情報と独立系の評価を組み合わせて判断することが大切になる。本記事では、そうした判断材料をひとつずつ確認していく。</p>
+      </body></html>`,
+      PAGE_URL,
+      200,
+      0,
+    );
+    // The old whitespace split counted this body as ~3 "words" (the runs of
+    // whitespace between the h1 and the paragraph), tripping thin-content on
+    // a long-form article.
+    expect(analysis.wordCount).toBeGreaterThan(150);
+  });
+
+  it("keeps Latin word counts on the whitespace split", () => {
+    const analysis = analyzeHtml(
+      `<body><p>Some visible body text with bold words here.</p></body>`,
+      PAGE_URL,
+      200,
+      0,
+    );
+    expect(analysis.wordCount).toBe(8);
   });
 });
 

--- a/src/server/lib/audit/page-analyzer.ts
+++ b/src/server/lib/audit/page-analyzer.ts
@@ -36,6 +36,23 @@ const MAX_ANCHOR_CHARS = 200;
 const MAX_EXTRACTED_LINKS = 1_000;
 const MAX_EXTRACTED_IMAGES = 1_000;
 
+// Locale-independent across CJK and Latin text, so the runtime default is fine.
+const WORD_SEGMENTER = new Intl.Segmenter(undefined, { granularity: "word" });
+
+/**
+ * Count words in extracted text. Whitespace splitting collapses scripts
+ * without inter-word spaces (Japanese, Chinese, Korean) into a handful of
+ * "words", so segment into word-like segments instead; for Latin prose the
+ * count matches the whitespace split.
+ */
+export function countWords(text: string): number {
+  let count = 0;
+  for (const segment of WORD_SEGMENTER.segment(text)) {
+    if (segment.isWordLike) count += 1;
+  }
+  return count;
+}
+
 interface OpenAnchor {
   href: string;
   rel: string;
@@ -235,7 +252,7 @@ export function analyzeHtml(
 
   const rawText = (sawBody ? bodyParts : fallbackParts).join("");
   const bodyText = rawText.replace(/\s+/g, " ").trim();
-  const wordCount = bodyText ? bodyText.split(/\s+/).length : 0;
+  const wordCount = bodyText ? countWords(bodyText) : 0;
 
   return {
     url: pageUrl,


### PR DESCRIPTION
## Problem
The site audit's `wordCount` splits body text on whitespace (`src/server/lib/audit/page-analyzer.ts`). Japanese, Chinese, and Korean don't use spaces between words, so a long-form CJK article collapses to a handful of whitespace-delimited runs and `thin-content` fires on nearly every page of a CJK site. On the site in #258 that was 48 of 50 pages, including a 9,769-character article that counted as 116 "words".

## Summary
Count words with `Intl.Segmenter` (`granularity: "word"`, `isWordLike` segments) instead of the whitespace split, at the single `wordCount` computation the audit uses. The segmenter is dictionary-based, so it breaks CJK text into words directly and needs no per-script branch; its counts are locale-independent here (verified the same result under `en`/`ja`/`zh`/`ko`/default), and for Latin prose it returns the same count as the whitespace split, so `THIN_CONTENT_WORDS = 150` stays meaningful with no threshold change.

The analyzer's parity test re-implements the old count inside its cheerio reference, so the reference now calls the same `countWords` the analyzer uses and both sides of the parity check move together.

On the issue's evidence pages this changes counts from 116/154/7 to numbers that reflect actual content length, and a long-form Japanese article no longer trips `thin-content`.

## Verification
- before, on current `main`: a body of ~500 Japanese characters counted as 3 words and fired `thin-content`
- after: `pnpm vitest run src/server/lib/audit/` with a CJK article fixture counting 200+ words, Latin prose staying at 8, all 71 audit tests pass
- full suite: 1167/1167 tests pass, and the `ci:check` gates (prettier, knip, tsc, oxlint) plus `pnpm vite build` are green locally

Fixes #258
