### PR TITLE
POC: add read-only Cloudflare Analytics integration

### DIFF
--- a/drizzle-pg/0023_free_donald_blake.sql
+++ b/drizzle-pg/0023_free_donald_blake.sql
@@ -1,0 +1,23 @@
+CREATE TABLE "cloudflare_analytics_connections" (
+	"id" text PRIMARY KEY NOT NULL,
+	"project_id" text NOT NULL,
+	"organization_id" text NOT NULL,
+	"encrypted_api_token" text NOT NULL,
+	"token_hint" text NOT NULL,
+	"zone_id" text NOT NULL,
+	"zone_label" text,
+	"traffic_available" boolean DEFAULT false NOT NULL,
+	"traffic_reason" text,
+	"security_events_available" boolean DEFAULT false NOT NULL,
+	"security_events_reason" text,
+	"crawler_access_available" boolean DEFAULT false NOT NULL,
+	"crawler_access_reason" text,
+	"connected_by_user_id" text NOT NULL,
+	"created_at" text DEFAULT to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') NOT NULL,
+	"updated_at" text DEFAULT to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "cloudflare_analytics_connections" ADD CONSTRAINT "cloudflare_analytics_connections_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "cloudflare_analytics_connections" ADD CONSTRAINT "cloudflare_analytics_connections_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "cloudflare_analytics_connections_project_idx" ON "cloudflare_analytics_connections" USING btree ("project_id");--> statement-breakpoint
+CREATE INDEX "cloudflare_analytics_connections_organization_idx" ON "cloudflare_analytics_connections" USING btree ("organization_id");

--- a/drizzle-pg/meta/0023_snapshot.json
+++ b/drizzle-pg/meta/0023_snapshot.json
@@ -1,0 +1,4292 @@
+{
+  "id": "55cccdc2-6b9c-431a-ab44-50505c11828c",
+  "prevId": "354b82d0-282b-4b17-99eb-63e81147cf51",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.backlink_snapshots": {
+      "name": "backlink_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backlinks": {
+          "name": "backlinks",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referring_domains": {
+          "name": "referring_domains",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "broken_backlinks": {
+          "name": "broken_backlinks",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_backlinks": {
+          "name": "new_backlinks",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lost_backlinks": {
+          "name": "lost_backlinks",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_referring_domains": {
+          "name": "new_referring_domains",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lost_referring_domains": {
+          "name": "lost_referring_domains",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "backlink_snapshots_project_captured_idx": {
+          "name": "backlink_snapshots_project_captured_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "backlink_snapshots_project_id_projects_id_fk": {
+          "name": "backlink_snapshots_project_id_projects_id_fk",
+          "tableFrom": "backlink_snapshots",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.keyword_metrics": {
+      "name": "keyword_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_code": {
+          "name": "location_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "search_volume": {
+          "name": "search_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpc": {
+          "name": "cpc",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "competition": {
+          "name": "competition",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keyword_difficulty": {
+          "name": "keyword_difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intent": {
+          "name": "intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monthly_searches": {
+          "name": "monthly_searches",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "keyword_metrics_unique_project_keyword_location_language": {
+          "name": "keyword_metrics_unique_project_keyword_location_language",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "keyword",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "keyword_metrics_lookup_idx": {
+          "name": "keyword_metrics_lookup_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "keyword",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "keyword_metrics_project_id_projects_id_fk": {
+          "name": "keyword_metrics_project_id_projects_id_fk",
+          "tableFrom": "keyword_metrics",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_activation_state": {
+      "name": "organization_activation_state",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_mcp_authorized_at": {
+          "name": "first_mcp_authorized_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_mcp_tool_call_at": {
+          "name": "first_mcp_tool_call_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_activation_state_organization_id_organization_id_fk": {
+          "name": "organization_activation_state_organization_id_organization_id_fk",
+          "tableFrom": "organization_activation_state",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_activation_state": {
+      "name": "project_activation_state",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "competitor_step_clicked_at": {
+          "name": "competitor_step_clicked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_card_dismissed_at": {
+          "name": "mcp_card_dismissed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ga4_card_dismissed_at": {
+          "name": "ga4_card_dismissed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_activation_state_project_id_projects_id_fk": {
+          "name": "project_activation_state_project_id_projects_id_fk",
+          "tableFrom": "project_activation_state",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_code": {
+          "name": "location_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2840
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "projects_one_default_per_organization_idx": {
+          "name": "projects_one_default_per_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"projects\".\"name\" = 'Default' AND \"projects\".\"domain\" IS NULL AND \"projects\".\"archived_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_organization_id_idx": {
+          "name": "projects_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_organization_id_organization_id_fk": {
+          "name": "projects_organization_id_organization_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rank_check_runs": {
+      "name": "rank_check_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "keywords_total": {
+          "name": "keywords_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "keywords_checked": {
+          "name": "keywords_checked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_subset_run": {
+          "name": "is_subset_run",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rank_check_runs_config_idx": {
+          "name": "rank_check_runs_config_idx",
+          "columns": [
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rank_check_runs_project_idx": {
+          "name": "rank_check_runs_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rank_check_runs_one_active_per_config_idx": {
+          "name": "rank_check_runs_one_active_per_config_idx",
+          "columns": [
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"rank_check_runs\".\"status\" IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rank_check_runs_config_id_rank_tracking_configs_id_fk": {
+          "name": "rank_check_runs_config_id_rank_tracking_configs_id_fk",
+          "tableFrom": "rank_check_runs",
+          "tableTo": "rank_tracking_configs",
+          "columnsFrom": [
+            "config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rank_check_runs_project_id_projects_id_fk": {
+          "name": "rank_check_runs_project_id_projects_id_fk",
+          "tableFrom": "rank_check_runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rank_snapshots": {
+      "name": "rank_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tracking_keyword_id": {
+          "name": "tracking_keyword_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device": {
+          "name": "device",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serp_features": {
+          "name": "serp_features",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "rank_snapshots_keyword_device_idx": {
+          "name": "rank_snapshots_keyword_device_idx",
+          "columns": [
+            {
+              "expression": "tracking_keyword_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rank_snapshots_run_keyword_device_idx": {
+          "name": "rank_snapshots_run_keyword_device_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tracking_keyword_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rank_snapshots_run_id_rank_check_runs_id_fk": {
+          "name": "rank_snapshots_run_id_rank_check_runs_id_fk",
+          "tableFrom": "rank_snapshots",
+          "tableTo": "rank_check_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rank_tracking_configs": {
+      "name": "rank_tracking_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_code": {
+          "name": "location_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2840
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "devices": {
+          "name": "devices",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'both'"
+        },
+        "serp_depth": {
+          "name": "serp_depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_interval": {
+          "name": "schedule_interval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'weekly'"
+        },
+        "location_name": {
+          "name": "location_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_check_at": {
+          "name": "next_check_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_skip_reason": {
+          "name": "last_skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "rank_tracking_configs_project_active_created_idx": {
+          "name": "rank_tracking_configs_project_active_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rank_tracking_configs_national_idx": {
+          "name": "rank_tracking_configs_national_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"rank_tracking_configs\".\"location_name\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rank_tracking_configs_local_idx": {
+          "name": "rank_tracking_configs_local_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"rank_tracking_configs\".\"location_name\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rank_tracking_configs_project_id_projects_id_fk": {
+          "name": "rank_tracking_configs_project_id_projects_id_fk",
+          "tableFrom": "rank_tracking_configs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rank_tracking_keywords": {
+      "name": "rank_tracking_keywords",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_volume": {
+          "name": "search_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keyword_difficulty": {
+          "name": "keyword_difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpc": {
+          "name": "cpc",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metrics_fetched_at": {
+          "name": "metrics_fetched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "rank_tracking_keywords_config_keyword_idx": {
+          "name": "rank_tracking_keywords_config_keyword_idx",
+          "columns": [
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "keyword",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rank_tracking_keywords_config_id_rank_tracking_configs_id_fk": {
+          "name": "rank_tracking_keywords_config_id_rank_tracking_configs_id_fk",
+          "tableFrom": "rank_tracking_keywords",
+          "tableTo": "rank_tracking_configs",
+          "columnsFrom": [
+            "config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_keyword_tag_assignments": {
+      "name": "saved_keyword_tag_assignments",
+      "schema": "",
+      "columns": {
+        "saved_keyword_id": {
+          "name": "saved_keyword_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "saved_keyword_tag_assignments_unique_idx": {
+          "name": "saved_keyword_tag_assignments_unique_idx",
+          "columns": [
+            {
+              "expression": "saved_keyword_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_keyword_tag_assignments_tag_idx": {
+          "name": "saved_keyword_tag_assignments_tag_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_keyword_tag_assignments_saved_keyword_id_saved_keywords_id_fk": {
+          "name": "saved_keyword_tag_assignments_saved_keyword_id_saved_keywords_id_fk",
+          "tableFrom": "saved_keyword_tag_assignments",
+          "tableTo": "saved_keywords",
+          "columnsFrom": [
+            "saved_keyword_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "saved_keyword_tag_assignments_tag_id_saved_keyword_tags_id_fk": {
+          "name": "saved_keyword_tag_assignments_tag_id_saved_keyword_tags_id_fk",
+          "tableFrom": "saved_keyword_tag_assignments",
+          "tableTo": "saved_keyword_tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_keyword_tags": {
+      "name": "saved_keyword_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "saved_keyword_tags_project_normalized_name_idx": {
+          "name": "saved_keyword_tags_project_normalized_name_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_keyword_tags_project_name_idx": {
+          "name": "saved_keyword_tags_project_name_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_keyword_tags_project_id_projects_id_fk": {
+          "name": "saved_keyword_tags_project_id_projects_id_fk",
+          "tableFrom": "saved_keyword_tags",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_keywords": {
+      "name": "saved_keywords",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_code": {
+          "name": "location_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2840
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "saved_keywords_unique_project_keyword_location_language": {
+          "name": "saved_keywords_unique_project_keyword_location_language",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "keyword",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_keywords_project_created_idx": {
+          "name": "saved_keywords_project_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_keywords_project_id_projects_id_fk": {
+          "name": "saved_keywords_project_id_projects_id_fk",
+          "tableFrom": "saved_keywords",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_onboarding_answers": {
+      "name": "user_onboarding_answers",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interested_features": {
+          "name": "interested_features",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "work_for": {
+          "name": "work_for",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_website_count": {
+          "name": "client_website_count",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "found_via": {
+          "name": "found_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_setup_intent": {
+          "name": "mcp_setup_intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gsc_nudge_dismissed_at": {
+          "name": "gsc_nudge_dismissed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "user_onboarding_answers_organization_idx": {
+          "name": "user_onboarding_answers_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_onboarding_answers_user_id_user_id_fk": {
+          "name": "user_onboarding_answers_user_id_user_id_fk",
+          "tableFrom": "user_onboarding_answers",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_onboarding_answers_organization_id_organization_id_fk": {
+          "name": "user_onboarding_answers_organization_id_organization_id_fk",
+          "tableFrom": "user_onboarding_answers",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_competitors": {
+      "name": "project_competitors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "project_competitors_project_domain_idx": {
+          "name": "project_competitors_project_domain_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_competitors_project_id_projects_id_fk": {
+          "name": "project_competitors_project_id_projects_id_fk",
+          "tableFrom": "project_competitors",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_context_sections": {
+      "name": "project_context_sections",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_context_sections_project_id_projects_id_fk": {
+          "name": "project_context_sections_project_id_projects_id_fk",
+          "tableFrom": "project_context_sections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_context_sections_project_id_key_pk": {
+          "name": "project_context_sections_project_id_key_pk",
+          "columns": [
+            "project_id",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_key_pages": {
+      "name": "project_key_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "project_key_pages_project_url_idx": {
+          "name": "project_key_pages_project_url_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_key_pages_project_id_projects_id_fk": {
+          "name": "project_key_pages_project_id_projects_id_fk",
+          "tableFrom": "project_key_pages",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_research_log": {
+      "name": "project_research_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_date": {
+          "name": "entry_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "project_research_log_project_date_idx": {
+          "name": "project_research_log_project_date_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entry_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_research_log_project_id_projects_id_fk": {
+          "name": "project_research_log_project_id_projects_id_fk",
+          "tableFrom": "project_research_log",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_issues": {
+      "name": "audit_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "audit_id": {
+          "name": "audit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_url": {
+          "name": "page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_type": {
+          "name": "issue_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "details_json": {
+          "name": "details_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_issues_audit_type_idx": {
+          "name": "audit_issues_audit_type_idx",
+          "columns": [
+            {
+              "expression": "audit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_issues_page_id_idx": {
+          "name": "audit_issues_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_issues_audit_id_audits_id_fk": {
+          "name": "audit_issues_audit_id_audits_id_fk",
+          "tableFrom": "audit_issues",
+          "tableTo": "audits",
+          "columnsFrom": [
+            "audit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_issues_page_id_audit_pages_id_fk": {
+          "name": "audit_issues_page_id_audit_pages_id_fk",
+          "tableFrom": "audit_issues",
+          "tableTo": "audit_pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_lighthouse_results": {
+      "name": "audit_lighthouse_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "audit_id": {
+          "name": "audit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strategy": {
+          "name": "strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performance_score": {
+          "name": "performance_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessibility_score": {
+          "name": "accessibility_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "best_practices_score": {
+          "name": "best_practices_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seo_score": {
+          "name": "seo_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lcp_ms": {
+          "name": "lcp_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cls": {
+          "name": "cls",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inp_ms": {
+          "name": "inp_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ttfb_ms": {
+          "name": "ttfb_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_size_bytes": {
+          "name": "payload_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_lighthouse_results_audit_id_idx": {
+          "name": "audit_lighthouse_results_audit_id_idx",
+          "columns": [
+            {
+              "expression": "audit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_lighthouse_results_page_id_idx": {
+          "name": "audit_lighthouse_results_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_lighthouse_results_audit_id_audits_id_fk": {
+          "name": "audit_lighthouse_results_audit_id_audits_id_fk",
+          "tableFrom": "audit_lighthouse_results",
+          "tableTo": "audits",
+          "columnsFrom": [
+            "audit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_lighthouse_results_page_id_audit_pages_id_fk": {
+          "name": "audit_lighthouse_results_page_id_audit_pages_id_fk",
+          "tableFrom": "audit_lighthouse_results",
+          "tableTo": "audit_pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_pages": {
+      "name": "audit_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "audit_id": {
+          "name": "audit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_url": {
+          "name": "canonical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "robots_meta": {
+          "name": "robots_meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_title": {
+          "name": "og_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_description": {
+          "name": "og_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_image": {
+          "name": "og_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "h1_count": {
+          "name": "h1_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "h2_count": {
+          "name": "h2_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "h3_count": {
+          "name": "h3_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "h4_count": {
+          "name": "h4_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "h5_count": {
+          "name": "h5_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "h6_count": {
+          "name": "h6_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "heading_order_json": {
+          "name": "heading_order_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "images_total": {
+          "name": "images_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "images_missing_alt": {
+          "name": "images_missing_alt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "images_json": {
+          "name": "images_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_link_count": {
+          "name": "internal_link_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "external_link_count": {
+          "name": "external_link_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "has_structured_data": {
+          "name": "has_structured_data",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hreflang_tags_json": {
+          "name": "hreflang_tags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_indexable": {
+          "name": "is_indexable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "x_robots_tag": {
+          "name": "x_robots_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "header_canonical_url": {
+          "name": "header_canonical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crawl_depth": {
+          "name": "crawl_depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "in_sitemap": {
+          "name": "in_sitemap",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetch_class": {
+          "name": "fetch_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ok'"
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_pages_audit_url_idx": {
+          "name": "audit_pages_audit_url_idx",
+          "columns": [
+            {
+              "expression": "audit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_pages_audit_id_audits_id_fk": {
+          "name": "audit_pages_audit_id_audits_id_fk",
+          "tableFrom": "audit_pages",
+          "tableTo": "audits",
+          "columnsFrom": [
+            "audit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audits": {
+      "name": "audits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_by_user_id": {
+          "name": "started_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_url": {
+          "name": "start_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "workflow_instance_id": {
+          "name": "workflow_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "pages_crawled": {
+          "name": "pages_crawled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pages_total": {
+          "name": "pages_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lighthouse_total": {
+          "name": "lighthouse_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lighthouse_completed": {
+          "name": "lighthouse_completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lighthouse_failed": {
+          "name": "lighthouse_failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_phase": {
+          "name": "current_phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'discovery'"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_detail": {
+          "name": "error_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_phase": {
+          "name": "failed_phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audits_project_id_idx": {
+          "name": "audits_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audits_started_by_user_id_idx": {
+          "name": "audits_started_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "started_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audits_project_id_projects_id_fk": {
+          "name": "audits_project_id_projects_id_fk",
+          "tableFrom": "audits",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sam_sessions": {
+      "name": "sam_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'New chat'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sam_sessions_project_updated_idx": {
+          "name": "sam_sessions_project_updated_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sam_sessions_project_id_projects_id_fk": {
+          "name": "sam_sessions_project_id_projects_id_fk",
+          "tableFrom": "sam_sessions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sam_sessions_user_id_user_id_fk": {
+          "name": "sam_sessions_user_id_user_id_fk",
+          "tableFrom": "sam_sessions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_accountId_providerId_idx": {
+          "name": "account_accountId_providerId_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apikey": {
+      "name": "apikey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 60000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 120
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "apikey_configId_idx": {
+          "name": "apikey_configId_idx",
+          "columns": [
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "apikey_referenceId_idx": {
+          "name": "apikey_referenceId_idx",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "apikey_key_idx": {
+          "name": "apikey_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_organizationId_userId_uidx": {
+          "name": "member_organizationId_userId_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_slug_uidx": {
+          "name": "organization_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "analytics_opted_out": {
+          "name": "analytics_opted_out",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_organization_id": {
+          "name": "last_active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verification_expiresAt_idx": {
+          "name": "verification_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_customer_status": {
+      "name": "billing_customer_status",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "is_paying": {
+          "name": "is_paying",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "paid_plan_id": {
+          "name": "paid_plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_plan_status": {
+          "name": "paid_plan_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_json": {
+          "name": "customer_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "billing_customer_status_organization_id_organization_id_fk": {
+          "name": "billing_customer_status_organization_id_organization_id_fk",
+          "tableFrom": "billing_customer_status",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cloudflare_analytics_connections": {
+      "name": "cloudflare_analytics_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_api_token": {
+          "name": "encrypted_api_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hint": {
+          "name": "token_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zone_label": {
+          "name": "zone_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "traffic_available": {
+          "name": "traffic_available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "traffic_reason": {
+          "name": "traffic_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "security_events_available": {
+          "name": "security_events_available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "security_events_reason": {
+          "name": "security_events_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crawler_access_available": {
+          "name": "crawler_access_available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "crawler_access_reason": {
+          "name": "crawler_access_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "cloudflare_analytics_connections_project_idx": {
+          "name": "cloudflare_analytics_connections_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cloudflare_analytics_connections_organization_idx": {
+          "name": "cloudflare_analytics_connections_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cloudflare_analytics_connections_project_id_projects_id_fk": {
+          "name": "cloudflare_analytics_connections_project_id_projects_id_fk",
+          "tableFrom": "cloudflare_analytics_connections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloudflare_analytics_connections_organization_id_organization_id_fk": {
+          "name": "cloudflare_analytics_connections_organization_id_organization_id_fk",
+          "tableFrom": "cloudflare_analytics_connections",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ga4_connections": {
+      "name": "ga4_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_display_name": {
+          "name": "property_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_time_zone": {
+          "name": "property_time_zone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_currency_code": {
+          "name": "property_currency_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ga4_account_id": {
+          "name": "ga4_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_account_email": {
+          "name": "connected_account_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "ga4_connections_project_idx": {
+          "name": "ga4_connections_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ga4_connections_organization_idx": {
+          "name": "ga4_connections_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ga4_connections_connector_idx": {
+          "name": "ga4_connections_connector_idx",
+          "columns": [
+            {
+              "expression": "connected_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ga4_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ga4_connections_project_id_projects_id_fk": {
+          "name": "ga4_connections_project_id_projects_id_fk",
+          "tableFrom": "ga4_connections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ga4_connections_organization_id_organization_id_fk": {
+          "name": "ga4_connections_organization_id_organization_id_fk",
+          "tableFrom": "ga4_connections",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gsc_connections": {
+      "name": "gsc_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_url": {
+          "name": "site_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gsc_account_id": {
+          "name": "gsc_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_account_email": {
+          "name": "connected_account_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "gsc_connections_project_idx": {
+          "name": "gsc_connections_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gsc_connections_organization_idx": {
+          "name": "gsc_connections_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gsc_connections_project_id_projects_id_fk": {
+          "name": "gsc_connections_project_id_projects_id_fk",
+          "tableFrom": "gsc_connections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gsc_connections_organization_id_organization_id_fk": {
+          "name": "gsc_connections_organization_id_organization_id_fk",
+          "tableFrom": "gsc_connections",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telemetry_state": {
+      "name": "telemetry_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "install_id": {
+          "name": "install_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_version": {
+          "name": "last_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_tool_call_count": {
+          "name": "mcp_tool_call_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle-pg/meta/_journal.json
+++ b/drizzle-pg/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1787773500453,
       "tag": "0022_third_supernaut",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1788521144371,
+      "tag": "0023_free_donald_blake",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/0045_rainy_talkback.sql
+++ b/drizzle/0045_rainy_talkback.sql
@@ -1,0 +1,23 @@
+CREATE TABLE `cloudflare_analytics_connections` (
+	`id` text PRIMARY KEY NOT NULL,
+	`project_id` text NOT NULL,
+	`organization_id` text NOT NULL,
+	`encrypted_api_token` text NOT NULL,
+	`token_hint` text NOT NULL,
+	`zone_id` text NOT NULL,
+	`zone_label` text,
+	`traffic_available` integer DEFAULT false NOT NULL,
+	`traffic_reason` text,
+	`security_events_available` integer DEFAULT false NOT NULL,
+	`security_events_reason` text,
+	`crawler_access_available` integer DEFAULT false NOT NULL,
+	`crawler_access_reason` text,
+	`connected_by_user_id` text NOT NULL,
+	`created_at` text DEFAULT (current_timestamp) NOT NULL,
+	`updated_at` text DEFAULT (current_timestamp) NOT NULL,
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`organization_id`) REFERENCES `organization`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `cloudflare_analytics_connections_project_idx` ON `cloudflare_analytics_connections` (`project_id`);--> statement-breakpoint
+CREATE INDEX `cloudflare_analytics_connections_organization_idx` ON `cloudflare_analytics_connections` (`organization_id`);

--- a/drizzle/meta/0045_snapshot.json
+++ b/drizzle/meta/0045_snapshot.json
@@ -1,0 +1,3916 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "9d14d2b4-646d-4a4d-ab54-11ed888b97b3",
+  "prevId": "d57a4d79-cd2f-4415-8b8e-7aeafb6b5a06",
+  "tables": {
+    "backlink_snapshots": {
+      "name": "backlink_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "backlinks": {
+          "name": "backlinks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "referring_domains": {
+          "name": "referring_domains",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "broken_backlinks": {
+          "name": "broken_backlinks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "new_backlinks": {
+          "name": "new_backlinks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lost_backlinks": {
+          "name": "lost_backlinks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "new_referring_domains": {
+          "name": "new_referring_domains",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lost_referring_domains": {
+          "name": "lost_referring_domains",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "backlink_snapshots_project_captured_idx": {
+          "name": "backlink_snapshots_project_captured_idx",
+          "columns": [
+            "project_id",
+            "captured_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "backlink_snapshots_project_id_projects_id_fk": {
+          "name": "backlink_snapshots_project_id_projects_id_fk",
+          "tableFrom": "backlink_snapshots",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "keyword_metrics": {
+      "name": "keyword_metrics",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_code": {
+          "name": "location_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "search_volume": {
+          "name": "search_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cpc": {
+          "name": "cpc",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "competition": {
+          "name": "competition",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "keyword_difficulty": {
+          "name": "keyword_difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "intent": {
+          "name": "intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "monthly_searches": {
+          "name": "monthly_searches",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "keyword_metrics_unique_project_keyword_location_language": {
+          "name": "keyword_metrics_unique_project_keyword_location_language",
+          "columns": [
+            "project_id",
+            "keyword",
+            "location_code",
+            "language_code"
+          ],
+          "isUnique": true
+        },
+        "keyword_metrics_lookup_idx": {
+          "name": "keyword_metrics_lookup_idx",
+          "columns": [
+            "project_id",
+            "keyword",
+            "location_code",
+            "language_code",
+            "fetched_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "keyword_metrics_project_id_projects_id_fk": {
+          "name": "keyword_metrics_project_id_projects_id_fk",
+          "tableFrom": "keyword_metrics",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_activation_state": {
+      "name": "organization_activation_state",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_mcp_authorized_at": {
+          "name": "first_mcp_authorized_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_mcp_tool_call_at": {
+          "name": "first_mcp_tool_call_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_activation_state_organization_id_organization_id_fk": {
+          "name": "organization_activation_state_organization_id_organization_id_fk",
+          "tableFrom": "organization_activation_state",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_activation_state": {
+      "name": "project_activation_state",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "competitor_step_clicked_at": {
+          "name": "competitor_step_clicked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcp_card_dismissed_at": {
+          "name": "mcp_card_dismissed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ga4_card_dismissed_at": {
+          "name": "ga4_card_dismissed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_activation_state_project_id_projects_id_fk": {
+          "name": "project_activation_state_project_id_projects_id_fk",
+          "tableFrom": "project_activation_state",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location_code": {
+          "name": "location_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2840
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_one_default_per_organization_idx": {
+          "name": "projects_one_default_per_organization_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true,
+          "where": "\"projects\".\"name\" = 'Default' AND \"projects\".\"domain\" IS NULL AND \"projects\".\"archived_at\" IS NULL"
+        },
+        "projects_organization_id_idx": {
+          "name": "projects_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "projects_organization_id_organization_id_fk": {
+          "name": "projects_organization_id_organization_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rank_check_runs": {
+      "name": "rank_check_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "keywords_total": {
+          "name": "keywords_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "keywords_checked": {
+          "name": "keywords_checked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_subset_run": {
+          "name": "is_subset_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rank_check_runs_config_idx": {
+          "name": "rank_check_runs_config_idx",
+          "columns": [
+            "config_id",
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "rank_check_runs_project_idx": {
+          "name": "rank_check_runs_project_idx",
+          "columns": [
+            "project_id",
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "rank_check_runs_one_active_per_config_idx": {
+          "name": "rank_check_runs_one_active_per_config_idx",
+          "columns": [
+            "config_id"
+          ],
+          "isUnique": true,
+          "where": "\"rank_check_runs\".\"status\" IN ('pending', 'running')"
+        }
+      },
+      "foreignKeys": {
+        "rank_check_runs_config_id_rank_tracking_configs_id_fk": {
+          "name": "rank_check_runs_config_id_rank_tracking_configs_id_fk",
+          "tableFrom": "rank_check_runs",
+          "tableTo": "rank_tracking_configs",
+          "columnsFrom": [
+            "config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rank_check_runs_project_id_projects_id_fk": {
+          "name": "rank_check_runs_project_id_projects_id_fk",
+          "tableFrom": "rank_check_runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rank_snapshots": {
+      "name": "rank_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tracking_keyword_id": {
+          "name": "tracking_keyword_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device": {
+          "name": "device",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "serp_features": {
+          "name": "serp_features",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "rank_snapshots_keyword_device_idx": {
+          "name": "rank_snapshots_keyword_device_idx",
+          "columns": [
+            "tracking_keyword_id",
+            "device",
+            "checked_at"
+          ],
+          "isUnique": false
+        },
+        "rank_snapshots_run_keyword_device_idx": {
+          "name": "rank_snapshots_run_keyword_device_idx",
+          "columns": [
+            "run_id",
+            "tracking_keyword_id",
+            "device"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "rank_snapshots_run_id_rank_check_runs_id_fk": {
+          "name": "rank_snapshots_run_id_rank_check_runs_id_fk",
+          "tableFrom": "rank_snapshots",
+          "tableTo": "rank_check_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rank_tracking_configs": {
+      "name": "rank_tracking_configs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_code": {
+          "name": "location_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2840
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "devices": {
+          "name": "devices",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'both'"
+        },
+        "serp_depth": {
+          "name": "serp_depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_interval": {
+          "name": "schedule_interval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'weekly'"
+        },
+        "location_name": {
+          "name": "location_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_check_at": {
+          "name": "next_check_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_skip_reason": {
+          "name": "last_skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "rank_tracking_configs_project_active_created_idx": {
+          "name": "rank_tracking_configs_project_active_created_idx",
+          "columns": [
+            "project_id",
+            "is_active",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "rank_tracking_configs_national_idx": {
+          "name": "rank_tracking_configs_national_idx",
+          "columns": [
+            "project_id",
+            "domain",
+            "location_code"
+          ],
+          "isUnique": true,
+          "where": "\"rank_tracking_configs\".\"location_name\" IS NULL"
+        },
+        "rank_tracking_configs_local_idx": {
+          "name": "rank_tracking_configs_local_idx",
+          "columns": [
+            "project_id",
+            "domain",
+            "location_code",
+            "location_name"
+          ],
+          "isUnique": true,
+          "where": "\"rank_tracking_configs\".\"location_name\" IS NOT NULL"
+        }
+      },
+      "foreignKeys": {
+        "rank_tracking_configs_project_id_projects_id_fk": {
+          "name": "rank_tracking_configs_project_id_projects_id_fk",
+          "tableFrom": "rank_tracking_configs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rank_tracking_keywords": {
+      "name": "rank_tracking_keywords",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "search_volume": {
+          "name": "search_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "keyword_difficulty": {
+          "name": "keyword_difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cpc": {
+          "name": "cpc",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metrics_fetched_at": {
+          "name": "metrics_fetched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "rank_tracking_keywords_config_keyword_idx": {
+          "name": "rank_tracking_keywords_config_keyword_idx",
+          "columns": [
+            "config_id",
+            "keyword"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "rank_tracking_keywords_config_id_rank_tracking_configs_id_fk": {
+          "name": "rank_tracking_keywords_config_id_rank_tracking_configs_id_fk",
+          "tableFrom": "rank_tracking_keywords",
+          "tableTo": "rank_tracking_configs",
+          "columnsFrom": [
+            "config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "saved_keyword_tag_assignments": {
+      "name": "saved_keyword_tag_assignments",
+      "columns": {
+        "saved_keyword_id": {
+          "name": "saved_keyword_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "saved_keyword_tag_assignments_unique_idx": {
+          "name": "saved_keyword_tag_assignments_unique_idx",
+          "columns": [
+            "saved_keyword_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        },
+        "saved_keyword_tag_assignments_tag_idx": {
+          "name": "saved_keyword_tag_assignments_tag_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "saved_keyword_tag_assignments_saved_keyword_id_saved_keywords_id_fk": {
+          "name": "saved_keyword_tag_assignments_saved_keyword_id_saved_keywords_id_fk",
+          "tableFrom": "saved_keyword_tag_assignments",
+          "tableTo": "saved_keywords",
+          "columnsFrom": [
+            "saved_keyword_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "saved_keyword_tag_assignments_tag_id_saved_keyword_tags_id_fk": {
+          "name": "saved_keyword_tag_assignments_tag_id_saved_keyword_tags_id_fk",
+          "tableFrom": "saved_keyword_tag_assignments",
+          "tableTo": "saved_keyword_tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "saved_keyword_tags": {
+      "name": "saved_keyword_tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "saved_keyword_tags_project_normalized_name_idx": {
+          "name": "saved_keyword_tags_project_normalized_name_idx",
+          "columns": [
+            "project_id",
+            "normalized_name"
+          ],
+          "isUnique": true
+        },
+        "saved_keyword_tags_project_name_idx": {
+          "name": "saved_keyword_tags_project_name_idx",
+          "columns": [
+            "project_id",
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "saved_keyword_tags_project_id_projects_id_fk": {
+          "name": "saved_keyword_tags_project_id_projects_id_fk",
+          "tableFrom": "saved_keyword_tags",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "saved_keywords": {
+      "name": "saved_keywords",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_code": {
+          "name": "location_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2840
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "saved_keywords_unique_project_keyword_location_language": {
+          "name": "saved_keywords_unique_project_keyword_location_language",
+          "columns": [
+            "project_id",
+            "keyword",
+            "location_code",
+            "language_code"
+          ],
+          "isUnique": true
+        },
+        "saved_keywords_project_created_idx": {
+          "name": "saved_keywords_project_created_idx",
+          "columns": [
+            "project_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "saved_keywords_project_id_projects_id_fk": {
+          "name": "saved_keywords_project_id_projects_id_fk",
+          "tableFrom": "saved_keywords",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_onboarding_answers": {
+      "name": "user_onboarding_answers",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "interested_features": {
+          "name": "interested_features",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "work_for": {
+          "name": "work_for",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_website_count": {
+          "name": "client_website_count",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "found_via": {
+          "name": "found_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcp_setup_intent": {
+          "name": "mcp_setup_intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gsc_nudge_dismissed_at": {
+          "name": "gsc_nudge_dismissed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "user_onboarding_answers_organization_idx": {
+          "name": "user_onboarding_answers_organization_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_onboarding_answers_user_id_user_id_fk": {
+          "name": "user_onboarding_answers_user_id_user_id_fk",
+          "tableFrom": "user_onboarding_answers",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_onboarding_answers_organization_id_organization_id_fk": {
+          "name": "user_onboarding_answers_organization_id_organization_id_fk",
+          "tableFrom": "user_onboarding_answers",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_competitors": {
+      "name": "project_competitors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "project_competitors_project_domain_idx": {
+          "name": "project_competitors_project_domain_idx",
+          "columns": [
+            "project_id",
+            "domain"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "project_competitors_project_id_projects_id_fk": {
+          "name": "project_competitors_project_id_projects_id_fk",
+          "tableFrom": "project_competitors",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_context_sections": {
+      "name": "project_context_sections",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_context_sections_project_id_projects_id_fk": {
+          "name": "project_context_sections_project_id_projects_id_fk",
+          "tableFrom": "project_context_sections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_context_sections_project_id_key_pk": {
+          "columns": [
+            "project_id",
+            "key"
+          ],
+          "name": "project_context_sections_project_id_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_key_pages": {
+      "name": "project_key_pages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "project_key_pages_project_url_idx": {
+          "name": "project_key_pages_project_url_idx",
+          "columns": [
+            "project_id",
+            "url"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "project_key_pages_project_id_projects_id_fk": {
+          "name": "project_key_pages_project_id_projects_id_fk",
+          "tableFrom": "project_key_pages",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_research_log": {
+      "name": "project_research_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entry_date": {
+          "name": "entry_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ','now'))"
+        }
+      },
+      "indexes": {
+        "project_research_log_project_date_idx": {
+          "name": "project_research_log_project_date_idx",
+          "columns": [
+            "project_id",
+            "entry_date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "project_research_log_project_id_projects_id_fk": {
+          "name": "project_research_log_project_id_projects_id_fk",
+          "tableFrom": "project_research_log",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_issues": {
+      "name": "audit_issues",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audit_id": {
+          "name": "audit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "page_url": {
+          "name": "page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issue_type": {
+          "name": "issue_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'info'"
+        },
+        "details_json": {
+          "name": "details_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "audit_issues_audit_type_idx": {
+          "name": "audit_issues_audit_type_idx",
+          "columns": [
+            "audit_id",
+            "issue_type"
+          ],
+          "isUnique": false
+        },
+        "audit_issues_page_id_idx": {
+          "name": "audit_issues_page_id_idx",
+          "columns": [
+            "page_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audit_issues_audit_id_audits_id_fk": {
+          "name": "audit_issues_audit_id_audits_id_fk",
+          "tableFrom": "audit_issues",
+          "tableTo": "audits",
+          "columnsFrom": [
+            "audit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_issues_page_id_audit_pages_id_fk": {
+          "name": "audit_issues_page_id_audit_pages_id_fk",
+          "tableFrom": "audit_issues",
+          "tableTo": "audit_pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_lighthouse_results": {
+      "name": "audit_lighthouse_results",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audit_id": {
+          "name": "audit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "strategy": {
+          "name": "strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "performance_score": {
+          "name": "performance_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accessibility_score": {
+          "name": "accessibility_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "best_practices_score": {
+          "name": "best_practices_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seo_score": {
+          "name": "seo_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lcp_ms": {
+          "name": "lcp_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cls": {
+          "name": "cls",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inp_ms": {
+          "name": "inp_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ttfb_ms": {
+          "name": "ttfb_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload_size_bytes": {
+          "name": "payload_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "audit_lighthouse_results_audit_id_idx": {
+          "name": "audit_lighthouse_results_audit_id_idx",
+          "columns": [
+            "audit_id"
+          ],
+          "isUnique": false
+        },
+        "audit_lighthouse_results_page_id_idx": {
+          "name": "audit_lighthouse_results_page_id_idx",
+          "columns": [
+            "page_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audit_lighthouse_results_audit_id_audits_id_fk": {
+          "name": "audit_lighthouse_results_audit_id_audits_id_fk",
+          "tableFrom": "audit_lighthouse_results",
+          "tableTo": "audits",
+          "columnsFrom": [
+            "audit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_lighthouse_results_page_id_audit_pages_id_fk": {
+          "name": "audit_lighthouse_results_page_id_audit_pages_id_fk",
+          "tableFrom": "audit_lighthouse_results",
+          "tableTo": "audit_pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_pages": {
+      "name": "audit_pages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audit_id": {
+          "name": "audit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "canonical_url": {
+          "name": "canonical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "robots_meta": {
+          "name": "robots_meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_title": {
+          "name": "og_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_description": {
+          "name": "og_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_image": {
+          "name": "og_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "h1_count": {
+          "name": "h1_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "h2_count": {
+          "name": "h2_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "h3_count": {
+          "name": "h3_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "h4_count": {
+          "name": "h4_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "h5_count": {
+          "name": "h5_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "h6_count": {
+          "name": "h6_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "heading_order_json": {
+          "name": "heading_order_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "images_total": {
+          "name": "images_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "images_missing_alt": {
+          "name": "images_missing_alt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "images_json": {
+          "name": "images_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "internal_link_count": {
+          "name": "internal_link_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "external_link_count": {
+          "name": "external_link_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "has_structured_data": {
+          "name": "has_structured_data",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "hreflang_tags_json": {
+          "name": "hreflang_tags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_indexable": {
+          "name": "is_indexable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "x_robots_tag": {
+          "name": "x_robots_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "header_canonical_url": {
+          "name": "header_canonical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "crawl_depth": {
+          "name": "crawl_depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "in_sitemap": {
+          "name": "in_sitemap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fetch_class": {
+          "name": "fetch_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ok'"
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "audit_pages_audit_url_idx": {
+          "name": "audit_pages_audit_url_idx",
+          "columns": [
+            "audit_id",
+            "url"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audit_pages_audit_id_audits_id_fk": {
+          "name": "audit_pages_audit_id_audits_id_fk",
+          "tableFrom": "audit_pages",
+          "tableTo": "audits",
+          "columnsFrom": [
+            "audit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audits": {
+      "name": "audits",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_by_user_id": {
+          "name": "started_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_url": {
+          "name": "start_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "workflow_instance_id": {
+          "name": "workflow_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "pages_crawled": {
+          "name": "pages_crawled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "pages_total": {
+          "name": "pages_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lighthouse_total": {
+          "name": "lighthouse_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lighthouse_completed": {
+          "name": "lighthouse_completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lighthouse_failed": {
+          "name": "lighthouse_failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "current_phase": {
+          "name": "current_phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'discovery'"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_detail": {
+          "name": "error_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failed_phase": {
+          "name": "failed_phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "audits_project_id_idx": {
+          "name": "audits_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "audits_started_by_user_id_idx": {
+          "name": "audits_started_by_user_id_idx",
+          "columns": [
+            "started_by_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audits_project_id_projects_id_fk": {
+          "name": "audits_project_id_projects_id_fk",
+          "tableFrom": "audits",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sam_sessions": {
+      "name": "sam_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'New chat'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sam_sessions_project_updated_idx": {
+          "name": "sam_sessions_project_updated_idx",
+          "columns": [
+            "project_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sam_sessions_project_id_projects_id_fk": {
+          "name": "sam_sessions_project_id_projects_id_fk",
+          "tableFrom": "sam_sessions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sam_sessions_user_id_user_id_fk": {
+          "name": "sam_sessions_user_id_user_id_fk",
+          "tableFrom": "sam_sessions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "account_accountId_providerId_idx": {
+          "name": "account_accountId_providerId_idx",
+          "columns": [
+            "account_id",
+            "provider_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 60000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 120
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "apikey_configId_idx": {
+          "name": "apikey_configId_idx",
+          "columns": [
+            "config_id"
+          ],
+          "isUnique": false
+        },
+        "apikey_referenceId_idx": {
+          "name": "apikey_referenceId_idx",
+          "columns": [
+            "reference_id"
+          ],
+          "isUnique": false
+        },
+        "apikey_key_idx": {
+          "name": "apikey_key_idx",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invitation": {
+      "name": "invitation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "member": {
+      "name": "member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "member_organizationId_userId_uidx": {
+          "name": "member_organizationId_userId_uidx",
+          "columns": [
+            "organization_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization": {
+      "name": "organization",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "organization_slug_uidx": {
+          "name": "organization_slug_uidx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "analytics_opted_out": {
+          "name": "analytics_opted_out",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_active_organization_id": {
+          "name": "last_active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        },
+        "verification_expiresAt_idx": {
+          "name": "verification_expiresAt_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "billing_customer_status": {
+      "name": "billing_customer_status",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_paying": {
+          "name": "is_paying",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "paid_plan_id": {
+          "name": "paid_plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "paid_plan_status": {
+          "name": "paid_plan_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "customer_json": {
+          "name": "customer_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "billing_customer_status_organization_id_organization_id_fk": {
+          "name": "billing_customer_status_organization_id_organization_id_fk",
+          "tableFrom": "billing_customer_status",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cloudflare_analytics_connections": {
+      "name": "cloudflare_analytics_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_api_token": {
+          "name": "encrypted_api_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hint": {
+          "name": "token_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "zone_label": {
+          "name": "zone_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "traffic_available": {
+          "name": "traffic_available",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "traffic_reason": {
+          "name": "traffic_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "security_events_available": {
+          "name": "security_events_available",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "security_events_reason": {
+          "name": "security_events_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "crawler_access_available": {
+          "name": "crawler_access_available",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "crawler_access_reason": {
+          "name": "crawler_access_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "cloudflare_analytics_connections_project_idx": {
+          "name": "cloudflare_analytics_connections_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": true
+        },
+        "cloudflare_analytics_connections_organization_idx": {
+          "name": "cloudflare_analytics_connections_organization_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "cloudflare_analytics_connections_project_id_projects_id_fk": {
+          "name": "cloudflare_analytics_connections_project_id_projects_id_fk",
+          "tableFrom": "cloudflare_analytics_connections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cloudflare_analytics_connections_organization_id_organization_id_fk": {
+          "name": "cloudflare_analytics_connections_organization_id_organization_id_fk",
+          "tableFrom": "cloudflare_analytics_connections",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ga4_connections": {
+      "name": "ga4_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "property_display_name": {
+          "name": "property_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "property_time_zone": {
+          "name": "property_time_zone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "property_currency_code": {
+          "name": "property_currency_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ga4_account_id": {
+          "name": "ga4_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connected_account_email": {
+          "name": "connected_account_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "ga4_connections_project_idx": {
+          "name": "ga4_connections_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": true
+        },
+        "ga4_connections_organization_idx": {
+          "name": "ga4_connections_organization_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "ga4_connections_connector_idx": {
+          "name": "ga4_connections_connector_idx",
+          "columns": [
+            "connected_by_user_id",
+            "ga4_account_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "ga4_connections_project_id_projects_id_fk": {
+          "name": "ga4_connections_project_id_projects_id_fk",
+          "tableFrom": "ga4_connections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ga4_connections_organization_id_organization_id_fk": {
+          "name": "ga4_connections_organization_id_organization_id_fk",
+          "tableFrom": "ga4_connections",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gsc_connections": {
+      "name": "gsc_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "site_url": {
+          "name": "site_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gsc_account_id": {
+          "name": "gsc_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connected_account_email": {
+          "name": "connected_account_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "gsc_connections_project_idx": {
+          "name": "gsc_connections_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": true
+        },
+        "gsc_connections_organization_idx": {
+          "name": "gsc_connections_organization_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gsc_connections_project_id_projects_id_fk": {
+          "name": "gsc_connections_project_id_projects_id_fk",
+          "tableFrom": "gsc_connections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gsc_connections_organization_id_organization_id_fk": {
+          "name": "gsc_connections_organization_id_organization_id_fk",
+          "tableFrom": "gsc_connections",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "telemetry_state": {
+      "name": "telemetry_state",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "install_id": {
+          "name": "install_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_version": {
+          "name": "last_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcp_tool_call_count": {
+          "name": "mcp_tool_call_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -316,6 +316,13 @@
       "when": 1787773498579,
       "tag": "0044_outstanding_sage",
       "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "6",
+      "when": 1788521143554,
+      "tag": "0045_rainy_talkback",
+      "breakpoints": true
     }
   ]
 }

--- a/src/client/features/ai-mcp/AvailableTools.test.ts
+++ b/src/client/features/ai-mcp/AvailableTools.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import {
+  CLOUDFLARE_ANALYTICS_TOOL_NAME_LIST,
+  CLOUDFLARE_ANALYTICS_TOOL_NAMES,
+} from "@/shared/cloudflare-analytics";
+import { availableToolNames } from "./AvailableTools";
+
+describe("Cloudflare Analytics tool catalog", () => {
+  it("includes every shared Cloudflare Analytics tool exactly once", () => {
+    expect(
+      CLOUDFLARE_ANALYTICS_TOOL_NAME_LIST.filter((name) =>
+        availableToolNames.includes(name),
+      ),
+    ).toEqual(CLOUDFLARE_ANALYTICS_TOOL_NAME_LIST);
+    expect(
+      availableToolNames.filter((name) => name.startsWith("get_cloudflare_")),
+    ).toEqual(CLOUDFLARE_ANALYTICS_TOOL_NAME_LIST);
+    expect(new Set(CLOUDFLARE_ANALYTICS_TOOL_NAME_LIST).size).toBe(3);
+    expect(CLOUDFLARE_ANALYTICS_TOOL_NAMES).toEqual({
+      trafficHealth: "get_cloudflare_traffic_health",
+      securityEvents: "get_cloudflare_security_events",
+      crawlerAccess: "get_cloudflare_crawler_access",
+    });
+  });
+});

--- a/src/client/features/ai-mcp/AvailableTools.tsx
+++ b/src/client/features/ai-mcp/AvailableTools.tsx
@@ -1,3 +1,5 @@
+import { CLOUDFLARE_ANALYTICS_TOOL_NAMES } from "@/shared/cloudflare-analytics";
+
 type McpTool = {
   name: string;
   title: string;
@@ -250,7 +252,34 @@ const toolCategories: ToolCategory[] = [
       },
     ],
   },
+  {
+    label: "Cloudflare Analytics",
+    tools: [
+      {
+        name: CLOUDFLARE_ANALYTICS_TOOL_NAMES.trafficHealth,
+        title: "Get Cloudflare traffic health",
+        description:
+          "Read aggregate requests, status codes, error rates, and sampling for a connected zone.",
+      },
+      {
+        name: CLOUDFLARE_ANALYTICS_TOOL_NAMES.securityEvents,
+        title: "Get Cloudflare security events",
+        description:
+          "Review aggregate security actions and privacy-redacted paths.",
+      },
+      {
+        name: CLOUDFLARE_ANALYTICS_TOOL_NAMES.crawlerAccess,
+        title: "Get Cloudflare crawler access",
+        description:
+          "Compare verified Googlebot and Bingbot access by status and privacy-redacted path.",
+      },
+    ],
+  },
 ];
+
+export const availableToolNames = toolCategories.flatMap(({ tools }) =>
+  tools.map(({ name }) => name),
+);
 
 export function AvailableTools() {
   return (

--- a/src/client/features/cloudflare-analytics/CloudflareAnalyticsConnectionCard.tsx
+++ b/src/client/features/cloudflare-analytics/CloudflareAnalyticsConnectionCard.tsx
@@ -9,6 +9,7 @@ import {
   disconnectCloudflareAnalytics,
   getCloudflareAnalyticsConnection,
 } from "@/serverFunctions/cloudflare-analytics";
+import { CLOUDFLARE_TRANSIENT_CAPABILITY_PREFIX } from "@/shared/cloudflare-analytics";
 
 const DOCS_URL =
   "https://developers.cloudflare.com/analytics/graphql-api/getting-started/authentication/api-token-auth/";
@@ -214,13 +215,23 @@ function ConnectedState({
       <div className="flex flex-wrap gap-2">
         {CAPABILITY_NAMES.map((name) => {
           const capability = capabilities[name];
+          const retryable =
+            !capability.available &&
+            capability.reason?.startsWith(
+              CLOUDFLARE_TRANSIENT_CAPABILITY_PREFIX,
+            );
           return (
             <span
               key={name}
-              title={capability.reason ?? undefined}
-              className={`badge badge-sm ${capability.available ? "badge-success" : "badge-ghost"}`}
+              title={
+                retryable
+                  ? "The initial probe failed temporarily; OpenSEO retries when this dataset is requested."
+                  : (capability.reason ?? undefined)
+              }
+              className={`badge badge-sm ${capability.available ? "badge-success" : retryable ? "badge-warning" : "badge-ghost"}`}
             >
               {CAPABILITY_LABELS[name]}
+              {retryable ? " · retryable" : ""}
             </span>
           );
         })}

--- a/src/client/features/cloudflare-analytics/CloudflareAnalyticsConnectionCard.tsx
+++ b/src/client/features/cloudflare-analytics/CloudflareAnalyticsConnectionCard.tsx
@@ -1,0 +1,290 @@
+import * as React from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Cloud, ExternalLink, ShieldCheck, TriangleAlert } from "lucide-react";
+import { toast } from "sonner";
+import { IntegrationConnectionCard } from "@/client/features/integrations/IntegrationConnectionCard";
+import { getStandardErrorMessage } from "@/client/lib/error-messages";
+import {
+  connectCloudflareAnalytics,
+  disconnectCloudflareAnalytics,
+  getCloudflareAnalyticsConnection,
+} from "@/serverFunctions/cloudflare-analytics";
+
+const DOCS_URL =
+  "https://developers.cloudflare.com/analytics/graphql-api/getting-started/authentication/api-token-auth/";
+
+const CAPABILITY_LABELS = {
+  traffic: "Traffic",
+  securityEvents: "Security events",
+  crawlerAccess: "Verified crawlers",
+} as const;
+const CAPABILITY_NAMES = [
+  "traffic",
+  "securityEvents",
+  "crawlerAccess",
+] as const;
+
+export function CloudflareAnalyticsConnectionCard({
+  projectId,
+}: {
+  projectId: string;
+}) {
+  const queryClient = useQueryClient();
+  const [editing, setEditing] = React.useState(false);
+  const [apiToken, setApiToken] = React.useState("");
+  const [zoneId, setZoneId] = React.useState("");
+  const [zoneLabel, setZoneLabel] = React.useState("");
+  const queryKey = ["cloudflareAnalyticsConnection", projectId];
+  const connection = useQuery({
+    queryKey,
+    queryFn: () => getCloudflareAnalyticsConnection({ data: { projectId } }),
+  });
+  const connected = connection.data?.connected === true;
+  const encryptionConfigured = connection.data?.encryptionConfigured === true;
+
+  const connect = useMutation({
+    mutationFn: () =>
+      connectCloudflareAnalytics({
+        data: {
+          projectId,
+          apiToken,
+          zoneId,
+          zoneLabel: zoneLabel || undefined,
+        },
+      }),
+    onSuccess: () => {
+      toast.success("Cloudflare Analytics connected");
+      setApiToken("");
+      setEditing(false);
+      void queryClient.invalidateQueries({ queryKey });
+    },
+    onError: (error) => toast.error(getStandardErrorMessage(error)),
+  });
+  const disconnect = useMutation({
+    mutationFn: () => disconnectCloudflareAnalytics({ data: { projectId } }),
+    onSuccess: () => {
+      toast.success("Cloudflare Analytics disconnected");
+      setEditing(false);
+      void queryClient.invalidateQueries({ queryKey });
+    },
+    onError: (error) => toast.error(getStandardErrorMessage(error)),
+  });
+
+  React.useEffect(() => {
+    const data = connection.data;
+    if (!data?.connected || editing) return;
+    setZoneId(data.zoneId ?? "");
+    setZoneLabel(data.zoneLabel ?? "");
+  }, [connection.data, editing]);
+
+  return (
+    <IntegrationConnectionCard
+      title="Cloudflare Analytics"
+      icon={<Cloud className="size-5 text-[#f38020]" />}
+      status={
+        connection.isPending || connection.isError
+          ? undefined
+          : connected && encryptionConfigured
+            ? "connected"
+            : !encryptionConfigured
+              ? "setup_required"
+              : "disconnected"
+      }
+    >
+      {connection.isPending ? (
+        <p className="text-sm text-base-content/55">Checking connection…</p>
+      ) : connection.isError ? (
+        <div className="alert alert-error text-sm">
+          <TriangleAlert className="size-4" />
+          Could not load the Cloudflare connection.
+        </div>
+      ) : !encryptionConfigured ? (
+        <div className="alert alert-warning items-start text-sm">
+          <ShieldCheck className="mt-0.5 size-4 shrink-0" />
+          <span>
+            Set a stable <code>BETTER_AUTH_SECRET</code> of at least 32
+            characters before storing an Analytics token.
+          </span>
+        </div>
+      ) : connected && !editing ? (
+        <ConnectedState
+          zone={connection.data.zoneLabel ?? connection.data.zoneId ?? ""}
+          tokenHint={connection.data.tokenHint ?? "Encrypted"}
+          capabilities={connection.data.capabilities}
+          disconnecting={disconnect.isPending}
+          onEdit={() => setEditing(true)}
+          onDisconnect={() => disconnect.mutate()}
+        />
+      ) : (
+        <form
+          className="space-y-4"
+          onSubmit={(event) => {
+            event.preventDefault();
+            connect.mutate();
+          }}
+        >
+          <div className="grid gap-4 sm:grid-cols-2">
+            <Field
+              label="Analytics API token"
+              value={apiToken}
+              onChange={setApiToken}
+              secret
+              required
+            />
+            <Field
+              label="Zone ID"
+              value={zoneId}
+              onChange={setZoneId}
+              mono
+              required
+            />
+            <Field
+              label="Zone label (optional)"
+              value={zoneLabel}
+              onChange={setZoneLabel}
+              placeholder="example.com"
+            />
+          </div>
+          <div className="rounded-lg border border-base-300 bg-base-200/30 p-3 text-xs text-base-content/65">
+            <ShieldCheck className="mr-2 inline size-4 text-success" />
+            Use a separate read-only token. OpenSEO validates the selected zone
+            before saving, encrypts the token, and never requests IP addresses,
+            query strings, or full User-Agent values.
+          </div>
+          <a
+            className="inline-flex items-center gap-1 text-xs link"
+            href={DOCS_URL}
+            target="_blank"
+            rel="noreferrer"
+          >
+            Cloudflare token guide <ExternalLink className="size-3" />
+          </a>
+          <div className="flex gap-2">
+            <button
+              type="submit"
+              className="btn btn-primary btn-sm"
+              disabled={
+                apiToken.trim().length < 20 ||
+                zoneId.trim().length !== 32 ||
+                connect.isPending
+              }
+            >
+              {connect.isPending ? "Validating…" : "Connect Cloudflare"}
+            </button>
+            {connected ? (
+              <button
+                type="button"
+                className="btn btn-ghost btn-sm"
+                onClick={() => setEditing(false)}
+              >
+                Cancel
+              </button>
+            ) : null}
+          </div>
+        </form>
+      )}
+    </IntegrationConnectionCard>
+  );
+}
+
+function ConnectedState({
+  zone,
+  tokenHint,
+  capabilities,
+  disconnecting,
+  onEdit,
+  onDisconnect,
+}: {
+  zone: string;
+  tokenHint: string;
+  capabilities: Record<
+    keyof typeof CAPABILITY_LABELS,
+    { available: boolean; reason: string | null }
+  >;
+  disconnecting: boolean;
+  onEdit: () => void;
+  onDisconnect: () => void;
+}) {
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-3 text-sm sm:grid-cols-2">
+        <ConnectionValue label="Zone" value={zone} />
+        <ConnectionValue label="Token" value={tokenHint} />
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {CAPABILITY_NAMES.map((name) => {
+          const capability = capabilities[name];
+          return (
+            <span
+              key={name}
+              title={capability.reason ?? undefined}
+              className={`badge badge-sm ${capability.available ? "badge-success" : "badge-ghost"}`}
+            >
+              {CAPABILITY_LABELS[name]}
+            </span>
+          );
+        })}
+      </div>
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          className="btn btn-primary btn-sm"
+          onClick={onEdit}
+        >
+          Replace settings
+        </button>
+        <button
+          type="button"
+          className="btn btn-ghost btn-sm text-error"
+          disabled={disconnecting}
+          onClick={onDisconnect}
+        >
+          {disconnecting ? "Disconnecting…" : "Disconnect"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ConnectionValue({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-base-300 bg-base-200/30 p-3">
+      <p className="text-xs text-base-content/50">{label}</p>
+      <p className="mt-1 truncate font-mono">{value}</p>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  value,
+  onChange,
+  secret,
+  required,
+  mono,
+  placeholder,
+}: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  secret?: boolean;
+  required?: boolean;
+  mono?: boolean;
+  placeholder?: string;
+}) {
+  return (
+    <label className="form-control block">
+      <span className="label-text text-sm font-medium">{label}</span>
+      <input
+        className={`input input-bordered mt-1 w-full text-sm ${mono ? "font-mono" : ""}`}
+        type={secret ? "password" : "text"}
+        autoComplete="off"
+        spellCheck={false}
+        required={required}
+        value={value}
+        placeholder={placeholder}
+        onChange={(event) => onChange(event.target.value)}
+      />
+    </label>
+  );
+}

--- a/src/db/cloudflare-analytics.schema.ts
+++ b/src/db/cloudflare-analytics.schema.ts
@@ -1,0 +1,59 @@
+import { sql } from "drizzle-orm";
+import {
+  index,
+  integer,
+  sqliteTable,
+  text,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core";
+import { projects } from "./app.schema";
+import { organization } from "./better-auth-schema";
+
+/** One read-only Cloudflare Analytics zone connection per OpenSEO project. */
+export const cloudflareAnalyticsConnections = sqliteTable(
+  "cloudflare_analytics_connections",
+  {
+    id: text("id").primaryKey(),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    encryptedApiToken: text("encrypted_api_token").notNull(),
+    tokenHint: text("token_hint").notNull(),
+    zoneId: text("zone_id").notNull(),
+    zoneLabel: text("zone_label"),
+    trafficAvailable: integer("traffic_available", { mode: "boolean" })
+      .notNull()
+      .default(false),
+    trafficReason: text("traffic_reason"),
+    securityEventsAvailable: integer("security_events_available", {
+      mode: "boolean",
+    })
+      .notNull()
+      .default(false),
+    securityEventsReason: text("security_events_reason"),
+    crawlerAccessAvailable: integer("crawler_access_available", {
+      mode: "boolean",
+    })
+      .notNull()
+      .default(false),
+    crawlerAccessReason: text("crawler_access_reason"),
+    connectedByUserId: text("connected_by_user_id").notNull(),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(current_timestamp)`),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(current_timestamp)`),
+  },
+  (table) => [
+    uniqueIndex("cloudflare_analytics_connections_project_idx").on(
+      table.projectId,
+    ),
+    index("cloudflare_analytics_connections_organization_idx").on(
+      table.organizationId,
+    ),
+  ],
+);

--- a/src/db/d1/schema.ts
+++ b/src/db/d1/schema.ts
@@ -7,6 +7,7 @@ export * from "../audit.schema";
 export * from "../sam.schema";
 export * from "../better-auth-schema";
 export * from "../billing.schema";
+export * from "../cloudflare-analytics.schema";
 export * from "../ga4.schema";
 export * from "../gsc.schema";
 export * from "../telemetry.schema";

--- a/src/db/pg/cloudflare-analytics.schema.ts
+++ b/src/db/pg/cloudflare-analytics.schema.ts
@@ -1,0 +1,51 @@
+import { sql } from "drizzle-orm";
+import {
+  boolean,
+  index,
+  pgTable,
+  text,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
+import { projects } from "./app.schema";
+import { organization } from "./better-auth-schema";
+
+const isoNow = sql`to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')`;
+
+/** Keep this definition structurally identical to ../cloudflare-analytics.schema.ts. */
+export const cloudflareAnalyticsConnections = pgTable(
+  "cloudflare_analytics_connections",
+  {
+    id: text("id").primaryKey(),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    encryptedApiToken: text("encrypted_api_token").notNull(),
+    tokenHint: text("token_hint").notNull(),
+    zoneId: text("zone_id").notNull(),
+    zoneLabel: text("zone_label"),
+    trafficAvailable: boolean("traffic_available").notNull().default(false),
+    trafficReason: text("traffic_reason"),
+    securityEventsAvailable: boolean("security_events_available")
+      .notNull()
+      .default(false),
+    securityEventsReason: text("security_events_reason"),
+    crawlerAccessAvailable: boolean("crawler_access_available")
+      .notNull()
+      .default(false),
+    crawlerAccessReason: text("crawler_access_reason"),
+    connectedByUserId: text("connected_by_user_id").notNull(),
+    createdAt: text("created_at").notNull().default(isoNow),
+    updatedAt: text("updated_at").notNull().default(isoNow),
+  },
+  (table) => [
+    uniqueIndex("cloudflare_analytics_connections_project_idx").on(
+      table.projectId,
+    ),
+    index("cloudflare_analytics_connections_organization_idx").on(
+      table.organizationId,
+    ),
+  ],
+);

--- a/src/db/pg/schema.ts
+++ b/src/db/pg/schema.ts
@@ -4,6 +4,7 @@ export * from "./audit.schema";
 export * from "./sam.schema";
 export * from "./better-auth-schema";
 export * from "./billing.schema";
+export * from "./cloudflare-analytics.schema";
 export * from "./ga4.schema";
 export * from "./gsc.schema";
 export * from "./telemetry.schema";

--- a/src/db/schema-parity.test.ts
+++ b/src/db/schema-parity.test.ts
@@ -11,6 +11,7 @@ import * as sqliteAudit from "./audit.schema";
 import * as sqliteSam from "./sam.schema";
 import * as sqliteAuth from "./better-auth-schema";
 import * as sqliteBilling from "./billing.schema";
+import * as sqliteCloudflareAnalytics from "./cloudflare-analytics.schema";
 import * as sqliteGa4 from "./ga4.schema";
 import * as sqliteGsc from "./gsc.schema";
 import * as sqliteTelemetry from "./telemetry.schema";
@@ -20,6 +21,7 @@ import * as pgAudit from "./pg/audit.schema";
 import * as pgSam from "./pg/sam.schema";
 import * as pgAuth from "./pg/better-auth-schema";
 import * as pgBilling from "./pg/billing.schema";
+import * as pgCloudflareAnalytics from "./pg/cloudflare-analytics.schema";
 import * as pgGa4 from "./pg/ga4.schema";
 import * as pgGsc from "./pg/gsc.schema";
 import * as pgTelemetry from "./pg/telemetry.schema";
@@ -150,6 +152,7 @@ const sqliteAppTables = tablesFrom(
   sqliteAudit,
   sqliteSam,
   sqliteBilling,
+  sqliteCloudflareAnalytics,
   sqliteGa4,
   sqliteGsc,
   sqliteTelemetry,
@@ -160,6 +163,7 @@ const pgAppTables = tablesFrom(
   pgAudit,
   pgSam,
   pgBilling,
+  pgCloudflareAnalytics,
   pgGa4,
   pgGsc,
   pgTelemetry,

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -5,6 +5,7 @@ import * as sqliteAudit from "./audit.schema";
 import * as sqliteSam from "./sam.schema";
 import * as sqliteAuth from "./better-auth-schema";
 import * as sqliteBilling from "./billing.schema";
+import * as sqliteCloudflareAnalytics from "./cloudflare-analytics.schema";
 import * as sqliteGa4 from "./ga4.schema";
 import * as sqliteGsc from "./gsc.schema";
 import * as sqliteTelemetry from "./telemetry.schema";
@@ -14,6 +15,7 @@ import * as pgAudit from "./pg/audit.schema";
 import * as pgSam from "./pg/sam.schema";
 import * as pgAuth from "./pg/better-auth-schema";
 import * as pgBilling from "./pg/billing.schema";
+import * as pgCloudflareAnalytics from "./pg/cloudflare-analytics.schema";
 import * as pgGa4 from "./pg/ga4.schema";
 import * as pgGsc from "./pg/gsc.schema";
 import * as pgTelemetry from "./pg/telemetry.schema";
@@ -34,6 +36,7 @@ type AppSchema = typeof sqliteApp &
   typeof sqliteSam &
   typeof sqliteAuth &
   typeof sqliteBilling &
+  typeof sqliteCloudflareAnalytics &
   typeof sqliteGa4 &
   typeof sqliteGsc &
   typeof sqliteTelemetry;
@@ -47,6 +50,7 @@ const runtimeSchema =
         ...pgSam,
         ...pgAuth,
         ...pgBilling,
+        ...pgCloudflareAnalytics,
         ...pgGa4,
         ...pgGsc,
         ...pgTelemetry,
@@ -58,6 +62,7 @@ const runtimeSchema =
         ...sqliteSam,
         ...sqliteAuth,
         ...sqliteBilling,
+        ...sqliteCloudflareAnalytics,
         ...sqliteGa4,
         ...sqliteGsc,
         ...sqliteTelemetry,
@@ -98,6 +103,7 @@ export const {
   member,
   invitation,
   billingCustomerStatus,
+  cloudflareAnalyticsConnections,
   ga4Connections,
   gscConnections,
   telemetryState,

--- a/src/routes/_project/p/$projectId/settings/integrations.tsx
+++ b/src/routes/_project/p/$projectId/settings/integrations.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { SearchConsoleConnectionCard } from "@/client/features/gsc/SearchConsoleConnectionCard";
 import { GoogleAnalyticsConnectionCard } from "@/client/features/ga4/GoogleAnalyticsConnectionCard";
+import { CloudflareAnalyticsConnectionCard } from "@/client/features/cloudflare-analytics/CloudflareAnalyticsConnectionCard";
 
 export const Route = createFileRoute(
   "/_project/p/$projectId/settings/integrations",
@@ -31,6 +32,13 @@ function ProjectIntegrationsRoute() {
             </h2>
           }
         />
+      </section>
+
+      <section id="cloudflare-analytics" className="scroll-mt-6 space-y-3">
+        <h2 className="text-sm font-medium text-base-content/50">
+          Edge analytics
+        </h2>
+        <CloudflareAnalyticsConnectionCard projectId={projectId} />
       </section>
     </div>
   );

--- a/src/server/features/cloudflare-analytics/CloudflareAnalyticsClient.test.ts
+++ b/src/server/features/cloudflare-analytics/CloudflareAnalyticsClient.test.ts
@@ -7,6 +7,7 @@ import {
   CLOUDFLARE_TRAFFIC_QUERY,
   createCloudflareAnalyticsClient,
 } from "./CloudflareAnalyticsClient";
+import { CLOUDFLARE_MAX_RETRY_AFTER_SECONDS } from "./CloudflareAnalyticsError";
 
 function mockFetch(response: () => Response): typeof fetch {
   return vi.fn(async () => response());
@@ -98,6 +99,23 @@ describe("CloudflareAnalyticsClient", () => {
       ),
     );
     await expect(client.traffic(request)).rejects.toMatchObject({ code });
+  });
+
+  it("bounds Retry-After before returning it to callers", async () => {
+    const client = createCloudflareAnalyticsClient(
+      mockFetch(
+        () =>
+          new Response("rate limited", {
+            status: 429,
+            headers: { "retry-after": "999999" },
+          }),
+      ),
+    );
+
+    await expect(client.traffic(request)).rejects.toMatchObject({
+      code: "rate_limited",
+      retryAfterSeconds: CLOUDFLARE_MAX_RETRY_AFTER_SECONDS,
+    });
   });
 
   it.each([

--- a/src/server/features/cloudflare-analytics/CloudflareAnalyticsClient.test.ts
+++ b/src/server/features/cloudflare-analytics/CloudflareAnalyticsClient.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import {
+  CLOUDFLARE_CRAWLER_QUERY,
+  CLOUDFLARE_MAX_RESPONSE_BYTES,
+  CLOUDFLARE_SECURITY_QUERY,
+  CLOUDFLARE_TRAFFIC_QUERY,
+  createCloudflareAnalyticsClient,
+} from "./CloudflareAnalyticsClient";
+
+function mockFetch(response: () => Response): typeof fetch {
+  return vi.fn(async () => response());
+}
+
+const request = {
+  apiToken: "secret-token",
+  zoneId: "a".repeat(32),
+  from: "2026-09-04T09:00:00.000Z",
+  to: "2026-09-04T11:00:00.000Z",
+};
+
+describe("CloudflareAnalyticsClient", () => {
+  it("parses aggregates, accepts errors:null, and keeps the token out of the body", async () => {
+    const fetcher = mockFetch(
+      () =>
+        new Response(
+          JSON.stringify({
+            data: {
+              viewer: {
+                zones: [
+                  {
+                    httpRequestsAdaptiveGroups: [
+                      {
+                        count: "12",
+                        dimensions: { edgeResponseStatus: 200 },
+                        sum: { edgeResponseBytes: "450", visits: 3 },
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+            errors: null,
+          }),
+        ),
+    );
+    const result =
+      await createCloudflareAnalyticsClient(fetcher).traffic(request);
+
+    expect(
+      result.data?.viewer.zones[0]?.httpRequestsAdaptiveGroups[0]?.count,
+    ).toBe(12);
+    const init = vi.mocked(fetcher).mock.calls[0]?.[1];
+    expect(new Headers(init?.headers).get("authorization")).toBe(
+      "Bearer secret-token",
+    );
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
+    if (typeof init?.body !== "string") throw new Error("Expected JSON body");
+    expect(init.body).not.toContain("secret-token");
+    expect(result.errors).toEqual([]);
+  });
+
+  it("keeps valid partial data and errors from HTTP 200", async () => {
+    const client = createCloudflareAnalyticsClient(
+      mockFetch(
+        () =>
+          new Response(
+            JSON.stringify({
+              data: {
+                viewer: { zones: [{ httpRequestsAdaptiveGroups: [] }] },
+              },
+              errors: [{ message: "optional field unavailable" }],
+            }),
+          ),
+      ),
+    );
+
+    await expect(client.traffic(request)).resolves.toEqual({
+      data: { viewer: { zones: [{ httpRequestsAdaptiveGroups: [] }] } },
+      errors: ["optional field unavailable"],
+    });
+  });
+
+  it.each([
+    [401, "authentication_failed"],
+    [403, "authentication_failed"],
+    [429, "rate_limited"],
+    [500, "upstream_unavailable"],
+    [503, "upstream_unavailable"],
+  ] as const)("maps HTTP %s to %s", async (status, code) => {
+    const client = createCloudflareAnalyticsClient(
+      mockFetch(
+        () =>
+          new Response("provider details", {
+            status,
+            headers: status === 429 ? { "retry-after": "42" } : undefined,
+          }),
+      ),
+    );
+    await expect(client.traffic(request)).rejects.toMatchObject({ code });
+  });
+
+  it.each([
+    ["cannot request data older than 2678400s", "dataset_unavailable"],
+    ["unknown field sampleInterval on type Query", "invalid_response"],
+  ] as const)("classifies HTTP 400 errors", async (message, code) => {
+    const client = createCloudflareAnalyticsClient(
+      mockFetch(
+        () =>
+          new Response(JSON.stringify({ data: null, errors: [{ message }] }), {
+            status: 400,
+          }),
+      ),
+    );
+    await expect(client.traffic(request)).rejects.toMatchObject({
+      code,
+      providerErrors: [message],
+    });
+  });
+
+  it("uses verified bot IDs without a User-Agent fallback", async () => {
+    const fetcher = mockFetch(
+      () =>
+        new Response(
+          JSON.stringify({
+            data: { viewer: { zones: [{ googlebot: [], bingbot: [] }] } },
+          }),
+        ),
+    );
+    await createCloudflareAnalyticsClient(fetcher).crawlerAccess(request);
+    const rawBody = vi.mocked(fetcher).mock.calls[0]?.[1]?.body;
+    if (typeof rawBody !== "string") throw new Error("Expected JSON body");
+    const body = z
+      .object({
+        variables: z.object({
+          googleFilter: z.object({
+            botDetectionIds_hasany: z.array(z.number()),
+          }),
+          bingFilter: z.object({
+            botDetectionIds_hasany: z.array(z.number()),
+          }),
+        }),
+      })
+      .parse(JSON.parse(rawBody));
+    expect(body.variables.googleFilter.botDetectionIds_hasany).toEqual([
+      120_623_194, 33_554_459,
+    ]);
+    expect(body.variables.bingFilter.botDetectionIds_hasany).toEqual([
+      117_479_730, 33_554_461,
+    ]);
+    expect(JSON.stringify(body)).not.toMatch(/userAgent/i);
+  });
+
+  it("never requests IP, query-string, or raw user-agent dimensions", () => {
+    const queries = [
+      CLOUDFLARE_TRAFFIC_QUERY,
+      CLOUDFLARE_SECURITY_QUERY,
+      CLOUDFLARE_CRAWLER_QUERY,
+    ].join("\n");
+    expect(queries).not.toMatch(
+      /clientIP|clientRequestQuery|clientRequestUserAgent|\buserAgent\b/i,
+    );
+    expect(CLOUDFLARE_SECURITY_QUERY).toMatch(/orderBy:\s*\[count_DESC\]/);
+  });
+
+  it("rejects oversized and invalid JSON responses", async () => {
+    const oversized = createCloudflareAnalyticsClient(
+      mockFetch(
+        () =>
+          new Response("{}", {
+            headers: {
+              "content-length": String(CLOUDFLARE_MAX_RESPONSE_BYTES + 1),
+            },
+          }),
+      ),
+    );
+    await expect(oversized.traffic(request)).rejects.toMatchObject({
+      code: "invalid_response",
+    });
+
+    const invalid = createCloudflareAnalyticsClient(
+      mockFetch(() => new Response("not-json")),
+    );
+    await expect(invalid.traffic(request)).rejects.toMatchObject({
+      code: "invalid_response",
+    });
+  });
+
+  it("classifies timeouts and network failures as upstream unavailable", async () => {
+    const fetcher: typeof fetch = vi.fn(async () => {
+      throw new DOMException("Timed out", "TimeoutError");
+    });
+    await expect(
+      createCloudflareAnalyticsClient(fetcher).traffic(request),
+    ).rejects.toMatchObject({ code: "upstream_unavailable" });
+  });
+});

--- a/src/server/features/cloudflare-analytics/CloudflareAnalyticsClient.ts
+++ b/src/server/features/cloudflare-analytics/CloudflareAnalyticsClient.ts
@@ -1,5 +1,8 @@
 import type { z } from "zod";
-import { CloudflareAnalyticsError } from "./CloudflareAnalyticsError";
+import {
+  CloudflareAnalyticsError,
+  CLOUDFLARE_MAX_RETRY_AFTER_SECONDS,
+} from "./CloudflareAnalyticsError";
 import {
   crawlerGraphqlDataSchema,
   graphqlResponseSchema,
@@ -136,10 +139,15 @@ function retryAfterSeconds(response: Response): number | undefined {
   const value = response.headers.get("retry-after");
   if (!value) return undefined;
   const seconds = Number(value);
-  if (Number.isFinite(seconds) && seconds >= 0) return Math.ceil(seconds);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.min(CLOUDFLARE_MAX_RETRY_AFTER_SECONDS, Math.ceil(seconds));
+  }
   const date = Date.parse(value);
   return Number.isFinite(date)
-    ? Math.max(0, Math.ceil((date - Date.now()) / 1_000))
+    ? Math.min(
+        CLOUDFLARE_MAX_RETRY_AFTER_SECONDS,
+        Math.max(0, Math.ceil((date - Date.now()) / 1_000)),
+      )
     : undefined;
 }
 

--- a/src/server/features/cloudflare-analytics/CloudflareAnalyticsClient.ts
+++ b/src/server/features/cloudflare-analytics/CloudflareAnalyticsClient.ts
@@ -1,0 +1,361 @@
+import type { z } from "zod";
+import { CloudflareAnalyticsError } from "./CloudflareAnalyticsError";
+import {
+  crawlerGraphqlDataSchema,
+  graphqlResponseSchema,
+  securityGraphqlDataSchema,
+  trafficGraphqlDataSchema,
+} from "./schemas";
+
+const CLOUDFLARE_GRAPHQL_URL = "https://api.cloudflare.com/client/v4/graphql";
+const ROW_LIMIT = 500;
+const CLOUDFLARE_REQUEST_TIMEOUT_MS = 15_000;
+export const CLOUDFLARE_MAX_RESPONSE_BYTES = 1_000_000;
+
+/**
+ * Cloudflare-verified detection IDs from the public bot reference. These IDs
+ * require Bot Management. Never fall back to spoofable User-Agent matching.
+ * https://developers.cloudflare.com/ai-crawl-control/reference/bots/
+ */
+const SEARCH_CRAWLER_DETECTION_IDS = {
+  googlebot: [120_623_194, 33_554_459],
+  bingbot: [117_479_730, 33_554_461],
+} as const;
+
+export const CLOUDFLARE_TRAFFIC_QUERY = /* GraphQL */ `
+  query OpenSeoCloudflareTraffic(
+    $zoneTag: String!
+    $filter: ZoneHttpRequestsAdaptiveGroupsFilter_InputObject!
+  ) {
+    viewer {
+      zones(filter: { zoneTag: $zoneTag }) {
+        httpRequestsAdaptiveGroups(
+          limit: ${ROW_LIMIT}
+          filter: $filter
+          orderBy: [datetimeHour_ASC]
+        ) {
+          count
+          dimensions { datetimeHour edgeResponseStatus }
+          sum { edgeResponseBytes visits }
+          avg { sampleInterval }
+        }
+      }
+    }
+  }
+`;
+
+export const CLOUDFLARE_SECURITY_QUERY = /* GraphQL */ `
+  query OpenSeoCloudflareSecurity(
+    $zoneTag: String!
+    $filter: ZoneFirewallEventsAdaptiveGroupsFilter_InputObject!
+  ) {
+    viewer {
+      zones(filter: { zoneTag: $zoneTag }) {
+        firewallEventsAdaptiveGroups(
+          limit: ${ROW_LIMIT}
+          filter: $filter
+          orderBy: [count_DESC]
+        ) {
+          count
+          avg { sampleInterval }
+          dimensions {
+            action
+            source
+            ruleId
+            clientRequestHTTPHost
+            clientRequestPath
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const CLOUDFLARE_CRAWLER_QUERY = /* GraphQL */ `
+  query OpenSeoCloudflareCrawlerAccess(
+    $zoneTag: String!
+    $googleFilter: ZoneHttpRequestsAdaptiveGroupsFilter_InputObject!
+    $bingFilter: ZoneHttpRequestsAdaptiveGroupsFilter_InputObject!
+  ) {
+    viewer {
+      zones(filter: { zoneTag: $zoneTag }) {
+        googlebot: httpRequestsAdaptiveGroups(
+          limit: ${ROW_LIMIT}
+          filter: $googleFilter
+          orderBy: [count_DESC]
+        ) {
+          count
+          dimensions {
+            clientRequestHTTPHost
+            clientRequestPath
+            edgeResponseStatus
+          }
+          avg { sampleInterval }
+        }
+        bingbot: httpRequestsAdaptiveGroups(
+          limit: ${ROW_LIMIT}
+          filter: $bingFilter
+          orderBy: [count_DESC]
+        ) {
+          count
+          dimensions {
+            clientRequestHTTPHost
+            clientRequestPath
+            edgeResponseStatus
+          }
+          avg { sampleInterval }
+        }
+      }
+    }
+  }
+`;
+
+const MAX_PROVIDER_ERRORS = 5;
+const MAX_PROVIDER_ERROR_LENGTH = 300;
+const DATASET_ACCESSIBILITY_ERROR_PATTERNS = [
+  /^cannot request data older than\b/i,
+  /^number of fields (?:can't|cannot) be more than\b/i,
+  /^limit must be positive number and not greater than\b/i,
+  /^query time range is too large\b/i,
+] as const;
+
+type CloudflareFetch = typeof fetch;
+
+export type CloudflareGraphqlResult<T> = {
+  data: T | null;
+  errors: string[];
+};
+
+function boundedProviderErrors(errors: readonly string[]): string[] {
+  return errors
+    .slice(0, MAX_PROVIDER_ERRORS)
+    .map((message) => message.slice(0, MAX_PROVIDER_ERROR_LENGTH));
+}
+
+function retryAfterSeconds(response: Response): number | undefined {
+  const value = response.headers.get("retry-after");
+  if (!value) return undefined;
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds >= 0) return Math.ceil(seconds);
+  const date = Date.parse(value);
+  return Number.isFinite(date)
+    ? Math.max(0, Math.ceil((date - Date.now()) / 1_000))
+    : undefined;
+}
+
+function statusError(
+  response: Response,
+  responseErrors: readonly string[] = [],
+): CloudflareAnalyticsError {
+  if (response.status === 401 || response.status === 403) {
+    return new CloudflareAnalyticsError(
+      "authentication_failed",
+      "Cloudflare rejected the Analytics token.",
+    );
+  }
+  if (response.status === 429) {
+    return new CloudflareAnalyticsError(
+      "rate_limited",
+      "Cloudflare Analytics rate limit reached.",
+      retryAfterSeconds(response),
+    );
+  }
+  if (response.status === 400) {
+    const providerErrors = boundedProviderErrors(responseErrors);
+    const datasetUnavailable =
+      providerErrors.length > 0 &&
+      providerErrors.every((message) =>
+        DATASET_ACCESSIBILITY_ERROR_PATTERNS.some((pattern) =>
+          pattern.test(message),
+        ),
+      );
+    return new CloudflareAnalyticsError(
+      datasetUnavailable ? "dataset_unavailable" : "invalid_response",
+      datasetUnavailable
+        ? "Cloudflare Analytics rejected this dataset window or plan limit."
+        : "Cloudflare Analytics rejected the GraphQL query.",
+      undefined,
+      providerErrors,
+    );
+  }
+  return new CloudflareAnalyticsError(
+    "upstream_unavailable",
+    `Cloudflare Analytics returned HTTP ${response.status}.`,
+  );
+}
+
+async function parseGraphqlResponse<T>(
+  response: Response,
+  schema: z.ZodType<T>,
+): Promise<CloudflareGraphqlResult<T>> {
+  if (!response.ok && response.status !== 400) throw statusError(response);
+
+  let json: unknown;
+  try {
+    json = await readBoundedJson(response);
+  } catch (error) {
+    if (error instanceof CloudflareAnalyticsError) throw error;
+    if (!response.ok) throw statusError(response);
+    throw new CloudflareAnalyticsError(
+      "invalid_response",
+      "Cloudflare Analytics returned invalid JSON.",
+    );
+  }
+  const envelope = graphqlResponseSchema.safeParse(json);
+  if (!envelope.success) {
+    if (!response.ok) throw statusError(response);
+    throw new CloudflareAnalyticsError(
+      "invalid_response",
+      "Cloudflare Analytics returned an unexpected response shape.",
+    );
+  }
+  const errors = (envelope.data.errors ?? []).map((error) => error.message);
+  if (!response.ok) throw statusError(response, errors);
+  if (envelope.data.data == null) return { data: null, errors };
+
+  const parsed = schema.safeParse(envelope.data.data);
+  if (!parsed.success) {
+    if (errors.length > 0) return { data: null, errors };
+    throw new CloudflareAnalyticsError(
+      "invalid_response",
+      "Cloudflare Analytics returned malformed dataset rows.",
+    );
+  }
+  return { data: parsed.data, errors };
+}
+
+async function readBoundedJson(response: Response): Promise<unknown> {
+  const declaredLength = Number(response.headers.get("content-length"));
+  if (
+    Number.isFinite(declaredLength) &&
+    declaredLength > CLOUDFLARE_MAX_RESPONSE_BYTES
+  ) {
+    throw new CloudflareAnalyticsError(
+      "invalid_response",
+      "Cloudflare Analytics response exceeded the size limit.",
+    );
+  }
+  if (!response.body) return JSON.parse(await response.text());
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let bytes = 0;
+  let text = "";
+  while (true) {
+    const chunk = await reader.read();
+    if (chunk.done) break;
+    bytes += chunk.value.byteLength;
+    if (bytes > CLOUDFLARE_MAX_RESPONSE_BYTES) {
+      await reader.cancel();
+      throw new CloudflareAnalyticsError(
+        "invalid_response",
+        "Cloudflare Analytics response exceeded the size limit.",
+      );
+    }
+    text += decoder.decode(chunk.value, { stream: true });
+  }
+  text += decoder.decode();
+  return JSON.parse(text);
+}
+
+export function createCloudflareAnalyticsClient(
+  fetcher: CloudflareFetch = fetch,
+) {
+  async function query<T>(input: {
+    apiToken: string;
+    query: string;
+    variables: Record<string, unknown>;
+    schema: z.ZodType<T>;
+  }): Promise<CloudflareGraphqlResult<T>> {
+    let response: Response;
+    try {
+      response = await fetcher(CLOUDFLARE_GRAPHQL_URL, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${input.apiToken}`,
+          "content-type": "application/json",
+        },
+        signal: AbortSignal.timeout(CLOUDFLARE_REQUEST_TIMEOUT_MS),
+        body: JSON.stringify({
+          query: input.query,
+          variables: input.variables,
+        }),
+      });
+    } catch {
+      throw new CloudflareAnalyticsError(
+        "upstream_unavailable",
+        "Cloudflare Analytics could not be reached.",
+      );
+    }
+    return parseGraphqlResponse(response, input.schema);
+  }
+
+  return {
+    traffic(input: {
+      apiToken: string;
+      zoneId: string;
+      from: string;
+      to: string;
+    }) {
+      return query({
+        apiToken: input.apiToken,
+        query: CLOUDFLARE_TRAFFIC_QUERY,
+        variables: {
+          zoneTag: input.zoneId,
+          filter: { datetime_geq: input.from, datetime_leq: input.to },
+        },
+        schema: trafficGraphqlDataSchema,
+      });
+    },
+    securityEvents(input: {
+      apiToken: string;
+      zoneId: string;
+      from: string;
+      to: string;
+    }) {
+      return query({
+        apiToken: input.apiToken,
+        query: CLOUDFLARE_SECURITY_QUERY,
+        variables: {
+          zoneTag: input.zoneId,
+          filter: { datetime_geq: input.from, datetime_leq: input.to },
+        },
+        schema: securityGraphqlDataSchema,
+      });
+    },
+    crawlerAccess(input: {
+      apiToken: string;
+      zoneId: string;
+      from: string;
+      to: string;
+    }) {
+      const timeFilter = {
+        datetime_geq: input.from,
+        datetime_leq: input.to,
+        requestSource: "eyeball",
+      };
+      return query({
+        apiToken: input.apiToken,
+        query: CLOUDFLARE_CRAWLER_QUERY,
+        variables: {
+          zoneTag: input.zoneId,
+          googleFilter: {
+            ...timeFilter,
+            botDetectionIds_hasany: SEARCH_CRAWLER_DETECTION_IDS.googlebot,
+          },
+          bingFilter: {
+            ...timeFilter,
+            botDetectionIds_hasany: SEARCH_CRAWLER_DETECTION_IDS.bingbot,
+          },
+        },
+        schema: crawlerGraphqlDataSchema,
+      });
+    },
+  };
+}
+
+export type CloudflareAnalyticsClient = ReturnType<
+  typeof createCloudflareAnalyticsClient
+>;
+
+export const cloudflareAnalyticsClient = createCloudflareAnalyticsClient();

--- a/src/server/features/cloudflare-analytics/CloudflareAnalyticsError.ts
+++ b/src/server/features/cloudflare-analytics/CloudflareAnalyticsError.ts
@@ -1,0 +1,21 @@
+type CloudflareAnalyticsErrorCode =
+  | "not_connected"
+  | "encryption_unavailable"
+  | "authentication_failed"
+  | "zone_not_accessible"
+  | "dataset_unavailable"
+  | "rate_limited"
+  | "upstream_unavailable"
+  | "invalid_response";
+
+export class CloudflareAnalyticsError extends Error {
+  constructor(
+    public readonly code: CloudflareAnalyticsErrorCode,
+    message: string,
+    public readonly retryAfterSeconds?: number,
+    public readonly providerErrors: readonly string[] = [],
+  ) {
+    super(message);
+    this.name = "CloudflareAnalyticsError";
+  }
+}

--- a/src/server/features/cloudflare-analytics/CloudflareAnalyticsError.ts
+++ b/src/server/features/cloudflare-analytics/CloudflareAnalyticsError.ts
@@ -8,6 +8,8 @@ type CloudflareAnalyticsErrorCode =
   | "upstream_unavailable"
   | "invalid_response";
 
+export const CLOUDFLARE_MAX_RETRY_AFTER_SECONDS = 24 * 60 * 60;
+
 export class CloudflareAnalyticsError extends Error {
   constructor(
     public readonly code: CloudflareAnalyticsErrorCode,

--- a/src/server/features/cloudflare-analytics/CloudflareAnalyticsRepository.ts
+++ b/src/server/features/cloudflare-analytics/CloudflareAnalyticsRepository.ts
@@ -1,0 +1,105 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { cloudflareAnalyticsConnections } from "@/db/schema";
+import type { CloudflareCapabilities } from "./schemas";
+
+export type CloudflareAnalyticsConnection =
+  typeof cloudflareAnalyticsConnections.$inferSelect;
+
+async function getByProjectId(
+  projectId: string,
+): Promise<CloudflareAnalyticsConnection | null> {
+  const rows = await db
+    .select()
+    .from(cloudflareAnalyticsConnections)
+    .where(eq(cloudflareAnalyticsConnections.projectId, projectId))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+async function replace(input: {
+  projectId: string;
+  organizationId: string;
+  encryptedApiToken: string;
+  tokenHint: string;
+  zoneId: string;
+  zoneLabel: string | null;
+  capabilities: CloudflareCapabilities;
+  connectedByUserId: string;
+  now: string;
+}): Promise<string> {
+  const id = crypto.randomUUID();
+  await db
+    .insert(cloudflareAnalyticsConnections)
+    .values({
+      id,
+      projectId: input.projectId,
+      organizationId: input.organizationId,
+      encryptedApiToken: input.encryptedApiToken,
+      tokenHint: input.tokenHint,
+      zoneId: input.zoneId,
+      zoneLabel: input.zoneLabel,
+      trafficAvailable: input.capabilities.traffic.available,
+      trafficReason: input.capabilities.traffic.reason,
+      securityEventsAvailable: input.capabilities.securityEvents.available,
+      securityEventsReason: input.capabilities.securityEvents.reason,
+      crawlerAccessAvailable: input.capabilities.crawlerAccess.available,
+      crawlerAccessReason: input.capabilities.crawlerAccess.reason,
+      connectedByUserId: input.connectedByUserId,
+      createdAt: input.now,
+      updatedAt: input.now,
+    })
+    .onConflictDoUpdate({
+      target: cloudflareAnalyticsConnections.projectId,
+      set: {
+        id,
+        organizationId: input.organizationId,
+        encryptedApiToken: input.encryptedApiToken,
+        tokenHint: input.tokenHint,
+        zoneId: input.zoneId,
+        zoneLabel: input.zoneLabel,
+        trafficAvailable: input.capabilities.traffic.available,
+        trafficReason: input.capabilities.traffic.reason,
+        securityEventsAvailable: input.capabilities.securityEvents.available,
+        securityEventsReason: input.capabilities.securityEvents.reason,
+        crawlerAccessAvailable: input.capabilities.crawlerAccess.available,
+        crawlerAccessReason: input.capabilities.crawlerAccess.reason,
+        connectedByUserId: input.connectedByUserId,
+        createdAt: input.now,
+        updatedAt: input.now,
+      },
+    });
+  return id;
+}
+
+async function disconnect(projectId: string): Promise<void> {
+  await db
+    .delete(cloudflareAnalyticsConnections)
+    .where(eq(cloudflareAnalyticsConnections.projectId, projectId));
+}
+
+function capabilitiesFromConnection(
+  connection: CloudflareAnalyticsConnection,
+): CloudflareCapabilities {
+  return {
+    traffic: {
+      available: connection.trafficAvailable,
+      reason: connection.trafficReason,
+    },
+    securityEvents: {
+      available: connection.securityEventsAvailable,
+      reason: connection.securityEventsReason,
+    },
+    crawlerAccess: {
+      available: connection.crawlerAccessAvailable,
+      reason: connection.crawlerAccessReason,
+    },
+  };
+}
+
+export const CloudflareAnalyticsRepository = {
+  getByProjectId,
+  replace,
+  disconnect,
+  capabilitiesFromConnection,
+};

--- a/src/server/features/cloudflare-analytics/CloudflareAnalyticsService.test.ts
+++ b/src/server/features/cloudflare-analytics/CloudflareAnalyticsService.test.ts
@@ -1,0 +1,307 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CloudflareAnalyticsClient } from "./CloudflareAnalyticsClient";
+import { CloudflareAnalyticsError } from "./CloudflareAnalyticsError";
+import { createCloudflareAnalyticsService } from "./CloudflareAnalyticsService";
+
+const repository = vi.hoisted(() => ({
+  getByProjectId: vi.fn(),
+  replace: vi.fn(),
+  disconnect: vi.fn(),
+  capabilitiesFromConnection: vi.fn(),
+}));
+const vault = vi.hoisted(() => ({
+  isConfigured: vi.fn(),
+  encrypt: vi.fn(),
+  decrypt: vi.fn(),
+}));
+
+vi.mock("./CloudflareAnalyticsRepository", () => ({
+  CloudflareAnalyticsRepository: repository,
+}));
+vi.mock("./CloudflareCredentialVault", () => ({
+  CloudflareCredentialVault: vault,
+}));
+
+const now = new Date("2026-09-04T12:00:00.000Z");
+const capabilities = {
+  traffic: { available: true, reason: null },
+  securityEvents: { available: true, reason: null },
+  crawlerAccess: { available: true, reason: null },
+};
+const connection = {
+  id: "connection-1",
+  projectId: "project-1",
+  organizationId: "org-1",
+  encryptedApiToken: "ciphertext",
+  tokenHint: "••••oken",
+  zoneId: "a".repeat(32),
+  zoneLabel: "example.com",
+  trafficAvailable: true,
+  trafficReason: null,
+  securityEventsAvailable: true,
+  securityEventsReason: null,
+  crawlerAccessAvailable: true,
+  crawlerAccessReason: null,
+  connectedByUserId: "user-1",
+  createdAt: now.toISOString(),
+  updatedAt: now.toISOString(),
+};
+
+function client(overrides: Partial<CloudflareAnalyticsClient> = {}) {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test double implements the complete client surface
+  return {
+    traffic: vi.fn(),
+    securityEvents: vi.fn(),
+    crawlerAccess: vi.fn(),
+    ...overrides,
+  } as CloudflareAnalyticsClient;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  repository.getByProjectId.mockResolvedValue(connection);
+  repository.capabilitiesFromConnection.mockReturnValue(capabilities);
+  repository.replace.mockResolvedValue("connection-2");
+  vault.isConfigured.mockResolvedValue(true);
+  vault.encrypt.mockResolvedValue("ciphertext-new");
+  vault.decrypt.mockResolvedValue("provider-token");
+});
+
+describe("CloudflareAnalyticsService connection", () => {
+  it("returns metadata without ciphertext or plaintext tokens", async () => {
+    const result =
+      await createCloudflareAnalyticsService().getConnection("project-1");
+
+    expect(result).toMatchObject({
+      connected: true,
+      tokenHint: "••••oken",
+      zoneId: "a".repeat(32),
+    });
+    expect(JSON.stringify(result)).not.toMatch(/ciphertext|provider-token/);
+  });
+
+  it("validates and encrypts before save while optional datasets fail independently", async () => {
+    const traffic = vi.fn(async () => ({
+      data: { viewer: { zones: [{ httpRequestsAdaptiveGroups: [] }] } },
+      errors: [],
+    }));
+    const service = createCloudflareAnalyticsService({
+      now: () => now,
+      client: client({
+        traffic,
+        securityEvents: vi.fn(async () => {
+          throw new CloudflareAnalyticsError(
+            "dataset_unavailable",
+            "Unavailable on plan",
+          );
+        }),
+        crawlerAccess: vi.fn(async () => ({
+          data: { viewer: { zones: [{ googlebot: [], bingbot: [] }] } },
+          errors: [],
+        })),
+      }),
+    });
+    const result = await service.connect({
+      projectId: "project-1",
+      organizationId: "org-1",
+      userId: "user-1",
+      apiToken: "provider-secret-token",
+      zoneId: "a".repeat(32),
+      zoneLabel: "example.com",
+    });
+
+    expect(vault.encrypt).toHaveBeenCalledWith("provider-secret-token");
+    expect(traffic).toHaveBeenCalled();
+    expect(repository.replace).toHaveBeenCalledWith({
+      projectId: "project-1",
+      organizationId: "org-1",
+      encryptedApiToken: "ciphertext-new",
+      tokenHint: "••••oken",
+      zoneId: "a".repeat(32),
+      zoneLabel: "example.com",
+      capabilities: {
+        traffic: { available: true, reason: null },
+        securityEvents: {
+          available: false,
+          reason: "dataset_unavailable",
+        },
+        crawlerAccess: { available: true, reason: null },
+      },
+      connectedByUserId: "user-1",
+      now: now.toISOString(),
+    });
+    expect(result.capabilities.traffic.available).toBe(true);
+    expect(JSON.stringify(result)).not.toContain("provider-secret-token");
+  });
+
+  it("does not persist when the token cannot read exactly one selected zone", async () => {
+    const service = createCloudflareAnalyticsService({
+      client: client({
+        traffic: vi.fn(async () => ({
+          data: { viewer: { zones: [] } },
+          errors: [],
+        })),
+      }),
+    });
+
+    await expect(
+      service.connect({
+        projectId: "project-1",
+        organizationId: "org-1",
+        userId: "user-1",
+        apiToken: "provider-secret-token",
+        zoneId: "a".repeat(32),
+      }),
+    ).rejects.toMatchObject({ code: "zone_not_accessible" });
+    expect(repository.replace).not.toHaveBeenCalled();
+  });
+});
+
+describe("CloudflareAnalyticsService reports", () => {
+  it("aggregates HTTP health and preserves sampling plus partial errors", async () => {
+    const service = createCloudflareAnalyticsService({
+      client: client({
+        traffic: vi.fn(async () => ({
+          errors: ["one aggregate unavailable"],
+          data: {
+            viewer: {
+              zones: [
+                {
+                  httpRequestsAdaptiveGroups: [
+                    {
+                      count: 100,
+                      dimensions: { edgeResponseStatus: 200 },
+                      sum: { edgeResponseBytes: 1_000, visits: 20 },
+                      avg: { sampleInterval: 10 },
+                    },
+                    {
+                      count: 7,
+                      dimensions: { edgeResponseStatus: 403 },
+                      sum: { edgeResponseBytes: 70, visits: 0 },
+                    },
+                    {
+                      count: 3,
+                      dimensions: { edgeResponseStatus: 502 },
+                      sum: { edgeResponseBytes: 30, visits: 0 },
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        })),
+      }),
+    });
+    const result = await service.trafficHealth({
+      projectId: "project-1",
+      from: "2026-09-04T11:00:00.000Z",
+      to: now.toISOString(),
+    });
+
+    expect(result.status).toBe("partial");
+    expect(result.coverage.sampled).toBe(true);
+    expect(result.data).toMatchObject({
+      requests: 110,
+      errors4xx: 7,
+      errors5xx: 3,
+      responseBytes: 1_100,
+    });
+  });
+
+  it("marks 500-row provider results partial and never complete", async () => {
+    const rows = Array.from({ length: 500 }, () => ({
+      count: 1,
+      dimensions: { edgeResponseStatus: 200 },
+      sum: { edgeResponseBytes: 1 },
+      avg: { sampleInterval: 1 },
+    }));
+    const service = createCloudflareAnalyticsService({
+      client: client({
+        traffic: vi.fn(async () => ({
+          errors: [],
+          data: { viewer: { zones: [{ httpRequestsAdaptiveGroups: rows }] } },
+        })),
+      }),
+    });
+    const result = await service.trafficHealth({
+      projectId: "project-1",
+      from: "2026-09-04T11:00:00.000Z",
+      to: now.toISOString(),
+    });
+
+    expect(result.status).toBe("partial");
+    expect(result.coverage).toEqual({ sampled: false, truncated: true });
+    expect(result.warnings).toContain("provider_row_limit_reached");
+  });
+
+  it("treats errors plus empty rows as unavailable, not no_data", async () => {
+    const service = createCloudflareAnalyticsService({
+      client: client({
+        traffic: vi.fn(async () => ({
+          errors: ["dataset failed"],
+          data: {
+            viewer: { zones: [{ httpRequestsAdaptiveGroups: [] }] },
+          },
+        })),
+      }),
+    });
+    const result = await service.trafficHealth({
+      projectId: "project-1",
+      from: "2026-09-04T11:00:00.000Z",
+      to: now.toISOString(),
+    });
+    expect(result.status).toBe("unavailable");
+    expect(result.data).toBeNull();
+  });
+
+  it("normalizes paths without retaining query strings", async () => {
+    const service = createCloudflareAnalyticsService({
+      client: client({
+        securityEvents: vi.fn(async () => ({
+          errors: [],
+          data: {
+            viewer: {
+              zones: [
+                {
+                  firewallEventsAdaptiveGroups: [
+                    {
+                      count: 4,
+                      dimensions: {
+                        action: "block",
+                        clientRequestHTTPHost: "Example.COM",
+                        clientRequestPath: "/login?email=private@example.com",
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        })),
+      }),
+    });
+    const result = await service.securityEvents({
+      projectId: "project-1",
+      from: "2026-09-04T11:00:00.000Z",
+      to: now.toISOString(),
+    });
+
+    expect(result.data?.events[0]).toMatchObject({
+      host: "example.com",
+      pathname: "/login",
+    });
+    expect(JSON.stringify(result)).not.toContain("private@example.com");
+  });
+
+  it("scopes every credential lookup to the requested project", async () => {
+    repository.getByProjectId.mockResolvedValue(null);
+    const result = await createCloudflareAnalyticsService().trafficHealth({
+      projectId: "project-foreign",
+      from: "2026-09-04T11:00:00.000Z",
+      to: now.toISOString(),
+    });
+
+    expect(repository.getByProjectId).toHaveBeenCalledWith("project-foreign");
+    expect(result.status).toBe("not_connected");
+  });
+});

--- a/src/server/features/cloudflare-analytics/CloudflareAnalyticsService.test.ts
+++ b/src/server/features/cloudflare-analytics/CloudflareAnalyticsService.test.ts
@@ -96,8 +96,8 @@ describe("CloudflareAnalyticsService connection", () => {
           );
         }),
         crawlerAccess: vi.fn(async () => ({
-          data: { viewer: { zones: [{ googlebot: [], bingbot: [] }] } },
-          errors: [],
+          data: null,
+          errors: ["temporary GraphQL field failure"],
         })),
       }),
     });
@@ -125,7 +125,10 @@ describe("CloudflareAnalyticsService connection", () => {
           available: false,
           reason: "dataset_unavailable",
         },
-        crawlerAccess: { available: true, reason: null },
+        crawlerAccess: {
+          available: false,
+          reason: "transient:provider_graphql_error",
+        },
       },
       connectedByUserId: "user-1",
       now: now.toISOString(),
@@ -155,9 +158,160 @@ describe("CloudflareAnalyticsService connection", () => {
     ).rejects.toMatchObject({ code: "zone_not_accessible" });
     expect(repository.replace).not.toHaveBeenCalled();
   });
+
+  it("records transient optional-dataset probe failures as retryable", async () => {
+    const service = createCloudflareAnalyticsService({
+      now: () => now,
+      client: client({
+        traffic: vi.fn(async () => ({
+          data: { viewer: { zones: [{ httpRequestsAdaptiveGroups: [] }] } },
+          errors: [],
+        })),
+        securityEvents: vi.fn(async () => {
+          throw new CloudflareAnalyticsError(
+            "rate_limited",
+            "Rate limited",
+            42,
+          );
+        }),
+        crawlerAccess: vi.fn(async () => ({
+          data: { viewer: { zones: [{ googlebot: [], bingbot: [] }] } },
+          errors: [],
+        })),
+      }),
+    });
+
+    await service.connect({
+      projectId: "project-1",
+      organizationId: "org-1",
+      userId: "user-1",
+      apiToken: "provider-secret-token",
+      zoneId: "a".repeat(32),
+    });
+
+    expect(repository.replace).toHaveBeenCalledWith({
+      projectId: "project-1",
+      organizationId: "org-1",
+      encryptedApiToken: "ciphertext-new",
+      tokenHint: "••••oken",
+      zoneId: "a".repeat(32),
+      zoneLabel: null,
+      capabilities: {
+        traffic: { available: true, reason: null },
+        securityEvents: {
+          available: false,
+          reason: "transient:rate_limited",
+        },
+        crawlerAccess: { available: true, reason: null },
+      },
+      connectedByUserId: "user-1",
+      now: now.toISOString(),
+    });
+  });
 });
 
 describe("CloudflareAnalyticsService reports", () => {
+  it("retries a transient capability probe and reports the recovered capability", async () => {
+    const securityEvents = vi.fn(async () => ({
+      errors: [],
+      data: {
+        viewer: {
+          zones: [
+            {
+              firewallEventsAdaptiveGroups: [
+                {
+                  count: 1,
+                  dimensions: {
+                    action: "block",
+                    clientRequestHTTPHost: "example.com",
+                    clientRequestPath: "/login",
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    }));
+    repository.capabilitiesFromConnection.mockReturnValue({
+      ...capabilities,
+      securityEvents: {
+        available: false,
+        reason: "transient:upstream_unavailable",
+      },
+    });
+    const service = createCloudflareAnalyticsService({
+      client: client({ securityEvents }),
+    });
+
+    const result = await service.securityEvents({
+      projectId: "project-1",
+      from: "2026-09-04T11:00:00.000Z",
+      to: now.toISOString(),
+    });
+
+    expect(securityEvents).toHaveBeenCalledOnce();
+    expect(result.status).toBe("ok");
+    expect(result.data?.capabilities.securityEvents).toEqual({
+      available: true,
+      reason: null,
+    });
+  });
+
+  it("does not retry a deterministic unavailable dataset", async () => {
+    const securityEvents = vi.fn();
+    repository.capabilitiesFromConnection.mockReturnValue({
+      ...capabilities,
+      securityEvents: {
+        available: false,
+        reason: "dataset_unavailable",
+      },
+    });
+    const service = createCloudflareAnalyticsService({
+      client: client({ securityEvents }),
+    });
+
+    const result = await service.securityEvents({
+      projectId: "project-1",
+      from: "2026-09-04T11:00:00.000Z",
+      to: now.toISOString(),
+    });
+
+    expect(securityEvents).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      status: "unavailable",
+      warnings: ["dataset_unavailable"],
+      data: null,
+    });
+  });
+
+  it("propagates provider backoff in a bounded structured result", async () => {
+    const service = createCloudflareAnalyticsService({
+      client: client({
+        traffic: vi.fn(async () => {
+          throw new CloudflareAnalyticsError(
+            "rate_limited",
+            "Rate limited",
+            999_999,
+          );
+        }),
+      }),
+    });
+
+    await expect(
+      service.trafficHealth({
+        projectId: "project-1",
+        from: "2026-09-04T11:00:00.000Z",
+        to: now.toISOString(),
+      }),
+    ).resolves.toMatchObject({
+      status: "rate_limited",
+      retryAfterSeconds: 86_400,
+      warnings: ["rate_limited"],
+      data: null,
+    });
+  });
+
   it("aggregates HTTP health and preserves sampling plus partial errors", async () => {
     const service = createCloudflareAnalyticsService({
       client: client({
@@ -252,45 +406,6 @@ describe("CloudflareAnalyticsService reports", () => {
     });
     expect(result.status).toBe("unavailable");
     expect(result.data).toBeNull();
-  });
-
-  it("normalizes paths without retaining query strings", async () => {
-    const service = createCloudflareAnalyticsService({
-      client: client({
-        securityEvents: vi.fn(async () => ({
-          errors: [],
-          data: {
-            viewer: {
-              zones: [
-                {
-                  firewallEventsAdaptiveGroups: [
-                    {
-                      count: 4,
-                      dimensions: {
-                        action: "block",
-                        clientRequestHTTPHost: "Example.COM",
-                        clientRequestPath: "/login?email=private@example.com",
-                      },
-                    },
-                  ],
-                },
-              ],
-            },
-          },
-        })),
-      }),
-    });
-    const result = await service.securityEvents({
-      projectId: "project-1",
-      from: "2026-09-04T11:00:00.000Z",
-      to: now.toISOString(),
-    });
-
-    expect(result.data?.events[0]).toMatchObject({
-      host: "example.com",
-      pathname: "/login",
-    });
-    expect(JSON.stringify(result)).not.toContain("private@example.com");
   });
 
   it("scopes every credential lookup to the requested project", async () => {

--- a/src/server/features/cloudflare-analytics/CloudflareAnalyticsService.ts
+++ b/src/server/features/cloudflare-analytics/CloudflareAnalyticsService.ts
@@ -3,7 +3,10 @@ import {
   type CloudflareAnalyticsClient,
   type CloudflareGraphqlResult,
 } from "./CloudflareAnalyticsClient";
-import { CloudflareAnalyticsError } from "./CloudflareAnalyticsError";
+import {
+  CloudflareAnalyticsError,
+  CLOUDFLARE_MAX_RETRY_AFTER_SECONDS,
+} from "./CloudflareAnalyticsError";
 import {
   CloudflareAnalyticsRepository,
   type CloudflareAnalyticsConnection,
@@ -22,6 +25,7 @@ import type {
   CloudflareSecurityResult,
   CloudflareTrafficResult,
 } from "./schemas";
+import { CLOUDFLARE_TRANSIENT_CAPABILITY_PREFIX } from "@/shared/cloudflare-analytics";
 
 type Repository = typeof CloudflareAnalyticsRepository;
 type Vault = typeof CloudflareCredentialVault;
@@ -44,6 +48,18 @@ const unavailableCapability = (reason: string) => ({
   available: false,
   reason,
 });
+const transientCapability = (reason: string) =>
+  unavailableCapability(`${CLOUDFLARE_TRANSIENT_CAPABILITY_PREFIX}${reason}`);
+
+function isTransientCapability(
+  storedCapability: CloudflareCapabilities[keyof CloudflareCapabilities],
+) {
+  return (
+    storedCapability.reason?.startsWith(
+      CLOUDFLARE_TRANSIENT_CAPABILITY_PREFIX,
+    ) ?? false
+  );
+}
 
 const EMPTY_CLOUDFLARE_CAPABILITIES: CloudflareCapabilities = {
   traffic: unavailableCapability("not_connected"),
@@ -59,11 +75,13 @@ function capability<T>(
   return {
     available,
     reason:
-      result.errors.length > 0
-        ? boundedErrors(result.errors).join("; ")
-        : available
-          ? null
-          : "dataset_not_returned",
+      !available && result.errors.length > 0
+        ? `${CLOUDFLARE_TRANSIENT_CAPABILITY_PREFIX}provider_graphql_error`
+        : result.errors.length > 0
+          ? boundedErrors(result.errors).join("; ")
+          : available
+            ? null
+            : `${CLOUDFLARE_TRANSIENT_CAPABILITY_PREFIX}dataset_not_returned`,
   };
 }
 
@@ -72,11 +90,13 @@ function settledCapability<T>(
   present: (data: T) => boolean,
 ) {
   if (result.status === "fulfilled") return capability(result.value, present);
-  return unavailableCapability(
-    result.reason instanceof CloudflareAnalyticsError
-      ? result.reason.code
-      : "provider_probe_failed",
-  );
+  if (!(result.reason instanceof CloudflareAnalyticsError)) {
+    return transientCapability("provider_probe_failed");
+  }
+  return result.reason.code === "dataset_unavailable" ||
+    result.reason.code === "authentication_failed"
+    ? unavailableCapability(result.reason.code)
+    : transientCapability(result.reason.code);
 }
 
 function errorStatus(
@@ -91,6 +111,16 @@ function errorWarning(error: unknown): string {
   return error instanceof CloudflareAnalyticsError
     ? error.code
     : "cloudflare_request_failed";
+}
+
+function errorRetryAfterSeconds(error: unknown): number | undefined {
+  if (!(error instanceof CloudflareAnalyticsError)) return undefined;
+  const seconds = error.retryAfterSeconds;
+  if (seconds === undefined || !Number.isFinite(seconds)) return undefined;
+  return Math.min(
+    CLOUDFLARE_MAX_RETRY_AFTER_SECONDS,
+    Math.max(0, Math.ceil(seconds)),
+  );
 }
 
 export function createCloudflareAnalyticsService(
@@ -262,6 +292,7 @@ export function createCloudflareAnalyticsService(
         status: errorStatus(error),
         warning: errorWarning(error),
         window,
+        retryAfterSeconds: errorRetryAfterSeconds(error),
       });
     }
   }
@@ -274,7 +305,10 @@ export function createCloudflareAnalyticsService(
     const window = { from: input.from, to: input.to };
     try {
       const connected = await requireConnection(input.projectId);
-      if (!connected.capabilities.securityEvents.available) {
+      if (
+        !connected.capabilities.securityEvents.available &&
+        !isTransientCapability(connected.capabilities.securityEvents)
+      ) {
         return unavailableResult({
           status: "unavailable",
           warning:
@@ -292,13 +326,20 @@ export function createCloudflareAnalyticsService(
         rows: result.data?.viewer.zones[0]?.firewallEventsAdaptiveGroups,
         errors: result.errors,
         window,
-        capabilities: connected.capabilities,
+        capabilities: {
+          ...connected.capabilities,
+          securityEvents: capability(
+            result,
+            (data) => data.viewer.zones.length === 1,
+          ),
+        },
       });
     } catch (error) {
       return unavailableResult({
         status: errorStatus(error),
         warning: errorWarning(error),
         window,
+        retryAfterSeconds: errorRetryAfterSeconds(error),
       });
     }
   }
@@ -311,7 +352,10 @@ export function createCloudflareAnalyticsService(
     const window = { from: input.from, to: input.to };
     try {
       const connected = await requireConnection(input.projectId);
-      if (!connected.capabilities.crawlerAccess.available) {
+      if (
+        !connected.capabilities.crawlerAccess.available &&
+        !isTransientCapability(connected.capabilities.crawlerAccess)
+      ) {
         return unavailableResult({
           status: "unavailable",
           warning:
@@ -329,13 +373,20 @@ export function createCloudflareAnalyticsService(
         zone: result.data?.viewer.zones[0],
         errors: result.errors,
         window,
-        capabilities: connected.capabilities,
+        capabilities: {
+          ...connected.capabilities,
+          crawlerAccess: capability(
+            result,
+            (data) => data.viewer.zones.length === 1,
+          ),
+        },
       });
     } catch (error) {
       return unavailableResult({
         status: errorStatus(error),
         warning: errorWarning(error),
         window,
+        retryAfterSeconds: errorRetryAfterSeconds(error),
       });
     }
   }

--- a/src/server/features/cloudflare-analytics/CloudflareAnalyticsService.ts
+++ b/src/server/features/cloudflare-analytics/CloudflareAnalyticsService.ts
@@ -1,0 +1,353 @@
+import {
+  cloudflareAnalyticsClient,
+  type CloudflareAnalyticsClient,
+  type CloudflareGraphqlResult,
+} from "./CloudflareAnalyticsClient";
+import { CloudflareAnalyticsError } from "./CloudflareAnalyticsError";
+import {
+  CloudflareAnalyticsRepository,
+  type CloudflareAnalyticsConnection,
+} from "./CloudflareAnalyticsRepository";
+import { CloudflareCredentialVault } from "./CloudflareCredentialVault";
+import {
+  boundedErrors,
+  crawlerResult,
+  securityResult,
+  trafficResult,
+  unavailableResult,
+} from "./results";
+import type {
+  CloudflareCapabilities,
+  CloudflareCrawlerResult,
+  CloudflareSecurityResult,
+  CloudflareTrafficResult,
+} from "./schemas";
+
+type Repository = typeof CloudflareAnalyticsRepository;
+type Vault = typeof CloudflareCredentialVault;
+
+type Dependencies = {
+  client: CloudflareAnalyticsClient;
+  repository: Repository;
+  vault: Vault;
+  now: () => Date;
+};
+
+const defaults: Dependencies = {
+  client: cloudflareAnalyticsClient,
+  repository: CloudflareAnalyticsRepository,
+  vault: CloudflareCredentialVault,
+  now: () => new Date(),
+};
+
+const unavailableCapability = (reason: string) => ({
+  available: false,
+  reason,
+});
+
+const EMPTY_CLOUDFLARE_CAPABILITIES: CloudflareCapabilities = {
+  traffic: unavailableCapability("not_connected"),
+  securityEvents: unavailableCapability("not_connected"),
+  crawlerAccess: unavailableCapability("not_connected"),
+};
+
+function capability<T>(
+  result: CloudflareGraphqlResult<T>,
+  present: (data: T) => boolean,
+) {
+  const available = result.data !== null && present(result.data);
+  return {
+    available,
+    reason:
+      result.errors.length > 0
+        ? boundedErrors(result.errors).join("; ")
+        : available
+          ? null
+          : "dataset_not_returned",
+  };
+}
+
+function settledCapability<T>(
+  result: PromiseSettledResult<CloudflareGraphqlResult<T>>,
+  present: (data: T) => boolean,
+) {
+  if (result.status === "fulfilled") return capability(result.value, present);
+  return unavailableCapability(
+    result.reason instanceof CloudflareAnalyticsError
+      ? result.reason.code
+      : "provider_probe_failed",
+  );
+}
+
+function errorStatus(
+  error: unknown,
+): "not_connected" | "rate_limited" | "unavailable" {
+  if (!(error instanceof CloudflareAnalyticsError)) return "unavailable";
+  if (error.code === "not_connected") return "not_connected";
+  return error.code === "rate_limited" ? "rate_limited" : "unavailable";
+}
+
+function errorWarning(error: unknown): string {
+  return error instanceof CloudflareAnalyticsError
+    ? error.code
+    : "cloudflare_request_failed";
+}
+
+export function createCloudflareAnalyticsService(
+  dependencies: Partial<Dependencies> = {},
+) {
+  const deps = { ...defaults, ...dependencies };
+
+  async function getConnection(projectId: string) {
+    const [connection, encryptionConfigured] = await Promise.all([
+      deps.repository.getByProjectId(projectId),
+      deps.vault.isConfigured(),
+    ]);
+    if (!connection) {
+      return {
+        connected: false as const,
+        encryptionConfigured,
+        tokenHint: null,
+        zoneId: null,
+        zoneLabel: null,
+        capabilities: EMPTY_CLOUDFLARE_CAPABILITIES,
+        connectedAt: null,
+        updatedAt: null,
+      };
+    }
+    return {
+      connected: true as const,
+      encryptionConfigured,
+      tokenHint: connection.tokenHint,
+      zoneId: connection.zoneId,
+      zoneLabel: connection.zoneLabel,
+      capabilities: deps.repository.capabilitiesFromConnection(connection),
+      connectedAt: connection.createdAt,
+      updatedAt: connection.updatedAt,
+    };
+  }
+
+  async function connect(input: {
+    projectId: string;
+    organizationId: string;
+    userId: string;
+    apiToken: string;
+    zoneId: string;
+    zoneLabel?: string;
+  }) {
+    if (!(await deps.vault.isConfigured())) {
+      throw new CloudflareAnalyticsError(
+        "encryption_unavailable",
+        "Set BETTER_AUTH_SECRET to at least 32 characters before connecting Cloudflare Analytics.",
+      );
+    }
+    const apiToken = input.apiToken.trim();
+    const encryptedApiToken = await deps.vault.encrypt(apiToken);
+    const now = deps.now();
+    const probeWindow = {
+      from: new Date(now.getTime() - 60 * 60 * 1_000).toISOString(),
+      to: now.toISOString(),
+    };
+    const traffic = await deps.client.traffic({
+      apiToken,
+      zoneId: input.zoneId,
+      ...probeWindow,
+    });
+    if (!traffic.data || traffic.data.viewer.zones.length !== 1) {
+      throw new CloudflareAnalyticsError(
+        "zone_not_accessible",
+        "The token could not read Analytics for exactly one selected zone.",
+        undefined,
+        boundedErrors(traffic.errors),
+      );
+    }
+
+    const [security, crawler] = await Promise.allSettled([
+      deps.client.securityEvents({
+        apiToken,
+        zoneId: input.zoneId,
+        ...probeWindow,
+      }),
+      deps.client.crawlerAccess({
+        apiToken,
+        zoneId: input.zoneId,
+        ...probeWindow,
+      }),
+    ]);
+    const capabilities: CloudflareCapabilities = {
+      traffic: capability(traffic, (data) => data.viewer.zones.length === 1),
+      securityEvents: settledCapability(
+        security,
+        (data) => data.viewer.zones.length === 1,
+      ),
+      crawlerAccess: settledCapability(
+        crawler,
+        (data) => data.viewer.zones.length === 1,
+      ),
+    };
+    const savedAt = deps.now().toISOString();
+    const connectionId = await deps.repository.replace({
+      projectId: input.projectId,
+      organizationId: input.organizationId,
+      encryptedApiToken,
+      tokenHint: `••••${apiToken.slice(-4)}`,
+      zoneId: input.zoneId,
+      zoneLabel: input.zoneLabel?.trim() || null,
+      capabilities,
+      connectedByUserId: input.userId,
+      now: savedAt,
+    });
+    return { connected: true as const, connectionId, capabilities };
+  }
+
+  async function disconnect(projectId: string): Promise<void> {
+    await deps.repository.disconnect(projectId);
+  }
+
+  async function requireConnection(projectId: string): Promise<{
+    connection: CloudflareAnalyticsConnection;
+    apiToken: string;
+    capabilities: CloudflareCapabilities;
+  }> {
+    const connection = await deps.repository.getByProjectId(projectId);
+    if (!connection) {
+      throw new CloudflareAnalyticsError(
+        "not_connected",
+        "Cloudflare Analytics is not connected for this project.",
+      );
+    }
+    if (!(await deps.vault.isConfigured())) {
+      throw new CloudflareAnalyticsError(
+        "encryption_unavailable",
+        "Cloudflare Analytics credential encryption is unavailable.",
+      );
+    }
+    let apiToken: string;
+    try {
+      apiToken = await deps.vault.decrypt(connection.encryptedApiToken);
+    } catch {
+      throw new CloudflareAnalyticsError(
+        "encryption_unavailable",
+        "Cloudflare Analytics credential could not be decrypted; reconnect it.",
+      );
+    }
+    return {
+      connection,
+      apiToken,
+      capabilities: deps.repository.capabilitiesFromConnection(connection),
+    };
+  }
+
+  async function trafficHealth(input: {
+    projectId: string;
+    from: string;
+    to: string;
+  }): Promise<CloudflareTrafficResult> {
+    const window = { from: input.from, to: input.to };
+    try {
+      const connected = await requireConnection(input.projectId);
+      const result = await deps.client.traffic({
+        apiToken: connected.apiToken,
+        zoneId: connected.connection.zoneId,
+        ...window,
+      });
+      return trafficResult({
+        rows: result.data?.viewer.zones[0]?.httpRequestsAdaptiveGroups,
+        errors: result.errors,
+        window,
+        capabilities: connected.capabilities,
+      });
+    } catch (error) {
+      return unavailableResult({
+        status: errorStatus(error),
+        warning: errorWarning(error),
+        window,
+      });
+    }
+  }
+
+  async function securityEvents(input: {
+    projectId: string;
+    from: string;
+    to: string;
+  }): Promise<CloudflareSecurityResult> {
+    const window = { from: input.from, to: input.to };
+    try {
+      const connected = await requireConnection(input.projectId);
+      if (!connected.capabilities.securityEvents.available) {
+        return unavailableResult({
+          status: "unavailable",
+          warning:
+            connected.capabilities.securityEvents.reason ??
+            "security_dataset_unavailable",
+          window,
+        });
+      }
+      const result = await deps.client.securityEvents({
+        apiToken: connected.apiToken,
+        zoneId: connected.connection.zoneId,
+        ...window,
+      });
+      return securityResult({
+        rows: result.data?.viewer.zones[0]?.firewallEventsAdaptiveGroups,
+        errors: result.errors,
+        window,
+        capabilities: connected.capabilities,
+      });
+    } catch (error) {
+      return unavailableResult({
+        status: errorStatus(error),
+        warning: errorWarning(error),
+        window,
+      });
+    }
+  }
+
+  async function crawlerAccess(input: {
+    projectId: string;
+    from: string;
+    to: string;
+  }): Promise<CloudflareCrawlerResult> {
+    const window = { from: input.from, to: input.to };
+    try {
+      const connected = await requireConnection(input.projectId);
+      if (!connected.capabilities.crawlerAccess.available) {
+        return unavailableResult({
+          status: "unavailable",
+          warning:
+            connected.capabilities.crawlerAccess.reason ??
+            "crawler_dataset_unavailable",
+          window,
+        });
+      }
+      const result = await deps.client.crawlerAccess({
+        apiToken: connected.apiToken,
+        zoneId: connected.connection.zoneId,
+        ...window,
+      });
+      return crawlerResult({
+        zone: result.data?.viewer.zones[0],
+        errors: result.errors,
+        window,
+        capabilities: connected.capabilities,
+      });
+    } catch (error) {
+      return unavailableResult({
+        status: errorStatus(error),
+        warning: errorWarning(error),
+        window,
+      });
+    }
+  }
+
+  return {
+    getConnection,
+    connect,
+    disconnect,
+    trafficHealth,
+    securityEvents,
+    crawlerAccess,
+  };
+}
+
+export const CloudflareAnalyticsService = createCloudflareAnalyticsService();

--- a/src/server/features/cloudflare-analytics/CloudflareCredentialVault.test.ts
+++ b/src/server/features/cloudflare-analytics/CloudflareCredentialVault.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+import { CloudflareCredentialVault } from "./CloudflareCredentialVault";
+
+vi.mock("@/lib/auth", () => ({
+  getAuth: () => ({
+    $context: Promise.resolve({
+      secretConfig: "test-secret-at-least-32-characters",
+    }),
+  }),
+}));
+vi.mock("@/server/lib/runtime-env", () => ({
+  getOptionalEnvValue: async () => "x".repeat(32),
+}));
+
+describe("CloudflareCredentialVault", () => {
+  it("requires a valid deployment encryption secret", async () => {
+    await expect(CloudflareCredentialVault.isConfigured()).resolves.toBe(true);
+  });
+
+  it("round-trips a token without retaining plaintext", async () => {
+    const token = "cloudflare-read-only-token-that-must-remain-secret";
+    const encrypted = await CloudflareCredentialVault.encrypt(token);
+
+    expect(encrypted).not.toBe(token);
+    expect(encrypted).not.toContain(token);
+    await expect(CloudflareCredentialVault.decrypt(encrypted)).resolves.toBe(
+      token,
+    );
+  });
+});

--- a/src/server/features/cloudflare-analytics/CloudflareCredentialVault.ts
+++ b/src/server/features/cloudflare-analytics/CloudflareCredentialVault.ts
@@ -1,0 +1,24 @@
+import { symmetricDecrypt, symmetricEncrypt } from "better-auth/crypto";
+import { getAuth } from "@/lib/auth";
+import { getOptionalEnvValue } from "@/server/lib/runtime-env";
+import { MIN_BETTER_AUTH_SECRET_LENGTH } from "@/shared/selfhost-checks";
+
+async function isConfigured(): Promise<boolean> {
+  const secret = (await getOptionalEnvValue("BETTER_AUTH_SECRET"))?.trim();
+  return Boolean(secret && secret.length >= MIN_BETTER_AUTH_SECRET_LENGTH);
+}
+
+async function encrypt(apiToken: string): Promise<string> {
+  const context = await getAuth().$context;
+  return symmetricEncrypt({ key: context.secretConfig, data: apiToken });
+}
+
+async function decrypt(encryptedApiToken: string): Promise<string> {
+  const context = await getAuth().$context;
+  return symmetricDecrypt({
+    key: context.secretConfig,
+    data: encryptedApiToken,
+  });
+}
+
+export const CloudflareCredentialVault = { isConfigured, encrypt, decrypt };

--- a/src/server/features/cloudflare-analytics/pathPrivacy.test.ts
+++ b/src/server/features/cloudflare-analytics/pathPrivacy.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { privacySafePath } from "./pathPrivacy";
+
+describe("privacySafePath", () => {
+  it.each([
+    [undefined, "/"],
+    ["login", "/login"],
+    ["/login?email=private@example.com", "/login"],
+    ["/reset/alice@example.com", "/reset/:redacted"],
+    ["/reset/bob%2540example.com", "/reset/:redacted"],
+    ["/tax/AR-CUIT-20-12345678-3", "/tax/:redacted"],
+    ["/documents/550e8400-e29b-41d4-a716-446655440000", "/documents/:redacted"],
+    ["/vehicles/AA123AA", "/vehicles/:redacted"],
+    ["/sessions/aB3dE5fG7hI9jK1mN3pQ5rS7tV9x", "/sessions/:redacted"],
+    ["/blog/normal-seo-page", "/blog/normal-seo-page"],
+    ["/safe/\u0001slug", "/safe/slug"],
+  ])("maps %s to a privacy-safe route shape", (input, expected) => {
+    expect(privacySafePath(input)).toBe(expected);
+  });
+
+  it("redacts overlong segments rather than truncating identifiers", () => {
+    expect(privacySafePath(`/download/${"a".repeat(129)}`)).toBe(
+      "/download/:redacted",
+    );
+  });
+});

--- a/src/server/features/cloudflare-analytics/pathPrivacy.ts
+++ b/src/server/features/cloudflare-analytics/pathPrivacy.ts
@@ -1,0 +1,101 @@
+const REDACTED_PATH_SEGMENT = ":redacted";
+const MAX_PUBLIC_PATH_SEGMENT_LENGTH = 128;
+const SENSITIVE_PATH_PARENTS = new Set([
+  "account",
+  "accounts",
+  "auth",
+  "checkout",
+  "customer",
+  "customers",
+  "email",
+  "emails",
+  "invite",
+  "invites",
+  "order",
+  "orders",
+  "password",
+  "payment",
+  "payments",
+  "profile",
+  "reset",
+  "session",
+  "sessions",
+  "token",
+  "tokens",
+  "user",
+  "users",
+  "vehicle",
+  "vehicles",
+  "verification",
+  "verify",
+]);
+const EMAIL_IN_SEGMENT = /[^\s/@]+@[^\s/@]+\.[^\s/@]+/i;
+const UUID_IN_SEGMENT =
+  /(?:^|[^0-9a-f])[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(?=$|[^0-9a-f])/i;
+const JWT_SEGMENT = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
+const LONG_NUMBER_SEGMENT = /^\d{7,18}$/;
+const TAX_ID_IN_SEGMENT = /(?:^|\D)\d{2}[-.]?\d{8}[-.]?\d(?=$|\D)/;
+const VEHICLE_REGISTRATION_SEGMENT =
+  /^(?:[A-Z]{2}\d{3}[A-Z]{2}|[A-Z]{3}\d{3})$/i;
+const LONG_HEX_SEGMENT = /^[0-9a-f]{24,}$/i;
+const OPAQUE_TOKEN_SEGMENT =
+  /^(?=.{24,}$)(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[A-Za-z0-9_-]+={0,2}$/;
+
+function decodedPathSegment(segment: string): string {
+  let decoded = segment;
+  for (let pass = 0; pass < 3; pass += 1) {
+    try {
+      const next = decodeURIComponent(decoded);
+      if (next === decoded) break;
+      decoded = next;
+    } catch {
+      break;
+    }
+  }
+  return decoded;
+}
+
+function isSensitivePathSegment(segment: string, parent: string): boolean {
+  const decoded = decodedPathSegment(segment);
+  const decodedParent = decodedPathSegment(parent).toLowerCase();
+  if (SENSITIVE_PATH_PARENTS.has(decodedParent)) return true;
+  if (decoded.length > MAX_PUBLIC_PATH_SEGMENT_LENGTH) return true;
+  return (
+    EMAIL_IN_SEGMENT.test(decoded) ||
+    UUID_IN_SEGMENT.test(decoded) ||
+    JWT_SEGMENT.test(decoded) ||
+    LONG_NUMBER_SEGMENT.test(decoded) ||
+    TAX_ID_IN_SEGMENT.test(decoded) ||
+    VEHICLE_REGISTRATION_SEGMENT.test(decoded) ||
+    LONG_HEX_SEGMENT.test(decoded) ||
+    OPAQUE_TOKEN_SEGMENT.test(decoded)
+  );
+}
+
+function stripControlCharacters(segment: string): string {
+  let safe = "";
+  for (const character of segment) {
+    const code = character.charCodeAt(0);
+    if (code > 31 && code !== 127) safe += character;
+  }
+  return safe;
+}
+
+/**
+ * Keep useful route shape while ensuring attacker-controlled identifiers do
+ * not enter MCP output, model transcripts, or downstream telemetry.
+ */
+export function privacySafePath(raw: string | undefined): string {
+  const value = (raw?.trim() || "/").split(/[?#]/, 1)[0] || "/";
+  const path = value.startsWith("/") ? value : `/${value}`;
+  const segments = path.split("/");
+  return segments
+    .map((segment, index) => {
+      if (!segment) return segment;
+      const parent = segments[index - 1] ?? "";
+      return isSensitivePathSegment(segment, parent)
+        ? REDACTED_PATH_SEGMENT
+        : stripControlCharacters(segment);
+    })
+    .join("/");
+}

--- a/src/server/features/cloudflare-analytics/results.test.ts
+++ b/src/server/features/cloudflare-analytics/results.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { crawlerResult, securityResult } from "./results";
+
+const capabilities = {
+  traffic: { available: true, reason: null },
+  securityEvents: { available: true, reason: null },
+  crawlerAccess: { available: true, reason: null },
+};
+const window = {
+  from: "2026-09-03T12:00:00.000Z",
+  to: "2026-09-04T12:00:00.000Z",
+};
+
+describe("Cloudflare Analytics privacy-safe aggregation", () => {
+  it("coalesces security rows after identifiers are redacted", () => {
+    const result = securityResult({
+      rows: [
+        {
+          count: 2,
+          dimensions: {
+            action: "block",
+            clientRequestHTTPHost: "Example.COM",
+            clientRequestPath: "/reset/alice@example.com",
+          },
+        },
+        {
+          count: 3,
+          dimensions: {
+            action: "block",
+            clientRequestHTTPHost: "Example.COM",
+            clientRequestPath: "/reset/bob@example.com",
+          },
+        },
+      ],
+      errors: [],
+      window,
+      capabilities,
+    });
+
+    expect(result.data?.events).toEqual([
+      {
+        action: "block",
+        source: null,
+        ruleId: null,
+        host: "example.com",
+        pathname: "/reset/:redacted",
+        count: 5,
+      },
+    ]);
+    expect(JSON.stringify(result)).not.toMatch(/alice|bob/);
+  });
+
+  it("coalesces crawler rows after identifiers are redacted", () => {
+    const result = crawlerResult({
+      zone: {
+        googlebot: [
+          {
+            count: 2,
+            dimensions: {
+              clientRequestHTTPHost: "example.com",
+              clientRequestPath: "/users/12345678",
+              edgeResponseStatus: 403,
+            },
+          },
+          {
+            count: 3,
+            dimensions: {
+              clientRequestHTTPHost: "example.com",
+              clientRequestPath: "/users/87654321",
+              edgeResponseStatus: 403,
+            },
+          },
+        ],
+        bingbot: [],
+      },
+      errors: [],
+      window,
+      capabilities,
+    });
+
+    expect(result.data?.crawlers[0]?.pages).toEqual([
+      {
+        host: "example.com",
+        pathname: "/users/:redacted",
+        status: 403,
+        requests: 5,
+      },
+    ]);
+    expect(JSON.stringify(result)).not.toMatch(/12345678|87654321/);
+  });
+});

--- a/src/server/features/cloudflare-analytics/results.ts
+++ b/src/server/features/cloudflare-analytics/results.ts
@@ -1,0 +1,340 @@
+import type {
+  CloudflareCapabilities,
+  CloudflareCrawlerResult,
+  CloudflareSecurityResult,
+  CloudflareTrafficResult,
+} from "./schemas";
+import { sortBy } from "remeda";
+
+const CLOUDFLARE_QUERY_ROW_LIMIT = 500;
+
+type Window = { from: string; to: string };
+type Status = CloudflareTrafficResult["status"];
+
+export function boundedErrors(errors: readonly string[]): string[] {
+  return errors.slice(0, 5).map((message) => message.slice(0, 300));
+}
+
+function resultMeta(input: {
+  status: Status;
+  window: Window | null;
+  warnings?: string[];
+  sampled?: boolean;
+  truncated?: boolean;
+}) {
+  return {
+    source: "cloudflare_analytics" as const,
+    status: input.status,
+    window: input.window
+      ? {
+          ...input.window,
+          timezone: "UTC" as const,
+          granularity: "hour" as const,
+        }
+      : null,
+    coverage: {
+      sampled: input.sampled ?? false,
+      truncated: input.truncated ?? false,
+    },
+    warnings: input.warnings ?? [],
+  };
+}
+
+function queryStatus(errors: readonly string[], truncated: boolean): Status {
+  return errors.length > 0 || truncated ? "partial" : "ok";
+}
+
+function emptyStatus(errors: readonly string[]): Status {
+  return errors.length > 0 ? "unavailable" : "no_data";
+}
+
+function sampled(
+  errors: readonly string[],
+  intervals: readonly (number | undefined)[],
+) {
+  return (
+    intervals.some((interval) => interval !== undefined && interval > 1) ||
+    errors.some((message) => /sampl/i.test(message))
+  );
+}
+
+function normalizeHost(raw: string | undefined): string | null {
+  const value = raw?.trim().toLowerCase().replace(/\.$/, "") ?? "";
+  return value.length > 0 ? value : null;
+}
+
+function normalizePath(raw: string | undefined): string {
+  const value = (raw?.trim() || "/").split(/[?#]/, 1)[0] || "/";
+  return value.startsWith("/") ? value : `/${value}`;
+}
+
+export function trafficResult(input: {
+  rows:
+    | Array<{
+        count: number;
+        dimensions: { edgeResponseStatus?: number };
+        sum?: { edgeResponseBytes?: number; visits?: number };
+        avg?: { sampleInterval?: number };
+      }>
+    | undefined;
+  errors: string[];
+  window: Window;
+  capabilities: CloudflareCapabilities;
+}): CloudflareTrafficResult {
+  if (!input.rows) {
+    return {
+      ...resultMeta({
+        status: "unavailable",
+        window: input.window,
+        warnings: [
+          "traffic_dataset_unavailable",
+          ...boundedErrors(input.errors),
+        ],
+      }),
+      data: null,
+    };
+  }
+  if (input.rows.length === 0) {
+    return {
+      ...resultMeta({
+        status: emptyStatus(input.errors),
+        window: input.window,
+        warnings: boundedErrors(input.errors),
+      }),
+      data: null,
+    };
+  }
+
+  const byStatus = new Map<number, number>();
+  let requests = 0;
+  let responseBytes = 0;
+  let visits = 0;
+  let visitsAvailable = false;
+  for (const row of input.rows) {
+    requests += row.count;
+    responseBytes += row.sum?.edgeResponseBytes ?? 0;
+    if (row.sum?.visits !== undefined) {
+      visits += row.sum.visits;
+      visitsAvailable = true;
+    }
+    const status = Math.trunc(row.dimensions.edgeResponseStatus ?? 0);
+    byStatus.set(status, (byStatus.get(status) ?? 0) + row.count);
+  }
+  const statuses = sortBy(
+    [...byStatus.entries()].map(([status, count]) => ({
+      status,
+      requests: count,
+    })),
+    (item) => item.status,
+  );
+  const truncated = input.rows.length >= CLOUDFLARE_QUERY_ROW_LIMIT;
+  return {
+    ...resultMeta({
+      status: queryStatus(input.errors, truncated),
+      window: input.window,
+      sampled: sampled(
+        input.errors,
+        input.rows.map((row) => row.avg?.sampleInterval),
+      ),
+      truncated,
+      warnings: [
+        ...boundedErrors(input.errors),
+        ...(truncated ? ["provider_row_limit_reached"] : []),
+      ],
+    }),
+    data: {
+      requests,
+      responseBytes,
+      visits: visitsAvailable ? visits : null,
+      statuses,
+      errors4xx: statuses
+        .filter(({ status }) => status >= 400 && status < 500)
+        .reduce((sum, item) => sum + item.requests, 0),
+      errors5xx: statuses
+        .filter(({ status }) => status >= 500 && status < 600)
+        .reduce((sum, item) => sum + item.requests, 0),
+      capabilities: input.capabilities,
+    },
+  };
+}
+
+export function securityResult(input: {
+  rows:
+    | Array<{
+        count: number;
+        dimensions: {
+          action?: string;
+          source?: string;
+          ruleId?: string;
+          clientRequestHTTPHost?: string;
+          clientRequestPath?: string;
+        };
+        avg?: { sampleInterval?: number };
+      }>
+    | undefined;
+  errors: string[];
+  window: Window;
+  capabilities: CloudflareCapabilities;
+}): CloudflareSecurityResult {
+  if (!input.rows) {
+    return {
+      ...resultMeta({
+        status: "unavailable",
+        window: input.window,
+        warnings: [
+          "security_dataset_unavailable",
+          ...boundedErrors(input.errors),
+        ],
+      }),
+      data: null,
+    };
+  }
+  if (input.rows.length === 0) {
+    return {
+      ...resultMeta({
+        status: emptyStatus(input.errors),
+        window: input.window,
+        warnings: boundedErrors(input.errors),
+      }),
+      data: null,
+    };
+  }
+  const events = input.rows.map((row) => ({
+    action: row.dimensions.action ?? "unknown",
+    source: row.dimensions.source ?? null,
+    ruleId: row.dimensions.ruleId ?? null,
+    host: normalizeHost(row.dimensions.clientRequestHTTPHost),
+    pathname: normalizePath(row.dimensions.clientRequestPath),
+    count: row.count,
+  }));
+  const truncated = input.rows.length >= CLOUDFLARE_QUERY_ROW_LIMIT;
+  return {
+    ...resultMeta({
+      status: queryStatus(input.errors, truncated),
+      window: input.window,
+      sampled: sampled(
+        input.errors,
+        input.rows.map((row) => row.avg?.sampleInterval),
+      ),
+      truncated,
+      warnings: [
+        ...boundedErrors(input.errors),
+        ...(truncated ? ["provider_row_limit_reached"] : []),
+      ],
+    }),
+    data: {
+      totalEvents: events.reduce((sum, event) => sum + event.count, 0),
+      events,
+      capabilities: input.capabilities,
+    },
+  };
+}
+
+type CrawlerRow = {
+  count: number;
+  dimensions: {
+    clientRequestHTTPHost?: string;
+    clientRequestPath?: string;
+    edgeResponseStatus?: number;
+  };
+  avg?: { sampleInterval?: number };
+};
+
+function crawlerSummary(crawler: "googlebot" | "bingbot", rows: CrawlerRow[]) {
+  const pages = rows.flatMap((row) => {
+    const host = normalizeHost(row.dimensions.clientRequestHTTPHost);
+    if (!host) return [];
+    return [
+      {
+        host,
+        pathname: normalizePath(row.dimensions.clientRequestPath),
+        status: Math.trunc(row.dimensions.edgeResponseStatus ?? 0),
+        requests: row.count,
+      },
+    ];
+  });
+  const sum = (predicate: (status: number) => boolean) =>
+    pages
+      .filter((page) => predicate(page.status))
+      .reduce((total, page) => total + page.requests, 0);
+  return {
+    crawler,
+    requests: pages.reduce((total, page) => total + page.requests, 0),
+    successful: sum((status) => status >= 200 && status < 400),
+    blocked: sum((status) => status === 401 || status === 403),
+    serverErrors: sum((status) => status >= 500),
+    pages,
+  };
+}
+
+export function crawlerResult(input: {
+  zone: { googlebot: CrawlerRow[]; bingbot: CrawlerRow[] } | undefined;
+  errors: string[];
+  window: Window;
+  capabilities: CloudflareCapabilities;
+}): CloudflareCrawlerResult {
+  if (!input.zone) {
+    return {
+      ...resultMeta({
+        status: "unavailable",
+        window: input.window,
+        warnings: [
+          "crawler_dataset_unavailable",
+          ...boundedErrors(input.errors),
+        ],
+      }),
+      data: null,
+    };
+  }
+  const rows = [...input.zone.googlebot, ...input.zone.bingbot];
+  if (rows.length === 0) {
+    return {
+      ...resultMeta({
+        status: emptyStatus(input.errors),
+        window: input.window,
+        warnings: boundedErrors(input.errors),
+      }),
+      data: null,
+    };
+  }
+  const truncated =
+    input.zone.googlebot.length >= CLOUDFLARE_QUERY_ROW_LIMIT ||
+    input.zone.bingbot.length >= CLOUDFLARE_QUERY_ROW_LIMIT;
+  return {
+    ...resultMeta({
+      status: queryStatus(input.errors, truncated),
+      window: input.window,
+      sampled: sampled(
+        input.errors,
+        rows.map((row) => row.avg?.sampleInterval),
+      ),
+      truncated,
+      warnings: [
+        ...boundedErrors(input.errors),
+        ...(truncated ? ["provider_row_limit_reached"] : []),
+      ],
+    }),
+    data: {
+      crawlers: [
+        crawlerSummary("googlebot", input.zone.googlebot),
+        crawlerSummary("bingbot", input.zone.bingbot),
+      ],
+      capabilities: input.capabilities,
+    },
+  };
+}
+
+export function unavailableResult(input: {
+  status: Status;
+  warning: string;
+  window: Window;
+}): ReturnType<typeof resultMeta> & { data: null } {
+  return {
+    ...resultMeta({
+      status: input.status,
+      window: input.window,
+      warnings: [input.warning],
+    }),
+    data: null,
+  };
+}

--- a/src/server/features/cloudflare-analytics/results.ts
+++ b/src/server/features/cloudflare-analytics/results.ts
@@ -5,6 +5,7 @@ import type {
   CloudflareTrafficResult,
 } from "./schemas";
 import { sortBy } from "remeda";
+import { privacySafePath } from "./pathPrivacy";
 
 const CLOUDFLARE_QUERY_ROW_LIMIT = 500;
 
@@ -21,6 +22,7 @@ function resultMeta(input: {
   warnings?: string[];
   sampled?: boolean;
   truncated?: boolean;
+  retryAfterSeconds?: number;
 }) {
   return {
     source: "cloudflare_analytics" as const,
@@ -36,6 +38,7 @@ function resultMeta(input: {
       sampled: input.sampled ?? false,
       truncated: input.truncated ?? false,
     },
+    retryAfterSeconds: input.retryAfterSeconds ?? null,
     warnings: input.warnings ?? [],
   };
 }
@@ -61,11 +64,6 @@ function sampled(
 function normalizeHost(raw: string | undefined): string | null {
   const value = raw?.trim().toLowerCase().replace(/\.$/, "") ?? "";
   return value.length > 0 ? value : null;
-}
-
-function normalizePath(raw: string | undefined): string {
-  const value = (raw?.trim() || "/").split(/[?#]/, 1)[0] || "/";
-  return value.startsWith("/") ? value : `/${value}`;
 }
 
 export function trafficResult(input: {
@@ -199,14 +197,31 @@ export function securityResult(input: {
       data: null,
     };
   }
-  const events = input.rows.map((row) => ({
-    action: row.dimensions.action ?? "unknown",
-    source: row.dimensions.source ?? null,
-    ruleId: row.dimensions.ruleId ?? null,
-    host: normalizeHost(row.dimensions.clientRequestHTTPHost),
-    pathname: normalizePath(row.dimensions.clientRequestPath),
-    count: row.count,
-  }));
+  const eventsByKey = new Map<
+    string,
+    NonNullable<CloudflareSecurityResult["data"]>["events"][number]
+  >();
+  for (const row of input.rows) {
+    const event = {
+      action: row.dimensions.action ?? "unknown",
+      source: row.dimensions.source ?? null,
+      ruleId: row.dimensions.ruleId ?? null,
+      host: normalizeHost(row.dimensions.clientRequestHTTPHost),
+      pathname: privacySafePath(row.dimensions.clientRequestPath),
+      count: row.count,
+    };
+    const key = JSON.stringify([
+      event.action,
+      event.source,
+      event.ruleId,
+      event.host,
+      event.pathname,
+    ]);
+    const existing = eventsByKey.get(key);
+    if (existing) existing.count += event.count;
+    else eventsByKey.set(key, event);
+  }
+  const events = sortBy([...eventsByKey.values()], (event) => -event.count);
   const truncated = input.rows.length >= CLOUDFLARE_QUERY_ROW_LIMIT;
   return {
     ...resultMeta({
@@ -241,18 +256,25 @@ type CrawlerRow = {
 };
 
 function crawlerSummary(crawler: "googlebot" | "bingbot", rows: CrawlerRow[]) {
-  const pages = rows.flatMap((row) => {
+  const pagesByKey = new Map<
+    string,
+    { host: string; pathname: string; status: number; requests: number }
+  >();
+  for (const row of rows) {
     const host = normalizeHost(row.dimensions.clientRequestHTTPHost);
-    if (!host) return [];
-    return [
-      {
-        host,
-        pathname: normalizePath(row.dimensions.clientRequestPath),
-        status: Math.trunc(row.dimensions.edgeResponseStatus ?? 0),
-        requests: row.count,
-      },
-    ];
-  });
+    if (!host) continue;
+    const page = {
+      host,
+      pathname: privacySafePath(row.dimensions.clientRequestPath),
+      status: Math.trunc(row.dimensions.edgeResponseStatus ?? 0),
+      requests: row.count,
+    };
+    const key = JSON.stringify([page.host, page.pathname, page.status]);
+    const existing = pagesByKey.get(key);
+    if (existing) existing.requests += page.requests;
+    else pagesByKey.set(key, page);
+  }
+  const pages = sortBy([...pagesByKey.values()], (page) => -page.requests);
   const sum = (predicate: (status: number) => boolean) =>
     pages
       .filter((page) => predicate(page.status))
@@ -328,11 +350,13 @@ export function unavailableResult(input: {
   status: Status;
   warning: string;
   window: Window;
+  retryAfterSeconds?: number;
 }): ReturnType<typeof resultMeta> & { data: null } {
   return {
     ...resultMeta({
       status: input.status,
       window: input.window,
+      retryAfterSeconds: input.retryAfterSeconds,
       warnings: [input.warning],
     }),
     data: null,

--- a/src/server/features/cloudflare-analytics/schemas.ts
+++ b/src/server/features/cloudflare-analytics/schemas.ts
@@ -1,0 +1,202 @@
+import { z } from "zod";
+
+const finiteNumber = z
+  .union([z.number(), z.string()])
+  .transform((value, ctx) => {
+    const parsed = typeof value === "number" ? value : Number(value);
+    if (!Number.isFinite(parsed)) {
+      ctx.addIssue({ code: "custom", message: "Expected a finite number" });
+      return z.NEVER;
+    }
+    return parsed;
+  });
+
+const cloudflareDatasetCapabilitySchema = z.object({
+  available: z.boolean(),
+  reason: z.string().nullable(),
+});
+
+export const cloudflareCapabilitiesSchema = z.object({
+  traffic: cloudflareDatasetCapabilitySchema,
+  securityEvents: cloudflareDatasetCapabilitySchema,
+  crawlerAccess: cloudflareDatasetCapabilitySchema,
+});
+
+export type CloudflareCapabilities = z.infer<
+  typeof cloudflareCapabilitiesSchema
+>;
+
+const resultStatusSchema = z.enum([
+  "ok",
+  "partial",
+  "no_data",
+  "not_connected",
+  "unavailable",
+  "rate_limited",
+]);
+
+const resultMetaSchema = z.object({
+  source: z.literal("cloudflare_analytics"),
+  status: resultStatusSchema,
+  window: z
+    .object({
+      from: z.string().datetime(),
+      to: z.string().datetime(),
+      timezone: z.literal("UTC"),
+      granularity: z.literal("hour"),
+    })
+    .nullable(),
+  coverage: z.object({
+    sampled: z.boolean(),
+    truncated: z.boolean(),
+  }),
+  warnings: z.array(z.string()),
+});
+
+function cloudflareResultSchema<T extends z.ZodType>(dataSchema: T) {
+  return resultMetaSchema.extend({ data: dataSchema.nullable() });
+}
+
+const dataCapabilities = { capabilities: cloudflareCapabilitiesSchema };
+
+export const cloudflareTrafficResultSchema = cloudflareResultSchema(
+  z.object({
+    requests: z.number().nonnegative(),
+    responseBytes: z.number().nonnegative(),
+    visits: z.number().nonnegative().nullable(),
+    statuses: z.array(
+      z.object({
+        status: z.number().int().nonnegative(),
+        requests: z.number().nonnegative(),
+      }),
+    ),
+    errors4xx: z.number().nonnegative(),
+    errors5xx: z.number().nonnegative(),
+    ...dataCapabilities,
+  }),
+);
+
+export const cloudflareSecurityResultSchema = cloudflareResultSchema(
+  z.object({
+    totalEvents: z.number().nonnegative(),
+    events: z.array(
+      z.object({
+        action: z.string(),
+        source: z.string().nullable(),
+        ruleId: z.string().nullable(),
+        host: z.string().nullable(),
+        pathname: z.string().nullable(),
+        count: z.number().nonnegative(),
+      }),
+    ),
+    ...dataCapabilities,
+  }),
+);
+
+export const cloudflareCrawlerResultSchema = cloudflareResultSchema(
+  z.object({
+    crawlers: z.array(
+      z.object({
+        crawler: z.enum(["googlebot", "bingbot"]),
+        requests: z.number().nonnegative(),
+        successful: z.number().nonnegative(),
+        blocked: z.number().nonnegative(),
+        serverErrors: z.number().nonnegative(),
+        pages: z.array(
+          z.object({
+            host: z.string(),
+            pathname: z.string(),
+            status: z.number().int().nonnegative(),
+            requests: z.number().nonnegative(),
+          }),
+        ),
+      }),
+    ),
+    ...dataCapabilities,
+  }),
+);
+
+const graphqlErrorSchema = z.object({
+  message: z.string(),
+  path: z.array(z.union([z.string(), z.number()])).nullish(),
+  extensions: z.record(z.string(), z.unknown()).optional(),
+});
+
+export const graphqlResponseSchema = z.object({
+  data: z.unknown().optional(),
+  errors: z.array(graphqlErrorSchema).nullish(),
+});
+
+const trafficGroupSchema = z.object({
+  count: finiteNumber,
+  dimensions: z.object({
+    datetimeHour: z.string().optional(),
+    edgeResponseStatus: finiteNumber.optional(),
+  }),
+  sum: z
+    .object({
+      edgeResponseBytes: finiteNumber.optional(),
+      visits: finiteNumber.optional(),
+    })
+    .optional(),
+  avg: z.object({ sampleInterval: finiteNumber.optional() }).optional(),
+});
+
+export const trafficGraphqlDataSchema = z.object({
+  viewer: z.object({
+    zones: z.array(
+      z.object({ httpRequestsAdaptiveGroups: z.array(trafficGroupSchema) }),
+    ),
+  }),
+});
+
+const securityGroupSchema = z.object({
+  count: finiteNumber,
+  avg: z.object({ sampleInterval: finiteNumber.optional() }).optional(),
+  dimensions: z.object({
+    action: z.string().optional(),
+    source: z.string().optional(),
+    ruleId: z.string().optional(),
+    clientRequestHTTPHost: z.string().optional(),
+    clientRequestPath: z.string().optional(),
+  }),
+});
+
+export const securityGraphqlDataSchema = z.object({
+  viewer: z.object({
+    zones: z.array(
+      z.object({ firewallEventsAdaptiveGroups: z.array(securityGroupSchema) }),
+    ),
+  }),
+});
+
+const crawlerGroupSchema = z.object({
+  count: finiteNumber,
+  avg: z.object({ sampleInterval: finiteNumber.optional() }).optional(),
+  dimensions: z.object({
+    clientRequestHTTPHost: z.string().optional(),
+    clientRequestPath: z.string().optional(),
+    edgeResponseStatus: finiteNumber.optional(),
+  }),
+});
+
+export const crawlerGraphqlDataSchema = z.object({
+  viewer: z.object({
+    zones: z.array(
+      z.object({
+        googlebot: z.array(crawlerGroupSchema),
+        bingbot: z.array(crawlerGroupSchema),
+      }),
+    ),
+  }),
+});
+
+export type CloudflareTrafficResult = z.infer<
+  typeof cloudflareTrafficResultSchema
+>;
+export type CloudflareSecurityResult = z.infer<
+  typeof cloudflareSecurityResultSchema
+>;
+export type CloudflareCrawlerResult = z.infer<
+  typeof cloudflareCrawlerResultSchema
+>;

--- a/src/server/features/cloudflare-analytics/schemas.ts
+++ b/src/server/features/cloudflare-analytics/schemas.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { CLOUDFLARE_MAX_RETRY_AFTER_SECONDS } from "./CloudflareAnalyticsError";
 
 const finiteNumber = z
   .union([z.number(), z.string()])
@@ -50,6 +51,12 @@ const resultMetaSchema = z.object({
     sampled: z.boolean(),
     truncated: z.boolean(),
   }),
+  retryAfterSeconds: z
+    .number()
+    .int()
+    .min(0)
+    .max(CLOUDFLARE_MAX_RETRY_AFTER_SECONDS)
+    .nullable(),
   warnings: z.array(z.string()),
 });
 

--- a/src/server/features/sam/samChatTools.ts
+++ b/src/server/features/sam/samChatTools.ts
@@ -64,6 +64,7 @@ import {
 } from "@/server/mcp/tools/cloudflare-analytics-tools";
 import { discoverSiteUrls, readPages, readSite } from "@/server/lib/scrape";
 import openSeoFactSheet from "@/server/features/onboarding/openseo-fact-sheet.md?raw";
+import { CLOUDFLARE_ANALYTICS_TOOL_NAMES } from "@/shared/cloudflare-analytics";
 
 // SAM reads more of a site than the onboarding preview: enough pages to work
 // out what a business does, sells, and positions against on its own.
@@ -404,9 +405,15 @@ export function buildSamMcpTools(
     get_google_analytics_audience_breakdown: adaptObjectTool(
       getGoogleAnalyticsAudienceBreakdownTool,
     ),
-    get_cloudflare_traffic_health: adaptTool(getCloudflareTrafficHealthTool),
-    get_cloudflare_security_events: adaptTool(getCloudflareSecurityEventsTool),
-    get_cloudflare_crawler_access: adaptTool(getCloudflareCrawlerAccessTool),
+    [CLOUDFLARE_ANALYTICS_TOOL_NAMES.trafficHealth]: adaptTool(
+      getCloudflareTrafficHealthTool,
+    ),
+    [CLOUDFLARE_ANALYTICS_TOOL_NAMES.securityEvents]: adaptTool(
+      getCloudflareSecurityEventsTool,
+    ),
+    [CLOUDFLARE_ANALYTICS_TOOL_NAMES.crawlerAccess]: adaptTool(
+      getCloudflareCrawlerAccessTool,
+    ),
     run_site_audit: adaptTool(runSiteAuditTool),
     get_audit_status: waitingAuditStatusTool(adaptTool),
     get_audit_issues: adaptTool(getAuditIssuesTool),

--- a/src/server/features/sam/samChatTools.ts
+++ b/src/server/features/sam/samChatTools.ts
@@ -57,6 +57,11 @@ import {
   inspectUrlsTool,
 } from "@/server/mcp/tools/search-console-tools";
 import { whoamiTool } from "@/server/mcp/tools/whoami";
+import {
+  getCloudflareCrawlerAccessTool,
+  getCloudflareSecurityEventsTool,
+  getCloudflareTrafficHealthTool,
+} from "@/server/mcp/tools/cloudflare-analytics-tools";
 import { discoverSiteUrls, readPages, readSite } from "@/server/lib/scrape";
 import openSeoFactSheet from "@/server/features/onboarding/openseo-fact-sheet.md?raw";
 
@@ -399,6 +404,9 @@ export function buildSamMcpTools(
     get_google_analytics_audience_breakdown: adaptObjectTool(
       getGoogleAnalyticsAudienceBreakdownTool,
     ),
+    get_cloudflare_traffic_health: adaptTool(getCloudflareTrafficHealthTool),
+    get_cloudflare_security_events: adaptTool(getCloudflareSecurityEventsTool),
+    get_cloudflare_crawler_access: adaptTool(getCloudflareCrawlerAccessTool),
     run_site_audit: adaptTool(runSiteAuditTool),
     get_audit_status: waitingAuditStatusTool(adaptTool),
     get_audit_issues: adaptTool(getAuditIssuesTool),

--- a/src/server/mcp/server.ts
+++ b/src/server/mcp/server.ts
@@ -69,6 +69,11 @@ import {
   runSiteAuditTool,
 } from "@/server/mcp/tools/site-audit-tools";
 import { whoamiTool } from "@/server/mcp/tools/whoami";
+import {
+  getCloudflareCrawlerAccessTool,
+  getCloudflareSecurityEventsTool,
+  getCloudflareTrafficHealthTool,
+} from "@/server/mcp/tools/cloudflare-analytics-tools";
 
 type ToolSchema = z.ZodType | z.ZodRawShape;
 
@@ -132,7 +137,7 @@ export function createOpenSeoMcpServer(authProps: McpProps) {
       title: "OpenSEO",
       version: "0.0.12",
       description:
-        "SEO research tools for AI agents: keyword research and metrics, SERP and local SERP results, domain and backlink analysis, rank tracking, and Google Search Console performance.",
+        "SEO research tools for AI agents: keyword research and metrics, SERP and local SERP results, domain and backlink analysis, rank tracking, Google Search Console performance, and Cloudflare edge analytics.",
       websiteUrl: "https://openseo.so",
       icons: [
         {
@@ -199,6 +204,9 @@ export function createOpenSeoMcpServer(authProps: McpProps) {
   register(getGoogleAnalyticsEcommercePerformanceTool);
   register(getGoogleAnalyticsSiteSearchTool);
   register(getGoogleAnalyticsAudienceBreakdownTool);
+  register(getCloudflareTrafficHealthTool);
+  register(getCloudflareSecurityEventsTool);
+  register(getCloudflareCrawlerAccessTool);
   register(runSiteAuditTool);
   register(getAuditStatusTool);
   register(getAuditIssuesTool);

--- a/src/server/mcp/tools/cloudflare-analytics-tools.test.ts
+++ b/src/server/mcp/tools/cloudflare-analytics-tools.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { makeToolContext, textContent } from "./tool-test-support";
+import { getCloudflareTrafficHealthTool } from "./cloudflare-analytics-tools";
+
+const mocks = vi.hoisted(() => ({
+  getProjectForOrganization: vi.fn(),
+  trafficHealth: vi.fn(),
+}));
+
+vi.mock("cloudflare:workers", () => ({ env: {} }));
+vi.mock("@/server/features/projects/services/ProjectService", () => ({
+  ProjectService: {
+    getProjectForOrganization: mocks.getProjectForOrganization,
+  },
+}));
+vi.mock(
+  "@/server/features/cloudflare-analytics/CloudflareAnalyticsService",
+  () => ({
+    CloudflareAnalyticsService: {
+      trafficHealth: mocks.trafficHealth,
+    },
+  }),
+);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.getProjectForOrganization.mockResolvedValue({ id: "project_123" });
+});
+
+describe("Cloudflare Analytics MCP tools", () => {
+  it("preserves bounded rate-limit backoff in text and structured output", async () => {
+    mocks.trafficHealth.mockResolvedValue({
+      source: "cloudflare_analytics",
+      status: "rate_limited",
+      window: {
+        from: "2026-09-03T12:00:00.000Z",
+        to: "2026-09-04T12:00:00.000Z",
+        timezone: "UTC",
+        granularity: "hour",
+      },
+      coverage: { sampled: false, truncated: false },
+      retryAfterSeconds: 42,
+      warnings: ["rate_limited"],
+      data: null,
+    });
+
+    const result = await getCloudflareTrafficHealthTool.handler(
+      {
+        projectId: "project_123",
+        from: "2026-09-03T12:00:00.000Z",
+        to: "2026-09-04T12:00:00.000Z",
+      },
+      makeToolContext(),
+    );
+
+    expect(result.structuredContent).toMatchObject({
+      status: "rate_limited",
+      retryAfterSeconds: 42,
+    });
+    expect(textContent(result)).toContain("Retry after 42 seconds");
+  });
+
+  it("rejects windows over 31 days before calling Cloudflare", async () => {
+    await expect(
+      getCloudflareTrafficHealthTool.handler(
+        {
+          projectId: "project_123",
+          from: "2026-07-01T00:00:00.000Z",
+          to: "2026-09-04T00:00:00.000Z",
+        },
+        makeToolContext(),
+      ),
+    ).rejects.toThrow("cannot exceed 31 days");
+    expect(mocks.trafficHealth).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/mcp/tools/cloudflare-analytics-tools.ts
+++ b/src/server/mcp/tools/cloudflare-analytics-tools.ts
@@ -1,0 +1,176 @@
+import { z } from "zod";
+import { CloudflareAnalyticsService } from "@/server/features/cloudflare-analytics/CloudflareAnalyticsService";
+import {
+  cloudflareCrawlerResultSchema,
+  cloudflareSecurityResultSchema,
+  cloudflareTrafficResultSchema,
+} from "@/server/features/cloudflare-analytics/schemas";
+import { buildProjectMeta } from "@/server/mcp/context";
+import { mcpResponse } from "@/server/mcp/formatters";
+import { withMcpProjectAuth } from "@/server/mcp/project-auth";
+import { projectIdSchema } from "@/server/mcp/schemas";
+
+const DAY_MS = 24 * 60 * 60 * 1_000;
+const MCP_MAX_ROWS = 100;
+
+const inputSchema = {
+  projectId: projectIdSchema,
+  from: z
+    .string()
+    .datetime()
+    .optional()
+    .describe("UTC interval start. Defaults to 24 hours before `to`."),
+  to: z
+    .string()
+    .datetime()
+    .optional()
+    .describe("UTC interval end. Defaults to now."),
+} as const;
+
+type CloudflareArgs = z.infer<z.ZodObject<typeof inputSchema>>;
+
+function resolveWindow(input: { from?: string; to?: string }) {
+  const to = input.to ? new Date(input.to) : new Date();
+  const from = input.from
+    ? new Date(input.from)
+    : new Date(to.getTime() - DAY_MS);
+  if (from >= to) throw new RangeError("from must precede to");
+  if (to.getTime() - from.getTime() > 31 * DAY_MS) {
+    throw new RangeError("Cloudflare Analytics window cannot exceed 31 days");
+  }
+  return { from: from.toISOString(), to: to.toISOString() };
+}
+
+function summary(
+  label: string,
+  result: { status: string; warnings: string[] },
+) {
+  const warnings =
+    result.warnings.length > 0
+      ? ` Warnings: ${result.warnings.join(", ")}.`
+      : "";
+  return `${label}: ${result.status}.${warnings}`;
+}
+
+const annotations = {
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+  openWorldHint: true,
+} as const;
+
+const settingsPath = (projectId: string) =>
+  `/p/${projectId}/settings/integrations#cloudflare-analytics`;
+
+export const getCloudflareTrafficHealthTool = {
+  name: "get_cloudflare_traffic_health",
+  config: {
+    title: "Get Cloudflare traffic health",
+    description:
+      "Read aggregate requests, status codes, 4xx/5xx counts, bytes, sampling, truncation, and dataset capabilities for the project's selected Cloudflare zone. Read-only and uses no OpenSEO credits.",
+    inputSchema,
+    outputSchema: cloudflareTrafficResultSchema,
+    annotations,
+  },
+  handler: withMcpProjectAuth(async (args: CloudflareArgs, context) => {
+    const result = await CloudflareAnalyticsService.trafficHealth({
+      projectId: args.projectId,
+      ...resolveWindow(args),
+    });
+    return mcpResponse({
+      text: summary("Cloudflare traffic health", result),
+      meta: buildProjectMeta(
+        context,
+        args.projectId,
+        settingsPath(args.projectId),
+      ),
+      structuredContent: result,
+    });
+  }),
+};
+
+export const getCloudflareSecurityEventsTool = {
+  name: "get_cloudflare_security_events",
+  config: {
+    title: "Get Cloudflare security events",
+    description:
+      "Read aggregate Cloudflare security actions and canonical paths without IP addresses, query strings, or full User-Agent values. Read-only and uses no OpenSEO credits.",
+    inputSchema,
+    outputSchema: cloudflareSecurityResultSchema,
+    annotations,
+  },
+  handler: withMcpProjectAuth(async (args: CloudflareArgs, context) => {
+    let result = await CloudflareAnalyticsService.securityEvents({
+      projectId: args.projectId,
+      ...resolveWindow(args),
+    });
+    if (result.data && result.data.events.length > MCP_MAX_ROWS) {
+      result = {
+        ...result,
+        status: "partial",
+        coverage: { ...result.coverage, truncated: true },
+        warnings: [...result.warnings, "mcp_rows_truncated"],
+        data: {
+          ...result.data,
+          events: result.data.events.slice(0, MCP_MAX_ROWS),
+        },
+      };
+    }
+    return mcpResponse({
+      text: summary("Cloudflare security events", result),
+      meta: buildProjectMeta(
+        context,
+        args.projectId,
+        settingsPath(args.projectId),
+      ),
+      structuredContent: result,
+    });
+  }),
+};
+
+export const getCloudflareCrawlerAccessTool = {
+  name: "get_cloudflare_crawler_access",
+  config: {
+    title: "Get Cloudflare crawler access",
+    description:
+      "Compare aggregate Googlebot and Bingbot status codes and paths using Cloudflare-verified bot detection IDs. If Bot Management does not expose the dataset, the capability is unavailable; User-Agent matching is never used. Read-only and uses no OpenSEO credits.",
+    inputSchema,
+    outputSchema: cloudflareCrawlerResultSchema,
+    annotations,
+  },
+  handler: withMcpProjectAuth(async (args: CloudflareArgs, context) => {
+    let result = await CloudflareAnalyticsService.crawlerAccess({
+      projectId: args.projectId,
+      ...resolveWindow(args),
+    });
+    if (result.data) {
+      const truncated = result.data.crawlers.some(
+        (crawler) => crawler.pages.length > MCP_MAX_ROWS,
+      );
+      if (truncated) {
+        result = {
+          ...result,
+          status: "partial",
+          coverage: { ...result.coverage, truncated: true },
+          warnings: [...result.warnings, "mcp_rows_truncated"],
+          data: {
+            ...result.data,
+            crawlers: result.data.crawlers.map((crawler) => ({
+              ...crawler,
+              pages: crawler.pages.slice(0, MCP_MAX_ROWS),
+            })),
+          },
+        };
+      }
+    }
+    return mcpResponse({
+      text: summary("Cloudflare crawler access", result),
+      meta: buildProjectMeta(
+        context,
+        args.projectId,
+        settingsPath(args.projectId),
+      ),
+      structuredContent: result,
+    });
+  }),
+};

--- a/src/server/mcp/tools/cloudflare-analytics-tools.ts
+++ b/src/server/mcp/tools/cloudflare-analytics-tools.ts
@@ -9,6 +9,7 @@ import { buildProjectMeta } from "@/server/mcp/context";
 import { mcpResponse } from "@/server/mcp/formatters";
 import { withMcpProjectAuth } from "@/server/mcp/project-auth";
 import { projectIdSchema } from "@/server/mcp/schemas";
+import { CLOUDFLARE_ANALYTICS_TOOL_NAMES } from "@/shared/cloudflare-analytics";
 
 const DAY_MS = 24 * 60 * 60 * 1_000;
 const MCP_MAX_ROWS = 100;
@@ -43,13 +44,21 @@ function resolveWindow(input: { from?: string; to?: string }) {
 
 function summary(
   label: string,
-  result: { status: string; warnings: string[] },
+  result: {
+    status: string;
+    warnings: string[];
+    retryAfterSeconds: number | null;
+  },
 ) {
   const warnings =
     result.warnings.length > 0
       ? ` Warnings: ${result.warnings.join(", ")}.`
       : "";
-  return `${label}: ${result.status}.${warnings}`;
+  const retry =
+    result.retryAfterSeconds === null
+      ? ""
+      : ` Retry after ${result.retryAfterSeconds} seconds.`;
+  return `${label}: ${result.status}.${retry}${warnings}`;
 }
 
 const annotations = {
@@ -63,7 +72,7 @@ const settingsPath = (projectId: string) =>
   `/p/${projectId}/settings/integrations#cloudflare-analytics`;
 
 export const getCloudflareTrafficHealthTool = {
-  name: "get_cloudflare_traffic_health",
+  name: CLOUDFLARE_ANALYTICS_TOOL_NAMES.trafficHealth,
   config: {
     title: "Get Cloudflare traffic health",
     description:
@@ -90,7 +99,7 @@ export const getCloudflareTrafficHealthTool = {
 };
 
 export const getCloudflareSecurityEventsTool = {
-  name: "get_cloudflare_security_events",
+  name: CLOUDFLARE_ANALYTICS_TOOL_NAMES.securityEvents,
   config: {
     title: "Get Cloudflare security events",
     description:
@@ -129,7 +138,7 @@ export const getCloudflareSecurityEventsTool = {
 };
 
 export const getCloudflareCrawlerAccessTool = {
-  name: "get_cloudflare_crawler_access",
+  name: CLOUDFLARE_ANALYTICS_TOOL_NAMES.crawlerAccess,
   config: {
     title: "Get Cloudflare crawler access",
     description:

--- a/src/serverFunctions/cloudflare-analytics.ts
+++ b/src/serverFunctions/cloudflare-analytics.ts
@@ -1,0 +1,90 @@
+import { createServerFn } from "@tanstack/react-start";
+import { waitUntil } from "cloudflare:workers";
+import { z } from "zod";
+import { requireOrgPermission } from "@/server/auth/org-gate";
+import { CloudflareAnalyticsError } from "@/server/features/cloudflare-analytics/CloudflareAnalyticsError";
+import { CloudflareAnalyticsService } from "@/server/features/cloudflare-analytics/CloudflareAnalyticsService";
+import { AppError } from "@/server/lib/errors";
+import { captureServerEvent } from "@/server/lib/posthog";
+import { requireProjectContext } from "@/serverFunctions/middleware";
+
+const projectSchema = z.object({ projectId: z.string().min(1) });
+const connectSchema = projectSchema.extend({
+  apiToken: z.string().trim().min(20).max(4_096),
+  zoneId: z
+    .string()
+    .trim()
+    .regex(/^[a-f0-9]{32}$/i, "Expected a 32-character Cloudflare zone ID"),
+  zoneLabel: z.string().trim().min(1).max(255).optional(),
+});
+
+function translateConnectError(error: unknown): never {
+  if (!(error instanceof CloudflareAnalyticsError)) throw error;
+  if (error.code === "encryption_unavailable") {
+    throw new AppError("AUTH_CONFIG_MISSING", error.message);
+  }
+  if (error.code === "rate_limited") throw new AppError("RATE_LIMITED");
+  if (
+    error.code === "authentication_failed" ||
+    error.code === "zone_not_accessible" ||
+    error.code === "dataset_unavailable" ||
+    error.code === "invalid_response"
+  ) {
+    throw new AppError("VALIDATION_ERROR");
+  }
+  throw new AppError("UPSTREAM_UNAVAILABLE");
+}
+
+export const getCloudflareAnalyticsConnection = createServerFn({
+  method: "POST",
+})
+  .middleware(requireProjectContext)
+  .validator(projectSchema)
+  .handler(({ context }) =>
+    CloudflareAnalyticsService.getConnection(context.projectId),
+  );
+
+export const connectCloudflareAnalytics = createServerFn({ method: "POST" })
+  .middleware(requireProjectContext)
+  .validator(connectSchema)
+  .handler(async ({ data, context }) => {
+    requireOrgPermission(context, { integration: ["manage"] });
+    try {
+      const result = await CloudflareAnalyticsService.connect({
+        projectId: context.projectId,
+        organizationId: context.organizationId,
+        userId: context.userId,
+        apiToken: data.apiToken,
+        zoneId: data.zoneId,
+        zoneLabel: data.zoneLabel,
+      });
+      waitUntil(
+        captureServerEvent({
+          distinctId: context.userId,
+          event: "cloudflare-analytics:connect",
+          organizationId: context.organizationId,
+          properties: { project_id: context.projectId },
+        }),
+      );
+      return result;
+    } catch (error) {
+      return translateConnectError(error);
+    }
+  });
+
+export const disconnectCloudflareAnalytics = createServerFn({ method: "POST" })
+  .middleware(requireProjectContext)
+  .validator(projectSchema)
+  .handler(async ({ context }) => {
+    requireOrgPermission(context, { integration: ["manage"] });
+    await CloudflareAnalyticsService.disconnect(context.projectId);
+    waitUntil(
+      captureServerEvent({
+        distinctId: context.userId,
+        event: "cloudflare-analytics:disconnect",
+        organizationId: context.organizationId,
+        properties: { project_id: context.projectId },
+      }),
+    );
+    return { connected: false as const };
+  });

--- a/src/shared/cloudflare-analytics.ts
+++ b/src/shared/cloudflare-analytics.ts
@@ -1,0 +1,11 @@
+export const CLOUDFLARE_ANALYTICS_TOOL_NAMES = {
+  trafficHealth: "get_cloudflare_traffic_health",
+  securityEvents: "get_cloudflare_security_events",
+  crawlerAccess: "get_cloudflare_crawler_access",
+} as const;
+
+export const CLOUDFLARE_ANALYTICS_TOOL_NAME_LIST = Object.values(
+  CLOUDFLARE_ANALYTICS_TOOL_NAMES,
+);
+
+export const CLOUDFLARE_TRANSIENT_CAPABILITY_PREFIX = "transient:";


### PR DESCRIPTION
# Cloudflare Analytics read-only POC

Related to every-app/open-seo#282.

## What this demonstrates

- A per-project Cloudflare connection for exactly one zone.
- Validate-before-write and token encryption using the existing Better Auth secret.
- Independent capability detection for traffic, security events, and verified crawler access.
- Three read-only MCP/SAM tools: `get_cloudflare_traffic_health`, `get_cloudflare_security_events`, and `get_cloudflare_crawler_access`.
- A matching visible tool catalog plus a minimal Settings card for connect, capability status, credential replacement, and disconnect.
- D1/Postgres schema parity and migrations through the standard upstream lanes.

## Security and data handling

- The token is accepted only by an authorized `integration:manage` server mutation, is never returned to the client, and is stored encrypted with only a four-character hint exposed.
- Queries do not request IP addresses, query strings, or full User-Agent values.
- Paths are normalized before any MCP/SAM output. Query strings and fragments are removed, common identifier-shaped segments (including encoded email addresses, UUIDs, long numeric identifiers, tax/vehicle identifiers, opaque tokens, and values below sensitive route parents) are replaced with `:redacted`, and rows that collapse to the same safe route are re-aggregated.
- Googlebot/Bingbot use Cloudflare verified bot detection IDs; plans without the required dataset receive an explicit unavailable capability.
- Deterministic plan/permission failures remain unavailable, while HTTP 200 field errors, throttling, upstream failures, malformed probe responses, and network failures are marked transient and retried when that dataset is requested.
- Provider responses have a 15-second timeout and a 1 MB body limit. HTTP 200 GraphQL errors, dataset-specific HTTP 400 errors, auth failures, throttling, and 5xx responses remain distinguishable.
- `Retry-After` is clamped to 24 hours and propagated through the common result schema and MCP human/structured output.
- A 500-row provider boundary is reported as partial/truncated, and `avg.sampleInterval > 1` is reported as sampled.
- Shared Cloudflare tool IDs keep MCP definitions, SAM registrations, and the visible catalog in parity.

## Verification

- `pnpm ci:check` passed (Prettier, Knip, TypeScript, type-aware Oxlint, and generated skill sync).
- `pnpm test:ci`: 145 files and 1,214 tests passed.
- Focused Cloudflare/client/service/vault/privacy/MCP/catalog/schema/SAM suite: 9 files and 230 tests passed.
- `git diff --check` passed, and the changed-file scan found no downstream branding, private-key markers, or live-token patterns.

## Intentionally out of scope

- Cloudflare Worker Analytics/account-level worker allowlists.
- Site Signals correlation, R2 caching, downstream branding, commercial metrics, or release automation.
- OAuth or automatic zone discovery; this POC uses a manually created least-privilege token and explicit zone ID.
- Deployment or changes to a live Cloudflare account.

Built from stable commit `ac9ee482d2b4cd8f472065d6f9b57db35cec560e` as an implementation reference for the accompanying issue. Per the current contribution policy, this is a POC rather than an expectation that the PR be merged as-is.

AI assistance disclosure: this proof of concept was implemented and tested with Codex, then independently reviewed and hardened against the stated security, privacy, retry, and data-handling boundaries before publication.