### PR TITLE
POC: add privacy-safe first-party aggregate signals

### DIFF
--- a/alchemy.run.ts
+++ b/alchemy.run.ts
@@ -484,8 +484,11 @@ export default Alchemy.Stack(
         // guard catches random UUID sprays before body/D1/crypto work; a second
         // opaque claimed-source guard catches repeated claims without using or
         // retaining IP addresses. The authenticated limiter remains the final,
-        // stricter per-source guard after HMAC verification.
+        // stricter per-source guard after HMAC verification. Rate-limit
+        // namespace counters can be shared across Workers, so every key is
+        // scoped by the trusted, stage-specific Worker name.
         FIRST_PARTY_INGEST_EDGE_LIMITS_REQUIRED: "true",
+        FIRST_PARTY_INGEST_RATE_LIMIT_SCOPE: workerName(stage),
         FIRST_PARTY_INGEST_GLOBAL_RATE_LIMIT: Cloudflare.RateLimit(
           "FIRST_PARTY_INGEST_GLOBAL_RATE_LIMIT",
           {

--- a/alchemy.run.ts
+++ b/alchemy.run.ts
@@ -480,8 +480,26 @@ export default Alchemy.Stack(
           simple: { limit: 5000, period: 60 },
         }),
 
-        // Authenticated per-source throttle for aggregate ingestion. Storage
-        // is separately bounded to one immutable receipt per source/day.
+        // The receiver is public and HMAC-authenticated. A constant-key coarse
+        // guard catches random UUID sprays before body/D1/crypto work; a second
+        // opaque claimed-source guard catches repeated claims without using or
+        // retaining IP addresses. The authenticated limiter remains the final,
+        // stricter per-source guard after HMAC verification.
+        FIRST_PARTY_INGEST_EDGE_LIMITS_REQUIRED: "true",
+        FIRST_PARTY_INGEST_GLOBAL_RATE_LIMIT: Cloudflare.RateLimit(
+          "FIRST_PARTY_INGEST_GLOBAL_RATE_LIMIT",
+          {
+            namespaceId: 1003,
+            simple: { limit: 600, period: 60 },
+          },
+        ),
+        FIRST_PARTY_INGEST_CLAIMED_SOURCE_RATE_LIMIT: Cloudflare.RateLimit(
+          "FIRST_PARTY_INGEST_CLAIMED_SOURCE_RATE_LIMIT",
+          {
+            namespaceId: 1004,
+            simple: { limit: 240, period: 60 },
+          },
+        ),
         FIRST_PARTY_INGEST_RATE_LIMIT: Cloudflare.RateLimit(
           "FIRST_PARTY_INGEST_RATE_LIMIT",
           {

--- a/alchemy.run.ts
+++ b/alchemy.run.ts
@@ -480,6 +480,16 @@ export default Alchemy.Stack(
           simple: { limit: 5000, period: 60 },
         }),
 
+        // Authenticated per-source throttle for aggregate ingestion. Storage
+        // is separately bounded to one immutable receipt per source/day.
+        FIRST_PARTY_INGEST_RATE_LIMIT: Cloudflare.RateLimit(
+          "FIRST_PARTY_INGEST_RATE_LIMIT",
+          {
+            namespaceId: 1002,
+            simple: { limit: 120, period: 60 },
+          },
+        ),
+
         // Durable Objects (the chat agents; the audit scratchpad lives
         // privately in the open-seo-audit worker). Alchemy backs new DO
         // classes with SQLite storage; wrangler.jsonc's `migrations` only

--- a/docs/FIRST_PARTY_AGGREGATES.md
+++ b/docs/FIRST_PARTY_AGGREGATES.md
@@ -1,0 +1,82 @@
+# First-party aggregate signals
+
+OpenSEO can receive daily, privacy-safe business funnel snapshots at:
+
+```text
+POST /api/site-signals/v1/aggregates
+```
+
+Create a source from **Project settings → Integrations → First-party
+aggregates**. The generated 256-bit secret is encrypted at rest with
+`BETTER_AUTH_SECRET` and displayed only once. Rotating a source immediately
+invalidates its previous secret. Each project has one source, so its daily
+landing totals cannot be double-counted by overlapping emitters.
+
+## Payload
+
+Each batch is a complete, immutable snapshot for one UTC day. A source accepts
+exactly one batch per day; exact retries are idempotent and a second batch for
+the same day is rejected. This bounds retained history to one snapshot per day.
+
+```json
+{
+  "schemaVersion": 1,
+  "batchId": "f1a2ae17-b157-4bb9-b1a1-960ce8d4c01d",
+  "snapshotDate": "2026-09-04",
+  "rows": [
+    {
+      "landingPath": "/pricing",
+      "searchStarted": 120,
+      "searchCompleted": 96,
+      "searchNoResults": 8,
+      "registrationsCompleted": 21,
+      "checkoutStarted": 12,
+      "paymentsCompleted": 9
+    }
+  ]
+}
+```
+
+Only the six nonnegative counters shown above are accepted. Do not send
+amounts, users, sessions, orders, search terms, email addresses, or other
+identifiers. Every `landingPath` must be an exact public pathname configured on
+the source. Query strings, fragments, private application paths, and common
+identifier-shaped path segments are rejected. Every configured path must
+appear exactly once, including paths whose six counters are all zero.
+
+Payloads are capped at 256 KiB and 1,000 landing rows. Snapshots older than 400
+days or dated in the future are rejected. A daily maintenance pass deletes
+batches beyond the 400-day retention window. Cloudflare deployments provisioned
+by Alchemy also throttle authenticated ingestion to 120 requests per source per
+minute.
+
+## Authentication and idempotency
+
+Send these headers:
+
+```text
+Content-Type: application/json
+X-OpenSEO-Source: <source UUID>
+X-OpenSEO-Timestamp: <Unix seconds or milliseconds>
+X-OpenSEO-Signature: <lowercase hex HMAC-SHA256>
+```
+
+The signed message is the UTF-8 timestamp, one literal period, and the exact
+request body bytes:
+
+```text
+HMAC-SHA256(secret, timestamp + "." + exactRawBody)
+```
+
+OpenSEO accepts at most five minutes of clock skew. Reformatting JSON after
+signing invalidates the signature.
+
+`batchId` is an opaque UUID idempotency key within a source. Replaying the same ID and
+exact payload returns HTTP 200 without another write. Reusing an ID with
+different bytes returns HTTP 409. Treat it as an opaque technical key; never
+derive it from a user, session, order, search term, or other business
+identifier. A newly accepted batch returns HTTP 202.
+
+The MCP and SAM tools `get_first_party_funnel` and
+`get_first_party_landing_conversions` expose only aggregate counts and derived
+rates for an authorized OpenSEO project.

--- a/docs/FIRST_PARTY_AGGREGATES.md
+++ b/docs/FIRST_PARTY_AGGREGATES.md
@@ -45,10 +45,13 @@ identifier-shaped path segments are rejected. Every configured path must
 appear exactly once, including paths whose six counters are all zero.
 
 Payloads are capped at 256 KiB and 1,000 landing rows. Snapshots older than 400
-days or dated in the future are rejected. A daily maintenance pass deletes
-batches beyond the 400-day retention window. Cloudflare deployments provisioned
-by Alchemy also throttle authenticated ingestion to 120 requests per source per
-minute.
+days or dated in the future are rejected. Cloudflare deployments delete one
+bounded page of expired batches on the daily scheduled event and throttle
+authenticated ingestion to 120 requests per source per minute. Docker and
+other self-hosted runtimes do not dispatch that Cloudflare cron: an integration
+manager can invoke the same project-scoped, 250-batch cleanup page from the
+integration card. If it reports more work, run it again. Cleanup never performs
+an unbounded delete.
 
 ## Authentication and idempotency
 
@@ -71,11 +74,14 @@ HMAC-SHA256(secret, timestamp + "." + exactRawBody)
 OpenSEO accepts at most five minutes of clock skew. Reformatting JSON after
 signing invalidates the signature.
 
-`batchId` is an opaque UUID idempotency key within a source. Replaying the same ID and
-exact payload returns HTTP 200 without another write. Reusing an ID with
-different bytes returns HTTP 409. Treat it as an opaque technical key; never
-derive it from a user, session, order, search term, or other business
-identifier. A newly accepted batch returns HTTP 202.
+`batchId` is an opaque UUID idempotency key within a source. Replaying the same
+ID and exact payload after completion returns HTTP 200 without another write.
+An exact retry while the first request still owns the processing lease returns
+HTTP 202 with `status: "in_progress"` and a `Retry-After` header. Reusing an ID
+with different bytes, or submitting a different batch for the same UTC date,
+returns HTTP 409. Treat the ID as an opaque technical key; never derive it from
+a user, session, order, search term, or other business identifier. A newly
+accepted batch returns HTTP 202.
 
 The MCP and SAM tools `get_first_party_funnel` and
 `get_first_party_landing_conversions` expose only aggregate counts and derived

--- a/docs/FIRST_PARTY_AGGREGATES.md
+++ b/docs/FIRST_PARTY_AGGREGATES.md
@@ -45,13 +45,22 @@ identifier-shaped path segments are rejected. Every configured path must
 appear exactly once, including paths whose six counters are all zero.
 
 Payloads are capped at 256 KiB and 1,000 landing rows. Snapshots older than 400
-days or dated in the future are rejected. Cloudflare deployments delete one
-bounded page of expired batches on the daily scheduled event and throttle
-authenticated ingestion to 120 requests per source per minute. Docker and
+days or dated in the future are rejected. Alchemy-hosted Cloudflare deployments
+apply a constant-key 600 requests/minute coarse limiter plus an opaque
+claimed-source 240 requests/minute limiter before body, database, secret, or
+HMAC work. This contains random UUID sprays without using, persisting, or
+logging IP addresses. The existing authenticated per-source 120
+requests/minute limiter remains after HMAC verification. A configured binding
+set fails closed if any limiter is missing or unavailable. Portable Docker
+runtimes omit Cloudflare bindings and should provide equivalent coarse
+protection in their trusted reverse proxy.
+
+The daily scheduled event drains up to twenty ordered pages (5,000 batches).
+If more work remains, the invocation fails observably and the next run resumes
+safely from the oldest remaining receipt without storing a cursor. Docker and
 other self-hosted runtimes do not dispatch that Cloudflare cron: an integration
-manager can invoke the same project-scoped, 250-batch cleanup page from the
-integration card. If it reports more work, run it again. Cleanup never performs
-an unbounded delete.
+manager can invoke the same bounded, project-scoped drain from the integration
+card and repeat it only while `hasMore` is true.
 
 ## Authentication and idempotency
 

--- a/docs/FIRST_PARTY_AGGREGATES.md
+++ b/docs/FIRST_PARTY_AGGREGATES.md
@@ -51,9 +51,13 @@ claimed-source 240 requests/minute limiter before body, database, secret, or
 HMAC work. This contains random UUID sprays without using, persisting, or
 logging IP addresses. The existing authenticated per-source 120
 requests/minute limiter remains after HMAC verification. A configured binding
-set fails closed if any limiter is missing or unavailable. Portable Docker
-runtimes omit Cloudflare bindings and should provide equivalent coarse
-protection in their trusted reverse proxy.
+set fails closed if any limiter, or its trusted deployment scope, is missing or
+unavailable. Alchemy injects the stage-specific Worker name as that scope and
+prefixes every limiter key with it, because a Cloudflare rate-limit namespace
+can share counters across Workers in the same account. The scope is deployment
+configuration and never comes from a request. Portable Docker runtimes omit
+Cloudflare bindings and should provide equivalent coarse protection in their
+trusted reverse proxy.
 
 The daily scheduled event drains up to twenty ordered pages (5,000 batches).
 If more work remains, the invocation fails observably and the next run resumes

--- a/drizzle-pg/0023_clear_brood.sql
+++ b/drizzle-pg/0023_clear_brood.sql
@@ -1,0 +1,61 @@
+CREATE TABLE "first_party_signal_batches" (
+	"id" text PRIMARY KEY NOT NULL,
+	"source_id" text NOT NULL,
+	"batch_id" text NOT NULL,
+	"snapshot_date" text NOT NULL,
+	"payload_digest" text NOT NULL,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"processing_lease_id" text,
+	"processing_lease_expires_at" text,
+	"received_at" text DEFAULT to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') NOT NULL,
+	"completed_at" text,
+	CONSTRAINT "first_party_signal_batches_status_check" CHECK ("first_party_signal_batches"."status" IN ('pending', 'complete', 'failed'))
+);
+--> statement-breakpoint
+CREATE TABLE "first_party_signal_daily_aggregates" (
+	"id" text PRIMARY KEY NOT NULL,
+	"batch_receipt_id" text NOT NULL,
+	"processing_attempt_id" text NOT NULL,
+	"landing_path" text NOT NULL,
+	"search_started" integer DEFAULT 0 NOT NULL,
+	"search_completed" integer DEFAULT 0 NOT NULL,
+	"search_no_results" integer DEFAULT 0 NOT NULL,
+	"registrations_completed" integer DEFAULT 0 NOT NULL,
+	"checkout_started" integer DEFAULT 0 NOT NULL,
+	"payments_completed" integer DEFAULT 0 NOT NULL,
+	"received_at" text DEFAULT to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') NOT NULL,
+	CONSTRAINT "first_party_signal_daily_nonnegative_check" CHECK ("first_party_signal_daily_aggregates"."search_started" >= 0 AND "first_party_signal_daily_aggregates"."search_completed" >= 0 AND "first_party_signal_daily_aggregates"."search_no_results" >= 0 AND "first_party_signal_daily_aggregates"."registrations_completed" >= 0 AND "first_party_signal_daily_aggregates"."checkout_started" >= 0 AND "first_party_signal_daily_aggregates"."payments_completed" >= 0)
+);
+--> statement-breakpoint
+CREATE TABLE "first_party_signal_source_paths" (
+	"id" text PRIMARY KEY NOT NULL,
+	"source_id" text NOT NULL,
+	"path" text NOT NULL,
+	"created_at" text DEFAULT to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "first_party_signal_sources" (
+	"id" text PRIMARY KEY NOT NULL,
+	"project_id" text NOT NULL,
+	"organization_id" text NOT NULL,
+	"name" text NOT NULL,
+	"encrypted_secret" text NOT NULL,
+	"secret_hint" text NOT NULL,
+	"created_by_user_id" text,
+	"revoked_at" text,
+	"created_at" text DEFAULT to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') NOT NULL,
+	"updated_at" text DEFAULT to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "first_party_signal_batches" ADD CONSTRAINT "first_party_signal_batches_source_id_first_party_signal_sources_id_fk" FOREIGN KEY ("source_id") REFERENCES "public"."first_party_signal_sources"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "first_party_signal_daily_aggregates" ADD CONSTRAINT "first_party_signal_daily_aggregates_batch_receipt_id_first_party_signal_batches_id_fk" FOREIGN KEY ("batch_receipt_id") REFERENCES "public"."first_party_signal_batches"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "first_party_signal_source_paths" ADD CONSTRAINT "first_party_signal_source_paths_source_id_first_party_signal_sources_id_fk" FOREIGN KEY ("source_id") REFERENCES "public"."first_party_signal_sources"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "first_party_signal_sources" ADD CONSTRAINT "first_party_signal_sources_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "first_party_signal_sources" ADD CONSTRAINT "first_party_signal_sources_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "first_party_signal_sources" ADD CONSTRAINT "first_party_signal_sources_created_by_user_id_user_id_fk" FOREIGN KEY ("created_by_user_id") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "first_party_signal_batches_source_batch_idx" ON "first_party_signal_batches" USING btree ("source_id","batch_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "first_party_signal_batches_source_date_idx" ON "first_party_signal_batches" USING btree ("source_id","snapshot_date");--> statement-breakpoint
+CREATE UNIQUE INDEX "first_party_signal_daily_batch_path_idx" ON "first_party_signal_daily_aggregates" USING btree ("batch_receipt_id","processing_attempt_id","landing_path");--> statement-breakpoint
+CREATE UNIQUE INDEX "first_party_signal_source_paths_unique_idx" ON "first_party_signal_source_paths" USING btree ("source_id","path");--> statement-breakpoint
+CREATE UNIQUE INDEX "first_party_signal_sources_project_idx" ON "first_party_signal_sources" USING btree ("project_id");--> statement-breakpoint
+CREATE INDEX "first_party_signal_sources_org_idx" ON "first_party_signal_sources" USING btree ("organization_id");

--- a/drizzle-pg/0024_first_party_retention_index.sql
+++ b/drizzle-pg/0024_first_party_retention_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "first_party_signal_batches_retention_idx" ON "first_party_signal_batches" USING btree ("snapshot_date","id");

--- a/drizzle-pg/meta/0023_snapshot.json
+++ b/drizzle-pg/meta/0023_snapshot.json
@@ -1,0 +1,4610 @@
+{
+  "id": "bbe70a70-ee46-41d1-988c-2d5c7fdefd4d",
+  "prevId": "354b82d0-282b-4b17-99eb-63e81147cf51",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.backlink_snapshots": {
+      "name": "backlink_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backlinks": {
+          "name": "backlinks",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referring_domains": {
+          "name": "referring_domains",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "broken_backlinks": {
+          "name": "broken_backlinks",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_backlinks": {
+          "name": "new_backlinks",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lost_backlinks": {
+          "name": "lost_backlinks",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_referring_domains": {
+          "name": "new_referring_domains",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lost_referring_domains": {
+          "name": "lost_referring_domains",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "backlink_snapshots_project_captured_idx": {
+          "name": "backlink_snapshots_project_captured_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "backlink_snapshots_project_id_projects_id_fk": {
+          "name": "backlink_snapshots_project_id_projects_id_fk",
+          "tableFrom": "backlink_snapshots",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.keyword_metrics": {
+      "name": "keyword_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_code": {
+          "name": "location_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "search_volume": {
+          "name": "search_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpc": {
+          "name": "cpc",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "competition": {
+          "name": "competition",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keyword_difficulty": {
+          "name": "keyword_difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intent": {
+          "name": "intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monthly_searches": {
+          "name": "monthly_searches",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "keyword_metrics_unique_project_keyword_location_language": {
+          "name": "keyword_metrics_unique_project_keyword_location_language",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "keyword",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "keyword_metrics_lookup_idx": {
+          "name": "keyword_metrics_lookup_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "keyword",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "keyword_metrics_project_id_projects_id_fk": {
+          "name": "keyword_metrics_project_id_projects_id_fk",
+          "tableFrom": "keyword_metrics",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_activation_state": {
+      "name": "organization_activation_state",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_mcp_authorized_at": {
+          "name": "first_mcp_authorized_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_mcp_tool_call_at": {
+          "name": "first_mcp_tool_call_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_activation_state_organization_id_organization_id_fk": {
+          "name": "organization_activation_state_organization_id_organization_id_fk",
+          "tableFrom": "organization_activation_state",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_activation_state": {
+      "name": "project_activation_state",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "competitor_step_clicked_at": {
+          "name": "competitor_step_clicked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_card_dismissed_at": {
+          "name": "mcp_card_dismissed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ga4_card_dismissed_at": {
+          "name": "ga4_card_dismissed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_activation_state_project_id_projects_id_fk": {
+          "name": "project_activation_state_project_id_projects_id_fk",
+          "tableFrom": "project_activation_state",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_code": {
+          "name": "location_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2840
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "projects_one_default_per_organization_idx": {
+          "name": "projects_one_default_per_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"projects\".\"name\" = 'Default' AND \"projects\".\"domain\" IS NULL AND \"projects\".\"archived_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_organization_id_idx": {
+          "name": "projects_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_organization_id_organization_id_fk": {
+          "name": "projects_organization_id_organization_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rank_check_runs": {
+      "name": "rank_check_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "keywords_total": {
+          "name": "keywords_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "keywords_checked": {
+          "name": "keywords_checked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_subset_run": {
+          "name": "is_subset_run",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rank_check_runs_config_idx": {
+          "name": "rank_check_runs_config_idx",
+          "columns": [
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rank_check_runs_project_idx": {
+          "name": "rank_check_runs_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rank_check_runs_one_active_per_config_idx": {
+          "name": "rank_check_runs_one_active_per_config_idx",
+          "columns": [
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"rank_check_runs\".\"status\" IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rank_check_runs_config_id_rank_tracking_configs_id_fk": {
+          "name": "rank_check_runs_config_id_rank_tracking_configs_id_fk",
+          "tableFrom": "rank_check_runs",
+          "tableTo": "rank_tracking_configs",
+          "columnsFrom": [
+            "config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rank_check_runs_project_id_projects_id_fk": {
+          "name": "rank_check_runs_project_id_projects_id_fk",
+          "tableFrom": "rank_check_runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rank_snapshots": {
+      "name": "rank_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tracking_keyword_id": {
+          "name": "tracking_keyword_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device": {
+          "name": "device",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serp_features": {
+          "name": "serp_features",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "rank_snapshots_keyword_device_idx": {
+          "name": "rank_snapshots_keyword_device_idx",
+          "columns": [
+            {
+              "expression": "tracking_keyword_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rank_snapshots_run_keyword_device_idx": {
+          "name": "rank_snapshots_run_keyword_device_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tracking_keyword_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rank_snapshots_run_id_rank_check_runs_id_fk": {
+          "name": "rank_snapshots_run_id_rank_check_runs_id_fk",
+          "tableFrom": "rank_snapshots",
+          "tableTo": "rank_check_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rank_tracking_configs": {
+      "name": "rank_tracking_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_code": {
+          "name": "location_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2840
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "devices": {
+          "name": "devices",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'both'"
+        },
+        "serp_depth": {
+          "name": "serp_depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_interval": {
+          "name": "schedule_interval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'weekly'"
+        },
+        "location_name": {
+          "name": "location_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_check_at": {
+          "name": "next_check_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_skip_reason": {
+          "name": "last_skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "rank_tracking_configs_project_active_created_idx": {
+          "name": "rank_tracking_configs_project_active_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rank_tracking_configs_national_idx": {
+          "name": "rank_tracking_configs_national_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"rank_tracking_configs\".\"location_name\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rank_tracking_configs_local_idx": {
+          "name": "rank_tracking_configs_local_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"rank_tracking_configs\".\"location_name\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rank_tracking_configs_project_id_projects_id_fk": {
+          "name": "rank_tracking_configs_project_id_projects_id_fk",
+          "tableFrom": "rank_tracking_configs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rank_tracking_keywords": {
+      "name": "rank_tracking_keywords",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_volume": {
+          "name": "search_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keyword_difficulty": {
+          "name": "keyword_difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpc": {
+          "name": "cpc",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metrics_fetched_at": {
+          "name": "metrics_fetched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "rank_tracking_keywords_config_keyword_idx": {
+          "name": "rank_tracking_keywords_config_keyword_idx",
+          "columns": [
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "keyword",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rank_tracking_keywords_config_id_rank_tracking_configs_id_fk": {
+          "name": "rank_tracking_keywords_config_id_rank_tracking_configs_id_fk",
+          "tableFrom": "rank_tracking_keywords",
+          "tableTo": "rank_tracking_configs",
+          "columnsFrom": [
+            "config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_keyword_tag_assignments": {
+      "name": "saved_keyword_tag_assignments",
+      "schema": "",
+      "columns": {
+        "saved_keyword_id": {
+          "name": "saved_keyword_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "saved_keyword_tag_assignments_unique_idx": {
+          "name": "saved_keyword_tag_assignments_unique_idx",
+          "columns": [
+            {
+              "expression": "saved_keyword_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_keyword_tag_assignments_tag_idx": {
+          "name": "saved_keyword_tag_assignments_tag_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_keyword_tag_assignments_saved_keyword_id_saved_keywords_id_fk": {
+          "name": "saved_keyword_tag_assignments_saved_keyword_id_saved_keywords_id_fk",
+          "tableFrom": "saved_keyword_tag_assignments",
+          "tableTo": "saved_keywords",
+          "columnsFrom": [
+            "saved_keyword_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "saved_keyword_tag_assignments_tag_id_saved_keyword_tags_id_fk": {
+          "name": "saved_keyword_tag_assignments_tag_id_saved_keyword_tags_id_fk",
+          "tableFrom": "saved_keyword_tag_assignments",
+          "tableTo": "saved_keyword_tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_keyword_tags": {
+      "name": "saved_keyword_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "saved_keyword_tags_project_normalized_name_idx": {
+          "name": "saved_keyword_tags_project_normalized_name_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_keyword_tags_project_name_idx": {
+          "name": "saved_keyword_tags_project_name_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_keyword_tags_project_id_projects_id_fk": {
+          "name": "saved_keyword_tags_project_id_projects_id_fk",
+          "tableFrom": "saved_keyword_tags",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_keywords": {
+      "name": "saved_keywords",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_code": {
+          "name": "location_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2840
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "saved_keywords_unique_project_keyword_location_language": {
+          "name": "saved_keywords_unique_project_keyword_location_language",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "keyword",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_keywords_project_created_idx": {
+          "name": "saved_keywords_project_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_keywords_project_id_projects_id_fk": {
+          "name": "saved_keywords_project_id_projects_id_fk",
+          "tableFrom": "saved_keywords",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_onboarding_answers": {
+      "name": "user_onboarding_answers",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interested_features": {
+          "name": "interested_features",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "work_for": {
+          "name": "work_for",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_website_count": {
+          "name": "client_website_count",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "found_via": {
+          "name": "found_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_setup_intent": {
+          "name": "mcp_setup_intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gsc_nudge_dismissed_at": {
+          "name": "gsc_nudge_dismissed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "user_onboarding_answers_organization_idx": {
+          "name": "user_onboarding_answers_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_onboarding_answers_user_id_user_id_fk": {
+          "name": "user_onboarding_answers_user_id_user_id_fk",
+          "tableFrom": "user_onboarding_answers",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_onboarding_answers_organization_id_organization_id_fk": {
+          "name": "user_onboarding_answers_organization_id_organization_id_fk",
+          "tableFrom": "user_onboarding_answers",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_competitors": {
+      "name": "project_competitors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "project_competitors_project_domain_idx": {
+          "name": "project_competitors_project_domain_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_competitors_project_id_projects_id_fk": {
+          "name": "project_competitors_project_id_projects_id_fk",
+          "tableFrom": "project_competitors",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_context_sections": {
+      "name": "project_context_sections",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_context_sections_project_id_projects_id_fk": {
+          "name": "project_context_sections_project_id_projects_id_fk",
+          "tableFrom": "project_context_sections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_context_sections_project_id_key_pk": {
+          "name": "project_context_sections_project_id_key_pk",
+          "columns": [
+            "project_id",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_key_pages": {
+      "name": "project_key_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "project_key_pages_project_url_idx": {
+          "name": "project_key_pages_project_url_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_key_pages_project_id_projects_id_fk": {
+          "name": "project_key_pages_project_id_projects_id_fk",
+          "tableFrom": "project_key_pages",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_research_log": {
+      "name": "project_research_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_date": {
+          "name": "entry_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "project_research_log_project_date_idx": {
+          "name": "project_research_log_project_date_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entry_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_research_log_project_id_projects_id_fk": {
+          "name": "project_research_log_project_id_projects_id_fk",
+          "tableFrom": "project_research_log",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_issues": {
+      "name": "audit_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "audit_id": {
+          "name": "audit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_url": {
+          "name": "page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_type": {
+          "name": "issue_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "details_json": {
+          "name": "details_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_issues_audit_type_idx": {
+          "name": "audit_issues_audit_type_idx",
+          "columns": [
+            {
+              "expression": "audit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_issues_page_id_idx": {
+          "name": "audit_issues_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_issues_audit_id_audits_id_fk": {
+          "name": "audit_issues_audit_id_audits_id_fk",
+          "tableFrom": "audit_issues",
+          "tableTo": "audits",
+          "columnsFrom": [
+            "audit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_issues_page_id_audit_pages_id_fk": {
+          "name": "audit_issues_page_id_audit_pages_id_fk",
+          "tableFrom": "audit_issues",
+          "tableTo": "audit_pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_lighthouse_results": {
+      "name": "audit_lighthouse_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "audit_id": {
+          "name": "audit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strategy": {
+          "name": "strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performance_score": {
+          "name": "performance_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessibility_score": {
+          "name": "accessibility_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "best_practices_score": {
+          "name": "best_practices_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seo_score": {
+          "name": "seo_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lcp_ms": {
+          "name": "lcp_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cls": {
+          "name": "cls",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inp_ms": {
+          "name": "inp_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ttfb_ms": {
+          "name": "ttfb_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_size_bytes": {
+          "name": "payload_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_lighthouse_results_audit_id_idx": {
+          "name": "audit_lighthouse_results_audit_id_idx",
+          "columns": [
+            {
+              "expression": "audit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_lighthouse_results_page_id_idx": {
+          "name": "audit_lighthouse_results_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_lighthouse_results_audit_id_audits_id_fk": {
+          "name": "audit_lighthouse_results_audit_id_audits_id_fk",
+          "tableFrom": "audit_lighthouse_results",
+          "tableTo": "audits",
+          "columnsFrom": [
+            "audit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_lighthouse_results_page_id_audit_pages_id_fk": {
+          "name": "audit_lighthouse_results_page_id_audit_pages_id_fk",
+          "tableFrom": "audit_lighthouse_results",
+          "tableTo": "audit_pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_pages": {
+      "name": "audit_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "audit_id": {
+          "name": "audit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_url": {
+          "name": "canonical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "robots_meta": {
+          "name": "robots_meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_title": {
+          "name": "og_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_description": {
+          "name": "og_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_image": {
+          "name": "og_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "h1_count": {
+          "name": "h1_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "h2_count": {
+          "name": "h2_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "h3_count": {
+          "name": "h3_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "h4_count": {
+          "name": "h4_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "h5_count": {
+          "name": "h5_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "h6_count": {
+          "name": "h6_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "heading_order_json": {
+          "name": "heading_order_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "images_total": {
+          "name": "images_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "images_missing_alt": {
+          "name": "images_missing_alt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "images_json": {
+          "name": "images_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_link_count": {
+          "name": "internal_link_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "external_link_count": {
+          "name": "external_link_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "has_structured_data": {
+          "name": "has_structured_data",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hreflang_tags_json": {
+          "name": "hreflang_tags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_indexable": {
+          "name": "is_indexable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "x_robots_tag": {
+          "name": "x_robots_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "header_canonical_url": {
+          "name": "header_canonical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crawl_depth": {
+          "name": "crawl_depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "in_sitemap": {
+          "name": "in_sitemap",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetch_class": {
+          "name": "fetch_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ok'"
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_pages_audit_url_idx": {
+          "name": "audit_pages_audit_url_idx",
+          "columns": [
+            {
+              "expression": "audit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_pages_audit_id_audits_id_fk": {
+          "name": "audit_pages_audit_id_audits_id_fk",
+          "tableFrom": "audit_pages",
+          "tableTo": "audits",
+          "columnsFrom": [
+            "audit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audits": {
+      "name": "audits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_by_user_id": {
+          "name": "started_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_url": {
+          "name": "start_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "workflow_instance_id": {
+          "name": "workflow_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "pages_crawled": {
+          "name": "pages_crawled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pages_total": {
+          "name": "pages_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lighthouse_total": {
+          "name": "lighthouse_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lighthouse_completed": {
+          "name": "lighthouse_completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lighthouse_failed": {
+          "name": "lighthouse_failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_phase": {
+          "name": "current_phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'discovery'"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_detail": {
+          "name": "error_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_phase": {
+          "name": "failed_phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audits_project_id_idx": {
+          "name": "audits_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audits_started_by_user_id_idx": {
+          "name": "audits_started_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "started_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audits_project_id_projects_id_fk": {
+          "name": "audits_project_id_projects_id_fk",
+          "tableFrom": "audits",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sam_sessions": {
+      "name": "sam_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'New chat'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sam_sessions_project_updated_idx": {
+          "name": "sam_sessions_project_updated_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sam_sessions_project_id_projects_id_fk": {
+          "name": "sam_sessions_project_id_projects_id_fk",
+          "tableFrom": "sam_sessions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sam_sessions_user_id_user_id_fk": {
+          "name": "sam_sessions_user_id_user_id_fk",
+          "tableFrom": "sam_sessions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_accountId_providerId_idx": {
+          "name": "account_accountId_providerId_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apikey": {
+      "name": "apikey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 60000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 120
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "apikey_configId_idx": {
+          "name": "apikey_configId_idx",
+          "columns": [
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "apikey_referenceId_idx": {
+          "name": "apikey_referenceId_idx",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "apikey_key_idx": {
+          "name": "apikey_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_organizationId_userId_uidx": {
+          "name": "member_organizationId_userId_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_slug_uidx": {
+          "name": "organization_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "analytics_opted_out": {
+          "name": "analytics_opted_out",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_organization_id": {
+          "name": "last_active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verification_expiresAt_idx": {
+          "name": "verification_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_customer_status": {
+      "name": "billing_customer_status",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "is_paying": {
+          "name": "is_paying",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "paid_plan_id": {
+          "name": "paid_plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_plan_status": {
+          "name": "paid_plan_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_json": {
+          "name": "customer_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "billing_customer_status_organization_id_organization_id_fk": {
+          "name": "billing_customer_status_organization_id_organization_id_fk",
+          "tableFrom": "billing_customer_status",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ga4_connections": {
+      "name": "ga4_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_display_name": {
+          "name": "property_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_time_zone": {
+          "name": "property_time_zone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_currency_code": {
+          "name": "property_currency_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ga4_account_id": {
+          "name": "ga4_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_account_email": {
+          "name": "connected_account_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "ga4_connections_project_idx": {
+          "name": "ga4_connections_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ga4_connections_organization_idx": {
+          "name": "ga4_connections_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ga4_connections_connector_idx": {
+          "name": "ga4_connections_connector_idx",
+          "columns": [
+            {
+              "expression": "connected_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ga4_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ga4_connections_project_id_projects_id_fk": {
+          "name": "ga4_connections_project_id_projects_id_fk",
+          "tableFrom": "ga4_connections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ga4_connections_organization_id_organization_id_fk": {
+          "name": "ga4_connections_organization_id_organization_id_fk",
+          "tableFrom": "ga4_connections",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gsc_connections": {
+      "name": "gsc_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_url": {
+          "name": "site_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gsc_account_id": {
+          "name": "gsc_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_account_email": {
+          "name": "connected_account_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "gsc_connections_project_idx": {
+          "name": "gsc_connections_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gsc_connections_organization_idx": {
+          "name": "gsc_connections_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gsc_connections_project_id_projects_id_fk": {
+          "name": "gsc_connections_project_id_projects_id_fk",
+          "tableFrom": "gsc_connections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gsc_connections_organization_id_organization_id_fk": {
+          "name": "gsc_connections_organization_id_organization_id_fk",
+          "tableFrom": "gsc_connections",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telemetry_state": {
+      "name": "telemetry_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "install_id": {
+          "name": "install_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_version": {
+          "name": "last_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_tool_call_count": {
+          "name": "mcp_tool_call_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.first_party_signal_batches": {
+      "name": "first_party_signal_batches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_digest": {
+          "name": "payload_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "processing_lease_id": {
+          "name": "processing_lease_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_lease_expires_at": {
+          "name": "processing_lease_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "first_party_signal_batches_source_batch_idx": {
+          "name": "first_party_signal_batches_source_batch_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "first_party_signal_batches_source_date_idx": {
+          "name": "first_party_signal_batches_source_date_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "snapshot_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "first_party_signal_batches_source_id_first_party_signal_sources_id_fk": {
+          "name": "first_party_signal_batches_source_id_first_party_signal_sources_id_fk",
+          "tableFrom": "first_party_signal_batches",
+          "tableTo": "first_party_signal_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "first_party_signal_batches_status_check": {
+          "name": "first_party_signal_batches_status_check",
+          "value": "\"first_party_signal_batches\".\"status\" IN ('pending', 'complete', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.first_party_signal_daily_aggregates": {
+      "name": "first_party_signal_daily_aggregates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "batch_receipt_id": {
+          "name": "batch_receipt_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processing_attempt_id": {
+          "name": "processing_attempt_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "landing_path": {
+          "name": "landing_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_started": {
+          "name": "search_started",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "search_completed": {
+          "name": "search_completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "search_no_results": {
+          "name": "search_no_results",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "registrations_completed": {
+          "name": "registrations_completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "checkout_started": {
+          "name": "checkout_started",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "payments_completed": {
+          "name": "payments_completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "first_party_signal_daily_batch_path_idx": {
+          "name": "first_party_signal_daily_batch_path_idx",
+          "columns": [
+            {
+              "expression": "batch_receipt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "processing_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "landing_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "first_party_signal_daily_aggregates_batch_receipt_id_first_party_signal_batches_id_fk": {
+          "name": "first_party_signal_daily_aggregates_batch_receipt_id_first_party_signal_batches_id_fk",
+          "tableFrom": "first_party_signal_daily_aggregates",
+          "tableTo": "first_party_signal_batches",
+          "columnsFrom": [
+            "batch_receipt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "first_party_signal_daily_nonnegative_check": {
+          "name": "first_party_signal_daily_nonnegative_check",
+          "value": "\"first_party_signal_daily_aggregates\".\"search_started\" >= 0 AND \"first_party_signal_daily_aggregates\".\"search_completed\" >= 0 AND \"first_party_signal_daily_aggregates\".\"search_no_results\" >= 0 AND \"first_party_signal_daily_aggregates\".\"registrations_completed\" >= 0 AND \"first_party_signal_daily_aggregates\".\"checkout_started\" >= 0 AND \"first_party_signal_daily_aggregates\".\"payments_completed\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.first_party_signal_source_paths": {
+      "name": "first_party_signal_source_paths",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "first_party_signal_source_paths_unique_idx": {
+          "name": "first_party_signal_source_paths_unique_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "first_party_signal_source_paths_source_id_first_party_signal_sources_id_fk": {
+          "name": "first_party_signal_source_paths_source_id_first_party_signal_sources_id_fk",
+          "tableFrom": "first_party_signal_source_paths",
+          "tableTo": "first_party_signal_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.first_party_signal_sources": {
+      "name": "first_party_signal_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_secret": {
+          "name": "encrypted_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hint": {
+          "name": "secret_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "first_party_signal_sources_project_idx": {
+          "name": "first_party_signal_sources_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "first_party_signal_sources_org_idx": {
+          "name": "first_party_signal_sources_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "first_party_signal_sources_project_id_projects_id_fk": {
+          "name": "first_party_signal_sources_project_id_projects_id_fk",
+          "tableFrom": "first_party_signal_sources",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "first_party_signal_sources_organization_id_organization_id_fk": {
+          "name": "first_party_signal_sources_organization_id_organization_id_fk",
+          "tableFrom": "first_party_signal_sources",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "first_party_signal_sources_created_by_user_id_user_id_fk": {
+          "name": "first_party_signal_sources_created_by_user_id_user_id_fk",
+          "tableFrom": "first_party_signal_sources",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle-pg/meta/0024_snapshot.json
+++ b/drizzle-pg/meta/0024_snapshot.json
@@ -1,0 +1,4631 @@
+{
+  "id": "9cf51e01-3f45-4ccf-ae81-b12c6f89b8a8",
+  "prevId": "bbe70a70-ee46-41d1-988c-2d5c7fdefd4d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.backlink_snapshots": {
+      "name": "backlink_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backlinks": {
+          "name": "backlinks",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referring_domains": {
+          "name": "referring_domains",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "broken_backlinks": {
+          "name": "broken_backlinks",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_backlinks": {
+          "name": "new_backlinks",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lost_backlinks": {
+          "name": "lost_backlinks",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_referring_domains": {
+          "name": "new_referring_domains",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lost_referring_domains": {
+          "name": "lost_referring_domains",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "backlink_snapshots_project_captured_idx": {
+          "name": "backlink_snapshots_project_captured_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "backlink_snapshots_project_id_projects_id_fk": {
+          "name": "backlink_snapshots_project_id_projects_id_fk",
+          "tableFrom": "backlink_snapshots",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.keyword_metrics": {
+      "name": "keyword_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_code": {
+          "name": "location_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "search_volume": {
+          "name": "search_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpc": {
+          "name": "cpc",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "competition": {
+          "name": "competition",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keyword_difficulty": {
+          "name": "keyword_difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intent": {
+          "name": "intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monthly_searches": {
+          "name": "monthly_searches",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "keyword_metrics_unique_project_keyword_location_language": {
+          "name": "keyword_metrics_unique_project_keyword_location_language",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "keyword",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "keyword_metrics_lookup_idx": {
+          "name": "keyword_metrics_lookup_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "keyword",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "keyword_metrics_project_id_projects_id_fk": {
+          "name": "keyword_metrics_project_id_projects_id_fk",
+          "tableFrom": "keyword_metrics",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_activation_state": {
+      "name": "organization_activation_state",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_mcp_authorized_at": {
+          "name": "first_mcp_authorized_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_mcp_tool_call_at": {
+          "name": "first_mcp_tool_call_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_activation_state_organization_id_organization_id_fk": {
+          "name": "organization_activation_state_organization_id_organization_id_fk",
+          "tableFrom": "organization_activation_state",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_activation_state": {
+      "name": "project_activation_state",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "competitor_step_clicked_at": {
+          "name": "competitor_step_clicked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_card_dismissed_at": {
+          "name": "mcp_card_dismissed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ga4_card_dismissed_at": {
+          "name": "ga4_card_dismissed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_activation_state_project_id_projects_id_fk": {
+          "name": "project_activation_state_project_id_projects_id_fk",
+          "tableFrom": "project_activation_state",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_code": {
+          "name": "location_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2840
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "projects_one_default_per_organization_idx": {
+          "name": "projects_one_default_per_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"projects\".\"name\" = 'Default' AND \"projects\".\"domain\" IS NULL AND \"projects\".\"archived_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_organization_id_idx": {
+          "name": "projects_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_organization_id_organization_id_fk": {
+          "name": "projects_organization_id_organization_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rank_check_runs": {
+      "name": "rank_check_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "keywords_total": {
+          "name": "keywords_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "keywords_checked": {
+          "name": "keywords_checked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_subset_run": {
+          "name": "is_subset_run",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rank_check_runs_config_idx": {
+          "name": "rank_check_runs_config_idx",
+          "columns": [
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rank_check_runs_project_idx": {
+          "name": "rank_check_runs_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rank_check_runs_one_active_per_config_idx": {
+          "name": "rank_check_runs_one_active_per_config_idx",
+          "columns": [
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"rank_check_runs\".\"status\" IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rank_check_runs_config_id_rank_tracking_configs_id_fk": {
+          "name": "rank_check_runs_config_id_rank_tracking_configs_id_fk",
+          "tableFrom": "rank_check_runs",
+          "tableTo": "rank_tracking_configs",
+          "columnsFrom": [
+            "config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rank_check_runs_project_id_projects_id_fk": {
+          "name": "rank_check_runs_project_id_projects_id_fk",
+          "tableFrom": "rank_check_runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rank_snapshots": {
+      "name": "rank_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tracking_keyword_id": {
+          "name": "tracking_keyword_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device": {
+          "name": "device",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serp_features": {
+          "name": "serp_features",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "rank_snapshots_keyword_device_idx": {
+          "name": "rank_snapshots_keyword_device_idx",
+          "columns": [
+            {
+              "expression": "tracking_keyword_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rank_snapshots_run_keyword_device_idx": {
+          "name": "rank_snapshots_run_keyword_device_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tracking_keyword_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rank_snapshots_run_id_rank_check_runs_id_fk": {
+          "name": "rank_snapshots_run_id_rank_check_runs_id_fk",
+          "tableFrom": "rank_snapshots",
+          "tableTo": "rank_check_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rank_tracking_configs": {
+      "name": "rank_tracking_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_code": {
+          "name": "location_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2840
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "devices": {
+          "name": "devices",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'both'"
+        },
+        "serp_depth": {
+          "name": "serp_depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_interval": {
+          "name": "schedule_interval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'weekly'"
+        },
+        "location_name": {
+          "name": "location_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_check_at": {
+          "name": "next_check_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_skip_reason": {
+          "name": "last_skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "rank_tracking_configs_project_active_created_idx": {
+          "name": "rank_tracking_configs_project_active_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rank_tracking_configs_national_idx": {
+          "name": "rank_tracking_configs_national_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"rank_tracking_configs\".\"location_name\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rank_tracking_configs_local_idx": {
+          "name": "rank_tracking_configs_local_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"rank_tracking_configs\".\"location_name\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rank_tracking_configs_project_id_projects_id_fk": {
+          "name": "rank_tracking_configs_project_id_projects_id_fk",
+          "tableFrom": "rank_tracking_configs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rank_tracking_keywords": {
+      "name": "rank_tracking_keywords",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_volume": {
+          "name": "search_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keyword_difficulty": {
+          "name": "keyword_difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpc": {
+          "name": "cpc",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metrics_fetched_at": {
+          "name": "metrics_fetched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "rank_tracking_keywords_config_keyword_idx": {
+          "name": "rank_tracking_keywords_config_keyword_idx",
+          "columns": [
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "keyword",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rank_tracking_keywords_config_id_rank_tracking_configs_id_fk": {
+          "name": "rank_tracking_keywords_config_id_rank_tracking_configs_id_fk",
+          "tableFrom": "rank_tracking_keywords",
+          "tableTo": "rank_tracking_configs",
+          "columnsFrom": [
+            "config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_keyword_tag_assignments": {
+      "name": "saved_keyword_tag_assignments",
+      "schema": "",
+      "columns": {
+        "saved_keyword_id": {
+          "name": "saved_keyword_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "saved_keyword_tag_assignments_unique_idx": {
+          "name": "saved_keyword_tag_assignments_unique_idx",
+          "columns": [
+            {
+              "expression": "saved_keyword_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_keyword_tag_assignments_tag_idx": {
+          "name": "saved_keyword_tag_assignments_tag_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_keyword_tag_assignments_saved_keyword_id_saved_keywords_id_fk": {
+          "name": "saved_keyword_tag_assignments_saved_keyword_id_saved_keywords_id_fk",
+          "tableFrom": "saved_keyword_tag_assignments",
+          "tableTo": "saved_keywords",
+          "columnsFrom": [
+            "saved_keyword_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "saved_keyword_tag_assignments_tag_id_saved_keyword_tags_id_fk": {
+          "name": "saved_keyword_tag_assignments_tag_id_saved_keyword_tags_id_fk",
+          "tableFrom": "saved_keyword_tag_assignments",
+          "tableTo": "saved_keyword_tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_keyword_tags": {
+      "name": "saved_keyword_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "saved_keyword_tags_project_normalized_name_idx": {
+          "name": "saved_keyword_tags_project_normalized_name_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_keyword_tags_project_name_idx": {
+          "name": "saved_keyword_tags_project_name_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_keyword_tags_project_id_projects_id_fk": {
+          "name": "saved_keyword_tags_project_id_projects_id_fk",
+          "tableFrom": "saved_keyword_tags",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_keywords": {
+      "name": "saved_keywords",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_code": {
+          "name": "location_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2840
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "saved_keywords_unique_project_keyword_location_language": {
+          "name": "saved_keywords_unique_project_keyword_location_language",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "keyword",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_keywords_project_created_idx": {
+          "name": "saved_keywords_project_created_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_keywords_project_id_projects_id_fk": {
+          "name": "saved_keywords_project_id_projects_id_fk",
+          "tableFrom": "saved_keywords",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_onboarding_answers": {
+      "name": "user_onboarding_answers",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interested_features": {
+          "name": "interested_features",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "work_for": {
+          "name": "work_for",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_website_count": {
+          "name": "client_website_count",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "found_via": {
+          "name": "found_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_setup_intent": {
+          "name": "mcp_setup_intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gsc_nudge_dismissed_at": {
+          "name": "gsc_nudge_dismissed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "user_onboarding_answers_organization_idx": {
+          "name": "user_onboarding_answers_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_onboarding_answers_user_id_user_id_fk": {
+          "name": "user_onboarding_answers_user_id_user_id_fk",
+          "tableFrom": "user_onboarding_answers",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_onboarding_answers_organization_id_organization_id_fk": {
+          "name": "user_onboarding_answers_organization_id_organization_id_fk",
+          "tableFrom": "user_onboarding_answers",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_competitors": {
+      "name": "project_competitors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "project_competitors_project_domain_idx": {
+          "name": "project_competitors_project_domain_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_competitors_project_id_projects_id_fk": {
+          "name": "project_competitors_project_id_projects_id_fk",
+          "tableFrom": "project_competitors",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_context_sections": {
+      "name": "project_context_sections",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_context_sections_project_id_projects_id_fk": {
+          "name": "project_context_sections_project_id_projects_id_fk",
+          "tableFrom": "project_context_sections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_context_sections_project_id_key_pk": {
+          "name": "project_context_sections_project_id_key_pk",
+          "columns": [
+            "project_id",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_key_pages": {
+      "name": "project_key_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "project_key_pages_project_url_idx": {
+          "name": "project_key_pages_project_url_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_key_pages_project_id_projects_id_fk": {
+          "name": "project_key_pages_project_id_projects_id_fk",
+          "tableFrom": "project_key_pages",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_research_log": {
+      "name": "project_research_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_date": {
+          "name": "entry_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "project_research_log_project_date_idx": {
+          "name": "project_research_log_project_date_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entry_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_research_log_project_id_projects_id_fk": {
+          "name": "project_research_log_project_id_projects_id_fk",
+          "tableFrom": "project_research_log",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_issues": {
+      "name": "audit_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "audit_id": {
+          "name": "audit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_url": {
+          "name": "page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_type": {
+          "name": "issue_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "details_json": {
+          "name": "details_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_issues_audit_type_idx": {
+          "name": "audit_issues_audit_type_idx",
+          "columns": [
+            {
+              "expression": "audit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_issues_page_id_idx": {
+          "name": "audit_issues_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_issues_audit_id_audits_id_fk": {
+          "name": "audit_issues_audit_id_audits_id_fk",
+          "tableFrom": "audit_issues",
+          "tableTo": "audits",
+          "columnsFrom": [
+            "audit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_issues_page_id_audit_pages_id_fk": {
+          "name": "audit_issues_page_id_audit_pages_id_fk",
+          "tableFrom": "audit_issues",
+          "tableTo": "audit_pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_lighthouse_results": {
+      "name": "audit_lighthouse_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "audit_id": {
+          "name": "audit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strategy": {
+          "name": "strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performance_score": {
+          "name": "performance_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessibility_score": {
+          "name": "accessibility_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "best_practices_score": {
+          "name": "best_practices_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seo_score": {
+          "name": "seo_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lcp_ms": {
+          "name": "lcp_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cls": {
+          "name": "cls",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inp_ms": {
+          "name": "inp_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ttfb_ms": {
+          "name": "ttfb_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_size_bytes": {
+          "name": "payload_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_lighthouse_results_audit_id_idx": {
+          "name": "audit_lighthouse_results_audit_id_idx",
+          "columns": [
+            {
+              "expression": "audit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_lighthouse_results_page_id_idx": {
+          "name": "audit_lighthouse_results_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_lighthouse_results_audit_id_audits_id_fk": {
+          "name": "audit_lighthouse_results_audit_id_audits_id_fk",
+          "tableFrom": "audit_lighthouse_results",
+          "tableTo": "audits",
+          "columnsFrom": [
+            "audit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_lighthouse_results_page_id_audit_pages_id_fk": {
+          "name": "audit_lighthouse_results_page_id_audit_pages_id_fk",
+          "tableFrom": "audit_lighthouse_results",
+          "tableTo": "audit_pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_pages": {
+      "name": "audit_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "audit_id": {
+          "name": "audit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_url": {
+          "name": "canonical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "robots_meta": {
+          "name": "robots_meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_title": {
+          "name": "og_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_description": {
+          "name": "og_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_image": {
+          "name": "og_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "h1_count": {
+          "name": "h1_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "h2_count": {
+          "name": "h2_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "h3_count": {
+          "name": "h3_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "h4_count": {
+          "name": "h4_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "h5_count": {
+          "name": "h5_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "h6_count": {
+          "name": "h6_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "heading_order_json": {
+          "name": "heading_order_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "images_total": {
+          "name": "images_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "images_missing_alt": {
+          "name": "images_missing_alt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "images_json": {
+          "name": "images_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_link_count": {
+          "name": "internal_link_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "external_link_count": {
+          "name": "external_link_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "has_structured_data": {
+          "name": "has_structured_data",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hreflang_tags_json": {
+          "name": "hreflang_tags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_indexable": {
+          "name": "is_indexable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "x_robots_tag": {
+          "name": "x_robots_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "header_canonical_url": {
+          "name": "header_canonical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crawl_depth": {
+          "name": "crawl_depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "in_sitemap": {
+          "name": "in_sitemap",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetch_class": {
+          "name": "fetch_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ok'"
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_pages_audit_url_idx": {
+          "name": "audit_pages_audit_url_idx",
+          "columns": [
+            {
+              "expression": "audit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_pages_audit_id_audits_id_fk": {
+          "name": "audit_pages_audit_id_audits_id_fk",
+          "tableFrom": "audit_pages",
+          "tableTo": "audits",
+          "columnsFrom": [
+            "audit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audits": {
+      "name": "audits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_by_user_id": {
+          "name": "started_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_url": {
+          "name": "start_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "workflow_instance_id": {
+          "name": "workflow_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "pages_crawled": {
+          "name": "pages_crawled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pages_total": {
+          "name": "pages_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lighthouse_total": {
+          "name": "lighthouse_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lighthouse_completed": {
+          "name": "lighthouse_completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lighthouse_failed": {
+          "name": "lighthouse_failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_phase": {
+          "name": "current_phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'discovery'"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_detail": {
+          "name": "error_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_phase": {
+          "name": "failed_phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audits_project_id_idx": {
+          "name": "audits_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audits_started_by_user_id_idx": {
+          "name": "audits_started_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "started_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audits_project_id_projects_id_fk": {
+          "name": "audits_project_id_projects_id_fk",
+          "tableFrom": "audits",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sam_sessions": {
+      "name": "sam_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'New chat'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sam_sessions_project_updated_idx": {
+          "name": "sam_sessions_project_updated_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sam_sessions_project_id_projects_id_fk": {
+          "name": "sam_sessions_project_id_projects_id_fk",
+          "tableFrom": "sam_sessions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sam_sessions_user_id_user_id_fk": {
+          "name": "sam_sessions_user_id_user_id_fk",
+          "tableFrom": "sam_sessions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_accountId_providerId_idx": {
+          "name": "account_accountId_providerId_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apikey": {
+      "name": "apikey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 60000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 120
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "apikey_configId_idx": {
+          "name": "apikey_configId_idx",
+          "columns": [
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "apikey_referenceId_idx": {
+          "name": "apikey_referenceId_idx",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "apikey_key_idx": {
+          "name": "apikey_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_organizationId_userId_uidx": {
+          "name": "member_organizationId_userId_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_slug_uidx": {
+          "name": "organization_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "analytics_opted_out": {
+          "name": "analytics_opted_out",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_organization_id": {
+          "name": "last_active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verification_expiresAt_idx": {
+          "name": "verification_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_customer_status": {
+      "name": "billing_customer_status",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "is_paying": {
+          "name": "is_paying",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "paid_plan_id": {
+          "name": "paid_plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_plan_status": {
+          "name": "paid_plan_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_json": {
+          "name": "customer_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "billing_customer_status_organization_id_organization_id_fk": {
+          "name": "billing_customer_status_organization_id_organization_id_fk",
+          "tableFrom": "billing_customer_status",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ga4_connections": {
+      "name": "ga4_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_display_name": {
+          "name": "property_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_time_zone": {
+          "name": "property_time_zone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_currency_code": {
+          "name": "property_currency_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ga4_account_id": {
+          "name": "ga4_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_account_email": {
+          "name": "connected_account_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "ga4_connections_project_idx": {
+          "name": "ga4_connections_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ga4_connections_organization_idx": {
+          "name": "ga4_connections_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ga4_connections_connector_idx": {
+          "name": "ga4_connections_connector_idx",
+          "columns": [
+            {
+              "expression": "connected_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ga4_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ga4_connections_project_id_projects_id_fk": {
+          "name": "ga4_connections_project_id_projects_id_fk",
+          "tableFrom": "ga4_connections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ga4_connections_organization_id_organization_id_fk": {
+          "name": "ga4_connections_organization_id_organization_id_fk",
+          "tableFrom": "ga4_connections",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gsc_connections": {
+      "name": "gsc_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_url": {
+          "name": "site_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gsc_account_id": {
+          "name": "gsc_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_account_email": {
+          "name": "connected_account_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "gsc_connections_project_idx": {
+          "name": "gsc_connections_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gsc_connections_organization_idx": {
+          "name": "gsc_connections_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gsc_connections_project_id_projects_id_fk": {
+          "name": "gsc_connections_project_id_projects_id_fk",
+          "tableFrom": "gsc_connections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gsc_connections_organization_id_organization_id_fk": {
+          "name": "gsc_connections_organization_id_organization_id_fk",
+          "tableFrom": "gsc_connections",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telemetry_state": {
+      "name": "telemetry_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "install_id": {
+          "name": "install_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_version": {
+          "name": "last_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_tool_call_count": {
+          "name": "mcp_tool_call_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.first_party_signal_batches": {
+      "name": "first_party_signal_batches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_digest": {
+          "name": "payload_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "processing_lease_id": {
+          "name": "processing_lease_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_lease_expires_at": {
+          "name": "processing_lease_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "first_party_signal_batches_source_batch_idx": {
+          "name": "first_party_signal_batches_source_batch_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "first_party_signal_batches_source_date_idx": {
+          "name": "first_party_signal_batches_source_date_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "snapshot_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "first_party_signal_batches_retention_idx": {
+          "name": "first_party_signal_batches_retention_idx",
+          "columns": [
+            {
+              "expression": "snapshot_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "first_party_signal_batches_source_id_first_party_signal_sources_id_fk": {
+          "name": "first_party_signal_batches_source_id_first_party_signal_sources_id_fk",
+          "tableFrom": "first_party_signal_batches",
+          "tableTo": "first_party_signal_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "first_party_signal_batches_status_check": {
+          "name": "first_party_signal_batches_status_check",
+          "value": "\"first_party_signal_batches\".\"status\" IN ('pending', 'complete', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.first_party_signal_daily_aggregates": {
+      "name": "first_party_signal_daily_aggregates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "batch_receipt_id": {
+          "name": "batch_receipt_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processing_attempt_id": {
+          "name": "processing_attempt_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "landing_path": {
+          "name": "landing_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_started": {
+          "name": "search_started",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "search_completed": {
+          "name": "search_completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "search_no_results": {
+          "name": "search_no_results",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "registrations_completed": {
+          "name": "registrations_completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "checkout_started": {
+          "name": "checkout_started",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "payments_completed": {
+          "name": "payments_completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "first_party_signal_daily_batch_path_idx": {
+          "name": "first_party_signal_daily_batch_path_idx",
+          "columns": [
+            {
+              "expression": "batch_receipt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "processing_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "landing_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "first_party_signal_daily_aggregates_batch_receipt_id_first_party_signal_batches_id_fk": {
+          "name": "first_party_signal_daily_aggregates_batch_receipt_id_first_party_signal_batches_id_fk",
+          "tableFrom": "first_party_signal_daily_aggregates",
+          "tableTo": "first_party_signal_batches",
+          "columnsFrom": [
+            "batch_receipt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "first_party_signal_daily_nonnegative_check": {
+          "name": "first_party_signal_daily_nonnegative_check",
+          "value": "\"first_party_signal_daily_aggregates\".\"search_started\" >= 0 AND \"first_party_signal_daily_aggregates\".\"search_completed\" >= 0 AND \"first_party_signal_daily_aggregates\".\"search_no_results\" >= 0 AND \"first_party_signal_daily_aggregates\".\"registrations_completed\" >= 0 AND \"first_party_signal_daily_aggregates\".\"checkout_started\" >= 0 AND \"first_party_signal_daily_aggregates\".\"payments_completed\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.first_party_signal_source_paths": {
+      "name": "first_party_signal_source_paths",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "first_party_signal_source_paths_unique_idx": {
+          "name": "first_party_signal_source_paths_unique_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "first_party_signal_source_paths_source_id_first_party_signal_sources_id_fk": {
+          "name": "first_party_signal_source_paths_source_id_first_party_signal_sources_id_fk",
+          "tableFrom": "first_party_signal_source_paths",
+          "tableTo": "first_party_signal_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.first_party_signal_sources": {
+      "name": "first_party_signal_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_secret": {
+          "name": "encrypted_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hint": {
+          "name": "secret_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')"
+        }
+      },
+      "indexes": {
+        "first_party_signal_sources_project_idx": {
+          "name": "first_party_signal_sources_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "first_party_signal_sources_org_idx": {
+          "name": "first_party_signal_sources_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "first_party_signal_sources_project_id_projects_id_fk": {
+          "name": "first_party_signal_sources_project_id_projects_id_fk",
+          "tableFrom": "first_party_signal_sources",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "first_party_signal_sources_organization_id_organization_id_fk": {
+          "name": "first_party_signal_sources_organization_id_organization_id_fk",
+          "tableFrom": "first_party_signal_sources",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "first_party_signal_sources_created_by_user_id_user_id_fk": {
+          "name": "first_party_signal_sources_created_by_user_id_user_id_fk",
+          "tableFrom": "first_party_signal_sources",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle-pg/meta/_journal.json
+++ b/drizzle-pg/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1788524449688,
       "tag": "0023_clear_brood",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1788527301467,
+      "tag": "0024_first_party_retention_index",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle-pg/meta/_journal.json
+++ b/drizzle-pg/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1787773500453,
       "tag": "0022_third_supernaut",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1788524449688,
+      "tag": "0023_clear_brood",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/0045_silent_cassandra_nova.sql
+++ b/drizzle/0045_silent_cassandra_nova.sql
@@ -1,0 +1,61 @@
+CREATE TABLE `first_party_signal_batches` (
+	`id` text PRIMARY KEY NOT NULL,
+	`source_id` text NOT NULL,
+	`batch_id` text NOT NULL,
+	`snapshot_date` text NOT NULL,
+	`payload_digest` text NOT NULL,
+	`status` text DEFAULT 'pending' NOT NULL,
+	`processing_lease_id` text,
+	`processing_lease_expires_at` text,
+	`received_at` text DEFAULT (current_timestamp) NOT NULL,
+	`completed_at` text,
+	FOREIGN KEY (`source_id`) REFERENCES `first_party_signal_sources`(`id`) ON UPDATE no action ON DELETE cascade,
+	CONSTRAINT "first_party_signal_batches_status_check" CHECK("first_party_signal_batches"."status" IN ('pending', 'complete', 'failed'))
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `first_party_signal_batches_source_batch_idx` ON `first_party_signal_batches` (`source_id`,`batch_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `first_party_signal_batches_source_date_idx` ON `first_party_signal_batches` (`source_id`,`snapshot_date`);--> statement-breakpoint
+CREATE TABLE `first_party_signal_daily_aggregates` (
+	`id` text PRIMARY KEY NOT NULL,
+	`batch_receipt_id` text NOT NULL,
+	`processing_attempt_id` text NOT NULL,
+	`landing_path` text NOT NULL,
+	`search_started` integer DEFAULT 0 NOT NULL,
+	`search_completed` integer DEFAULT 0 NOT NULL,
+	`search_no_results` integer DEFAULT 0 NOT NULL,
+	`registrations_completed` integer DEFAULT 0 NOT NULL,
+	`checkout_started` integer DEFAULT 0 NOT NULL,
+	`payments_completed` integer DEFAULT 0 NOT NULL,
+	`received_at` text DEFAULT (current_timestamp) NOT NULL,
+	FOREIGN KEY (`batch_receipt_id`) REFERENCES `first_party_signal_batches`(`id`) ON UPDATE no action ON DELETE cascade,
+	CONSTRAINT "first_party_signal_daily_nonnegative_check" CHECK("first_party_signal_daily_aggregates"."search_started" >= 0 AND "first_party_signal_daily_aggregates"."search_completed" >= 0 AND "first_party_signal_daily_aggregates"."search_no_results" >= 0 AND "first_party_signal_daily_aggregates"."registrations_completed" >= 0 AND "first_party_signal_daily_aggregates"."checkout_started" >= 0 AND "first_party_signal_daily_aggregates"."payments_completed" >= 0)
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `first_party_signal_daily_batch_path_idx` ON `first_party_signal_daily_aggregates` (`batch_receipt_id`,`processing_attempt_id`,`landing_path`);--> statement-breakpoint
+CREATE TABLE `first_party_signal_source_paths` (
+	`id` text PRIMARY KEY NOT NULL,
+	`source_id` text NOT NULL,
+	`path` text NOT NULL,
+	`created_at` text DEFAULT (current_timestamp) NOT NULL,
+	FOREIGN KEY (`source_id`) REFERENCES `first_party_signal_sources`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `first_party_signal_source_paths_unique_idx` ON `first_party_signal_source_paths` (`source_id`,`path`);--> statement-breakpoint
+CREATE TABLE `first_party_signal_sources` (
+	`id` text PRIMARY KEY NOT NULL,
+	`project_id` text NOT NULL,
+	`organization_id` text NOT NULL,
+	`name` text NOT NULL,
+	`encrypted_secret` text NOT NULL,
+	`secret_hint` text NOT NULL,
+	`created_by_user_id` text,
+	`revoked_at` text,
+	`created_at` text DEFAULT (current_timestamp) NOT NULL,
+	`updated_at` text DEFAULT (current_timestamp) NOT NULL,
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`organization_id`) REFERENCES `organization`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`created_by_user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `first_party_signal_sources_project_idx` ON `first_party_signal_sources` (`project_id`);--> statement-breakpoint
+CREATE INDEX `first_party_signal_sources_org_idx` ON `first_party_signal_sources` (`organization_id`);

--- a/drizzle/0046_first_party_retention_index.sql
+++ b/drizzle/0046_first_party_retention_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX `first_party_signal_batches_retention_idx` ON `first_party_signal_batches` (`snapshot_date`,`id`);

--- a/drizzle/meta/0045_snapshot.json
+++ b/drizzle/meta/0045_snapshot.json
@@ -1,0 +1,4187 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "c75e41a7-2803-4f5c-af64-860c434ea7c6",
+  "prevId": "d57a4d79-cd2f-4415-8b8e-7aeafb6b5a06",
+  "tables": {
+    "backlink_snapshots": {
+      "name": "backlink_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "backlinks": {
+          "name": "backlinks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "referring_domains": {
+          "name": "referring_domains",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "broken_backlinks": {
+          "name": "broken_backlinks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "new_backlinks": {
+          "name": "new_backlinks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lost_backlinks": {
+          "name": "lost_backlinks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "new_referring_domains": {
+          "name": "new_referring_domains",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lost_referring_domains": {
+          "name": "lost_referring_domains",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "backlink_snapshots_project_captured_idx": {
+          "name": "backlink_snapshots_project_captured_idx",
+          "columns": [
+            "project_id",
+            "captured_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "backlink_snapshots_project_id_projects_id_fk": {
+          "name": "backlink_snapshots_project_id_projects_id_fk",
+          "tableFrom": "backlink_snapshots",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "keyword_metrics": {
+      "name": "keyword_metrics",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_code": {
+          "name": "location_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "search_volume": {
+          "name": "search_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cpc": {
+          "name": "cpc",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "competition": {
+          "name": "competition",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "keyword_difficulty": {
+          "name": "keyword_difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "intent": {
+          "name": "intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "monthly_searches": {
+          "name": "monthly_searches",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "keyword_metrics_unique_project_keyword_location_language": {
+          "name": "keyword_metrics_unique_project_keyword_location_language",
+          "columns": [
+            "project_id",
+            "keyword",
+            "location_code",
+            "language_code"
+          ],
+          "isUnique": true
+        },
+        "keyword_metrics_lookup_idx": {
+          "name": "keyword_metrics_lookup_idx",
+          "columns": [
+            "project_id",
+            "keyword",
+            "location_code",
+            "language_code",
+            "fetched_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "keyword_metrics_project_id_projects_id_fk": {
+          "name": "keyword_metrics_project_id_projects_id_fk",
+          "tableFrom": "keyword_metrics",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_activation_state": {
+      "name": "organization_activation_state",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_mcp_authorized_at": {
+          "name": "first_mcp_authorized_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_mcp_tool_call_at": {
+          "name": "first_mcp_tool_call_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_activation_state_organization_id_organization_id_fk": {
+          "name": "organization_activation_state_organization_id_organization_id_fk",
+          "tableFrom": "organization_activation_state",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_activation_state": {
+      "name": "project_activation_state",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "competitor_step_clicked_at": {
+          "name": "competitor_step_clicked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcp_card_dismissed_at": {
+          "name": "mcp_card_dismissed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ga4_card_dismissed_at": {
+          "name": "ga4_card_dismissed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_activation_state_project_id_projects_id_fk": {
+          "name": "project_activation_state_project_id_projects_id_fk",
+          "tableFrom": "project_activation_state",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location_code": {
+          "name": "location_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2840
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_one_default_per_organization_idx": {
+          "name": "projects_one_default_per_organization_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true,
+          "where": "\"projects\".\"name\" = 'Default' AND \"projects\".\"domain\" IS NULL AND \"projects\".\"archived_at\" IS NULL"
+        },
+        "projects_organization_id_idx": {
+          "name": "projects_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "projects_organization_id_organization_id_fk": {
+          "name": "projects_organization_id_organization_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rank_check_runs": {
+      "name": "rank_check_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "keywords_total": {
+          "name": "keywords_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "keywords_checked": {
+          "name": "keywords_checked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_subset_run": {
+          "name": "is_subset_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rank_check_runs_config_idx": {
+          "name": "rank_check_runs_config_idx",
+          "columns": [
+            "config_id",
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "rank_check_runs_project_idx": {
+          "name": "rank_check_runs_project_idx",
+          "columns": [
+            "project_id",
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "rank_check_runs_one_active_per_config_idx": {
+          "name": "rank_check_runs_one_active_per_config_idx",
+          "columns": [
+            "config_id"
+          ],
+          "isUnique": true,
+          "where": "\"rank_check_runs\".\"status\" IN ('pending', 'running')"
+        }
+      },
+      "foreignKeys": {
+        "rank_check_runs_config_id_rank_tracking_configs_id_fk": {
+          "name": "rank_check_runs_config_id_rank_tracking_configs_id_fk",
+          "tableFrom": "rank_check_runs",
+          "tableTo": "rank_tracking_configs",
+          "columnsFrom": [
+            "config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rank_check_runs_project_id_projects_id_fk": {
+          "name": "rank_check_runs_project_id_projects_id_fk",
+          "tableFrom": "rank_check_runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rank_snapshots": {
+      "name": "rank_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tracking_keyword_id": {
+          "name": "tracking_keyword_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device": {
+          "name": "device",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "serp_features": {
+          "name": "serp_features",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "rank_snapshots_keyword_device_idx": {
+          "name": "rank_snapshots_keyword_device_idx",
+          "columns": [
+            "tracking_keyword_id",
+            "device",
+            "checked_at"
+          ],
+          "isUnique": false
+        },
+        "rank_snapshots_run_keyword_device_idx": {
+          "name": "rank_snapshots_run_keyword_device_idx",
+          "columns": [
+            "run_id",
+            "tracking_keyword_id",
+            "device"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "rank_snapshots_run_id_rank_check_runs_id_fk": {
+          "name": "rank_snapshots_run_id_rank_check_runs_id_fk",
+          "tableFrom": "rank_snapshots",
+          "tableTo": "rank_check_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rank_tracking_configs": {
+      "name": "rank_tracking_configs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_code": {
+          "name": "location_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2840
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "devices": {
+          "name": "devices",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'both'"
+        },
+        "serp_depth": {
+          "name": "serp_depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_interval": {
+          "name": "schedule_interval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'weekly'"
+        },
+        "location_name": {
+          "name": "location_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_check_at": {
+          "name": "next_check_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_skip_reason": {
+          "name": "last_skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "rank_tracking_configs_project_active_created_idx": {
+          "name": "rank_tracking_configs_project_active_created_idx",
+          "columns": [
+            "project_id",
+            "is_active",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "rank_tracking_configs_national_idx": {
+          "name": "rank_tracking_configs_national_idx",
+          "columns": [
+            "project_id",
+            "domain",
+            "location_code"
+          ],
+          "isUnique": true,
+          "where": "\"rank_tracking_configs\".\"location_name\" IS NULL"
+        },
+        "rank_tracking_configs_local_idx": {
+          "name": "rank_tracking_configs_local_idx",
+          "columns": [
+            "project_id",
+            "domain",
+            "location_code",
+            "location_name"
+          ],
+          "isUnique": true,
+          "where": "\"rank_tracking_configs\".\"location_name\" IS NOT NULL"
+        }
+      },
+      "foreignKeys": {
+        "rank_tracking_configs_project_id_projects_id_fk": {
+          "name": "rank_tracking_configs_project_id_projects_id_fk",
+          "tableFrom": "rank_tracking_configs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rank_tracking_keywords": {
+      "name": "rank_tracking_keywords",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "search_volume": {
+          "name": "search_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "keyword_difficulty": {
+          "name": "keyword_difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cpc": {
+          "name": "cpc",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metrics_fetched_at": {
+          "name": "metrics_fetched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "rank_tracking_keywords_config_keyword_idx": {
+          "name": "rank_tracking_keywords_config_keyword_idx",
+          "columns": [
+            "config_id",
+            "keyword"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "rank_tracking_keywords_config_id_rank_tracking_configs_id_fk": {
+          "name": "rank_tracking_keywords_config_id_rank_tracking_configs_id_fk",
+          "tableFrom": "rank_tracking_keywords",
+          "tableTo": "rank_tracking_configs",
+          "columnsFrom": [
+            "config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "saved_keyword_tag_assignments": {
+      "name": "saved_keyword_tag_assignments",
+      "columns": {
+        "saved_keyword_id": {
+          "name": "saved_keyword_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "saved_keyword_tag_assignments_unique_idx": {
+          "name": "saved_keyword_tag_assignments_unique_idx",
+          "columns": [
+            "saved_keyword_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        },
+        "saved_keyword_tag_assignments_tag_idx": {
+          "name": "saved_keyword_tag_assignments_tag_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "saved_keyword_tag_assignments_saved_keyword_id_saved_keywords_id_fk": {
+          "name": "saved_keyword_tag_assignments_saved_keyword_id_saved_keywords_id_fk",
+          "tableFrom": "saved_keyword_tag_assignments",
+          "tableTo": "saved_keywords",
+          "columnsFrom": [
+            "saved_keyword_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "saved_keyword_tag_assignments_tag_id_saved_keyword_tags_id_fk": {
+          "name": "saved_keyword_tag_assignments_tag_id_saved_keyword_tags_id_fk",
+          "tableFrom": "saved_keyword_tag_assignments",
+          "tableTo": "saved_keyword_tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "saved_keyword_tags": {
+      "name": "saved_keyword_tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "saved_keyword_tags_project_normalized_name_idx": {
+          "name": "saved_keyword_tags_project_normalized_name_idx",
+          "columns": [
+            "project_id",
+            "normalized_name"
+          ],
+          "isUnique": true
+        },
+        "saved_keyword_tags_project_name_idx": {
+          "name": "saved_keyword_tags_project_name_idx",
+          "columns": [
+            "project_id",
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "saved_keyword_tags_project_id_projects_id_fk": {
+          "name": "saved_keyword_tags_project_id_projects_id_fk",
+          "tableFrom": "saved_keyword_tags",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "saved_keywords": {
+      "name": "saved_keywords",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_code": {
+          "name": "location_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2840
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "saved_keywords_unique_project_keyword_location_language": {
+          "name": "saved_keywords_unique_project_keyword_location_language",
+          "columns": [
+            "project_id",
+            "keyword",
+            "location_code",
+            "language_code"
+          ],
+          "isUnique": true
+        },
+        "saved_keywords_project_created_idx": {
+          "name": "saved_keywords_project_created_idx",
+          "columns": [
+            "project_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "saved_keywords_project_id_projects_id_fk": {
+          "name": "saved_keywords_project_id_projects_id_fk",
+          "tableFrom": "saved_keywords",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_onboarding_answers": {
+      "name": "user_onboarding_answers",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "interested_features": {
+          "name": "interested_features",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "work_for": {
+          "name": "work_for",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_website_count": {
+          "name": "client_website_count",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "found_via": {
+          "name": "found_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcp_setup_intent": {
+          "name": "mcp_setup_intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gsc_nudge_dismissed_at": {
+          "name": "gsc_nudge_dismissed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "user_onboarding_answers_organization_idx": {
+          "name": "user_onboarding_answers_organization_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_onboarding_answers_user_id_user_id_fk": {
+          "name": "user_onboarding_answers_user_id_user_id_fk",
+          "tableFrom": "user_onboarding_answers",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_onboarding_answers_organization_id_organization_id_fk": {
+          "name": "user_onboarding_answers_organization_id_organization_id_fk",
+          "tableFrom": "user_onboarding_answers",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_competitors": {
+      "name": "project_competitors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "project_competitors_project_domain_idx": {
+          "name": "project_competitors_project_domain_idx",
+          "columns": [
+            "project_id",
+            "domain"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "project_competitors_project_id_projects_id_fk": {
+          "name": "project_competitors_project_id_projects_id_fk",
+          "tableFrom": "project_competitors",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_context_sections": {
+      "name": "project_context_sections",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_context_sections_project_id_projects_id_fk": {
+          "name": "project_context_sections_project_id_projects_id_fk",
+          "tableFrom": "project_context_sections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_context_sections_project_id_key_pk": {
+          "columns": [
+            "project_id",
+            "key"
+          ],
+          "name": "project_context_sections_project_id_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_key_pages": {
+      "name": "project_key_pages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "project_key_pages_project_url_idx": {
+          "name": "project_key_pages_project_url_idx",
+          "columns": [
+            "project_id",
+            "url"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "project_key_pages_project_id_projects_id_fk": {
+          "name": "project_key_pages_project_id_projects_id_fk",
+          "tableFrom": "project_key_pages",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_research_log": {
+      "name": "project_research_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entry_date": {
+          "name": "entry_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ','now'))"
+        }
+      },
+      "indexes": {
+        "project_research_log_project_date_idx": {
+          "name": "project_research_log_project_date_idx",
+          "columns": [
+            "project_id",
+            "entry_date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "project_research_log_project_id_projects_id_fk": {
+          "name": "project_research_log_project_id_projects_id_fk",
+          "tableFrom": "project_research_log",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_issues": {
+      "name": "audit_issues",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audit_id": {
+          "name": "audit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "page_url": {
+          "name": "page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issue_type": {
+          "name": "issue_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'info'"
+        },
+        "details_json": {
+          "name": "details_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "audit_issues_audit_type_idx": {
+          "name": "audit_issues_audit_type_idx",
+          "columns": [
+            "audit_id",
+            "issue_type"
+          ],
+          "isUnique": false
+        },
+        "audit_issues_page_id_idx": {
+          "name": "audit_issues_page_id_idx",
+          "columns": [
+            "page_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audit_issues_audit_id_audits_id_fk": {
+          "name": "audit_issues_audit_id_audits_id_fk",
+          "tableFrom": "audit_issues",
+          "tableTo": "audits",
+          "columnsFrom": [
+            "audit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_issues_page_id_audit_pages_id_fk": {
+          "name": "audit_issues_page_id_audit_pages_id_fk",
+          "tableFrom": "audit_issues",
+          "tableTo": "audit_pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_lighthouse_results": {
+      "name": "audit_lighthouse_results",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audit_id": {
+          "name": "audit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "strategy": {
+          "name": "strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "performance_score": {
+          "name": "performance_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accessibility_score": {
+          "name": "accessibility_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "best_practices_score": {
+          "name": "best_practices_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seo_score": {
+          "name": "seo_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lcp_ms": {
+          "name": "lcp_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cls": {
+          "name": "cls",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inp_ms": {
+          "name": "inp_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ttfb_ms": {
+          "name": "ttfb_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload_size_bytes": {
+          "name": "payload_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "audit_lighthouse_results_audit_id_idx": {
+          "name": "audit_lighthouse_results_audit_id_idx",
+          "columns": [
+            "audit_id"
+          ],
+          "isUnique": false
+        },
+        "audit_lighthouse_results_page_id_idx": {
+          "name": "audit_lighthouse_results_page_id_idx",
+          "columns": [
+            "page_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audit_lighthouse_results_audit_id_audits_id_fk": {
+          "name": "audit_lighthouse_results_audit_id_audits_id_fk",
+          "tableFrom": "audit_lighthouse_results",
+          "tableTo": "audits",
+          "columnsFrom": [
+            "audit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_lighthouse_results_page_id_audit_pages_id_fk": {
+          "name": "audit_lighthouse_results_page_id_audit_pages_id_fk",
+          "tableFrom": "audit_lighthouse_results",
+          "tableTo": "audit_pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_pages": {
+      "name": "audit_pages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audit_id": {
+          "name": "audit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "canonical_url": {
+          "name": "canonical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "robots_meta": {
+          "name": "robots_meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_title": {
+          "name": "og_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_description": {
+          "name": "og_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_image": {
+          "name": "og_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "h1_count": {
+          "name": "h1_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "h2_count": {
+          "name": "h2_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "h3_count": {
+          "name": "h3_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "h4_count": {
+          "name": "h4_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "h5_count": {
+          "name": "h5_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "h6_count": {
+          "name": "h6_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "heading_order_json": {
+          "name": "heading_order_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "images_total": {
+          "name": "images_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "images_missing_alt": {
+          "name": "images_missing_alt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "images_json": {
+          "name": "images_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "internal_link_count": {
+          "name": "internal_link_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "external_link_count": {
+          "name": "external_link_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "has_structured_data": {
+          "name": "has_structured_data",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "hreflang_tags_json": {
+          "name": "hreflang_tags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_indexable": {
+          "name": "is_indexable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "x_robots_tag": {
+          "name": "x_robots_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "header_canonical_url": {
+          "name": "header_canonical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "crawl_depth": {
+          "name": "crawl_depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "in_sitemap": {
+          "name": "in_sitemap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fetch_class": {
+          "name": "fetch_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ok'"
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "audit_pages_audit_url_idx": {
+          "name": "audit_pages_audit_url_idx",
+          "columns": [
+            "audit_id",
+            "url"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audit_pages_audit_id_audits_id_fk": {
+          "name": "audit_pages_audit_id_audits_id_fk",
+          "tableFrom": "audit_pages",
+          "tableTo": "audits",
+          "columnsFrom": [
+            "audit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audits": {
+      "name": "audits",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_by_user_id": {
+          "name": "started_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_url": {
+          "name": "start_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "workflow_instance_id": {
+          "name": "workflow_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "pages_crawled": {
+          "name": "pages_crawled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "pages_total": {
+          "name": "pages_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lighthouse_total": {
+          "name": "lighthouse_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lighthouse_completed": {
+          "name": "lighthouse_completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lighthouse_failed": {
+          "name": "lighthouse_failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "current_phase": {
+          "name": "current_phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'discovery'"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_detail": {
+          "name": "error_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failed_phase": {
+          "name": "failed_phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "audits_project_id_idx": {
+          "name": "audits_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "audits_started_by_user_id_idx": {
+          "name": "audits_started_by_user_id_idx",
+          "columns": [
+            "started_by_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audits_project_id_projects_id_fk": {
+          "name": "audits_project_id_projects_id_fk",
+          "tableFrom": "audits",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sam_sessions": {
+      "name": "sam_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'New chat'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sam_sessions_project_updated_idx": {
+          "name": "sam_sessions_project_updated_idx",
+          "columns": [
+            "project_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sam_sessions_project_id_projects_id_fk": {
+          "name": "sam_sessions_project_id_projects_id_fk",
+          "tableFrom": "sam_sessions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sam_sessions_user_id_user_id_fk": {
+          "name": "sam_sessions_user_id_user_id_fk",
+          "tableFrom": "sam_sessions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "account_accountId_providerId_idx": {
+          "name": "account_accountId_providerId_idx",
+          "columns": [
+            "account_id",
+            "provider_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 60000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 120
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "apikey_configId_idx": {
+          "name": "apikey_configId_idx",
+          "columns": [
+            "config_id"
+          ],
+          "isUnique": false
+        },
+        "apikey_referenceId_idx": {
+          "name": "apikey_referenceId_idx",
+          "columns": [
+            "reference_id"
+          ],
+          "isUnique": false
+        },
+        "apikey_key_idx": {
+          "name": "apikey_key_idx",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invitation": {
+      "name": "invitation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "member": {
+      "name": "member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "member_organizationId_userId_uidx": {
+          "name": "member_organizationId_userId_uidx",
+          "columns": [
+            "organization_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization": {
+      "name": "organization",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "organization_slug_uidx": {
+          "name": "organization_slug_uidx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "analytics_opted_out": {
+          "name": "analytics_opted_out",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_active_organization_id": {
+          "name": "last_active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        },
+        "verification_expiresAt_idx": {
+          "name": "verification_expiresAt_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "billing_customer_status": {
+      "name": "billing_customer_status",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_paying": {
+          "name": "is_paying",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "paid_plan_id": {
+          "name": "paid_plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "paid_plan_status": {
+          "name": "paid_plan_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "customer_json": {
+          "name": "customer_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "billing_customer_status_organization_id_organization_id_fk": {
+          "name": "billing_customer_status_organization_id_organization_id_fk",
+          "tableFrom": "billing_customer_status",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ga4_connections": {
+      "name": "ga4_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "property_display_name": {
+          "name": "property_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "property_time_zone": {
+          "name": "property_time_zone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "property_currency_code": {
+          "name": "property_currency_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ga4_account_id": {
+          "name": "ga4_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connected_account_email": {
+          "name": "connected_account_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "ga4_connections_project_idx": {
+          "name": "ga4_connections_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": true
+        },
+        "ga4_connections_organization_idx": {
+          "name": "ga4_connections_organization_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "ga4_connections_connector_idx": {
+          "name": "ga4_connections_connector_idx",
+          "columns": [
+            "connected_by_user_id",
+            "ga4_account_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "ga4_connections_project_id_projects_id_fk": {
+          "name": "ga4_connections_project_id_projects_id_fk",
+          "tableFrom": "ga4_connections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ga4_connections_organization_id_organization_id_fk": {
+          "name": "ga4_connections_organization_id_organization_id_fk",
+          "tableFrom": "ga4_connections",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gsc_connections": {
+      "name": "gsc_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "site_url": {
+          "name": "site_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gsc_account_id": {
+          "name": "gsc_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connected_account_email": {
+          "name": "connected_account_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "gsc_connections_project_idx": {
+          "name": "gsc_connections_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": true
+        },
+        "gsc_connections_organization_idx": {
+          "name": "gsc_connections_organization_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gsc_connections_project_id_projects_id_fk": {
+          "name": "gsc_connections_project_id_projects_id_fk",
+          "tableFrom": "gsc_connections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gsc_connections_organization_id_organization_id_fk": {
+          "name": "gsc_connections_organization_id_organization_id_fk",
+          "tableFrom": "gsc_connections",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "telemetry_state": {
+      "name": "telemetry_state",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "install_id": {
+          "name": "install_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_version": {
+          "name": "last_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcp_tool_call_count": {
+          "name": "mcp_tool_call_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "first_party_signal_batches": {
+      "name": "first_party_signal_batches",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload_digest": {
+          "name": "payload_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "processing_lease_id": {
+          "name": "processing_lease_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "processing_lease_expires_at": {
+          "name": "processing_lease_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "first_party_signal_batches_source_batch_idx": {
+          "name": "first_party_signal_batches_source_batch_idx",
+          "columns": [
+            "source_id",
+            "batch_id"
+          ],
+          "isUnique": true
+        },
+        "first_party_signal_batches_source_date_idx": {
+          "name": "first_party_signal_batches_source_date_idx",
+          "columns": [
+            "source_id",
+            "snapshot_date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "first_party_signal_batches_source_id_first_party_signal_sources_id_fk": {
+          "name": "first_party_signal_batches_source_id_first_party_signal_sources_id_fk",
+          "tableFrom": "first_party_signal_batches",
+          "tableTo": "first_party_signal_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "first_party_signal_batches_status_check": {
+          "name": "first_party_signal_batches_status_check",
+          "value": "\"first_party_signal_batches\".\"status\" IN ('pending', 'complete', 'failed')"
+        }
+      }
+    },
+    "first_party_signal_daily_aggregates": {
+      "name": "first_party_signal_daily_aggregates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "batch_receipt_id": {
+          "name": "batch_receipt_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "processing_attempt_id": {
+          "name": "processing_attempt_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "landing_path": {
+          "name": "landing_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "search_started": {
+          "name": "search_started",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "search_completed": {
+          "name": "search_completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "search_no_results": {
+          "name": "search_no_results",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "registrations_completed": {
+          "name": "registrations_completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "checkout_started": {
+          "name": "checkout_started",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "payments_completed": {
+          "name": "payments_completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "first_party_signal_daily_batch_path_idx": {
+          "name": "first_party_signal_daily_batch_path_idx",
+          "columns": [
+            "batch_receipt_id",
+            "processing_attempt_id",
+            "landing_path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "first_party_signal_daily_aggregates_batch_receipt_id_first_party_signal_batches_id_fk": {
+          "name": "first_party_signal_daily_aggregates_batch_receipt_id_first_party_signal_batches_id_fk",
+          "tableFrom": "first_party_signal_daily_aggregates",
+          "tableTo": "first_party_signal_batches",
+          "columnsFrom": [
+            "batch_receipt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "first_party_signal_daily_nonnegative_check": {
+          "name": "first_party_signal_daily_nonnegative_check",
+          "value": "\"first_party_signal_daily_aggregates\".\"search_started\" >= 0 AND \"first_party_signal_daily_aggregates\".\"search_completed\" >= 0 AND \"first_party_signal_daily_aggregates\".\"search_no_results\" >= 0 AND \"first_party_signal_daily_aggregates\".\"registrations_completed\" >= 0 AND \"first_party_signal_daily_aggregates\".\"checkout_started\" >= 0 AND \"first_party_signal_daily_aggregates\".\"payments_completed\" >= 0"
+        }
+      }
+    },
+    "first_party_signal_source_paths": {
+      "name": "first_party_signal_source_paths",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "first_party_signal_source_paths_unique_idx": {
+          "name": "first_party_signal_source_paths_unique_idx",
+          "columns": [
+            "source_id",
+            "path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "first_party_signal_source_paths_source_id_first_party_signal_sources_id_fk": {
+          "name": "first_party_signal_source_paths_source_id_first_party_signal_sources_id_fk",
+          "tableFrom": "first_party_signal_source_paths",
+          "tableTo": "first_party_signal_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "first_party_signal_sources": {
+      "name": "first_party_signal_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_secret": {
+          "name": "encrypted_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_hint": {
+          "name": "secret_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "first_party_signal_sources_project_idx": {
+          "name": "first_party_signal_sources_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": true
+        },
+        "first_party_signal_sources_org_idx": {
+          "name": "first_party_signal_sources_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "first_party_signal_sources_project_id_projects_id_fk": {
+          "name": "first_party_signal_sources_project_id_projects_id_fk",
+          "tableFrom": "first_party_signal_sources",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "first_party_signal_sources_organization_id_organization_id_fk": {
+          "name": "first_party_signal_sources_organization_id_organization_id_fk",
+          "tableFrom": "first_party_signal_sources",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "first_party_signal_sources_created_by_user_id_user_id_fk": {
+          "name": "first_party_signal_sources_created_by_user_id_user_id_fk",
+          "tableFrom": "first_party_signal_sources",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/0046_snapshot.json
+++ b/drizzle/meta/0046_snapshot.json
@@ -1,0 +1,4195 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "42f5da9b-c05c-4d3a-81c1-7f96347390b3",
+  "prevId": "c75e41a7-2803-4f5c-af64-860c434ea7c6",
+  "tables": {
+    "backlink_snapshots": {
+      "name": "backlink_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "backlinks": {
+          "name": "backlinks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "referring_domains": {
+          "name": "referring_domains",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "broken_backlinks": {
+          "name": "broken_backlinks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "new_backlinks": {
+          "name": "new_backlinks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lost_backlinks": {
+          "name": "lost_backlinks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "new_referring_domains": {
+          "name": "new_referring_domains",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lost_referring_domains": {
+          "name": "lost_referring_domains",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "backlink_snapshots_project_captured_idx": {
+          "name": "backlink_snapshots_project_captured_idx",
+          "columns": [
+            "project_id",
+            "captured_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "backlink_snapshots_project_id_projects_id_fk": {
+          "name": "backlink_snapshots_project_id_projects_id_fk",
+          "tableFrom": "backlink_snapshots",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "keyword_metrics": {
+      "name": "keyword_metrics",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_code": {
+          "name": "location_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "search_volume": {
+          "name": "search_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cpc": {
+          "name": "cpc",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "competition": {
+          "name": "competition",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "keyword_difficulty": {
+          "name": "keyword_difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "intent": {
+          "name": "intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "monthly_searches": {
+          "name": "monthly_searches",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "keyword_metrics_unique_project_keyword_location_language": {
+          "name": "keyword_metrics_unique_project_keyword_location_language",
+          "columns": [
+            "project_id",
+            "keyword",
+            "location_code",
+            "language_code"
+          ],
+          "isUnique": true
+        },
+        "keyword_metrics_lookup_idx": {
+          "name": "keyword_metrics_lookup_idx",
+          "columns": [
+            "project_id",
+            "keyword",
+            "location_code",
+            "language_code",
+            "fetched_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "keyword_metrics_project_id_projects_id_fk": {
+          "name": "keyword_metrics_project_id_projects_id_fk",
+          "tableFrom": "keyword_metrics",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_activation_state": {
+      "name": "organization_activation_state",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_mcp_authorized_at": {
+          "name": "first_mcp_authorized_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_mcp_tool_call_at": {
+          "name": "first_mcp_tool_call_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_activation_state_organization_id_organization_id_fk": {
+          "name": "organization_activation_state_organization_id_organization_id_fk",
+          "tableFrom": "organization_activation_state",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_activation_state": {
+      "name": "project_activation_state",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "competitor_step_clicked_at": {
+          "name": "competitor_step_clicked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcp_card_dismissed_at": {
+          "name": "mcp_card_dismissed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ga4_card_dismissed_at": {
+          "name": "ga4_card_dismissed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_activation_state_project_id_projects_id_fk": {
+          "name": "project_activation_state_project_id_projects_id_fk",
+          "tableFrom": "project_activation_state",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location_code": {
+          "name": "location_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2840
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_one_default_per_organization_idx": {
+          "name": "projects_one_default_per_organization_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true,
+          "where": "\"projects\".\"name\" = 'Default' AND \"projects\".\"domain\" IS NULL AND \"projects\".\"archived_at\" IS NULL"
+        },
+        "projects_organization_id_idx": {
+          "name": "projects_organization_id_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "projects_organization_id_organization_id_fk": {
+          "name": "projects_organization_id_organization_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rank_check_runs": {
+      "name": "rank_check_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "keywords_total": {
+          "name": "keywords_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "keywords_checked": {
+          "name": "keywords_checked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_subset_run": {
+          "name": "is_subset_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rank_check_runs_config_idx": {
+          "name": "rank_check_runs_config_idx",
+          "columns": [
+            "config_id",
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "rank_check_runs_project_idx": {
+          "name": "rank_check_runs_project_idx",
+          "columns": [
+            "project_id",
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "rank_check_runs_one_active_per_config_idx": {
+          "name": "rank_check_runs_one_active_per_config_idx",
+          "columns": [
+            "config_id"
+          ],
+          "isUnique": true,
+          "where": "\"rank_check_runs\".\"status\" IN ('pending', 'running')"
+        }
+      },
+      "foreignKeys": {
+        "rank_check_runs_config_id_rank_tracking_configs_id_fk": {
+          "name": "rank_check_runs_config_id_rank_tracking_configs_id_fk",
+          "tableFrom": "rank_check_runs",
+          "tableTo": "rank_tracking_configs",
+          "columnsFrom": [
+            "config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rank_check_runs_project_id_projects_id_fk": {
+          "name": "rank_check_runs_project_id_projects_id_fk",
+          "tableFrom": "rank_check_runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rank_snapshots": {
+      "name": "rank_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tracking_keyword_id": {
+          "name": "tracking_keyword_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device": {
+          "name": "device",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "serp_features": {
+          "name": "serp_features",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "rank_snapshots_keyword_device_idx": {
+          "name": "rank_snapshots_keyword_device_idx",
+          "columns": [
+            "tracking_keyword_id",
+            "device",
+            "checked_at"
+          ],
+          "isUnique": false
+        },
+        "rank_snapshots_run_keyword_device_idx": {
+          "name": "rank_snapshots_run_keyword_device_idx",
+          "columns": [
+            "run_id",
+            "tracking_keyword_id",
+            "device"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "rank_snapshots_run_id_rank_check_runs_id_fk": {
+          "name": "rank_snapshots_run_id_rank_check_runs_id_fk",
+          "tableFrom": "rank_snapshots",
+          "tableTo": "rank_check_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rank_tracking_configs": {
+      "name": "rank_tracking_configs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_code": {
+          "name": "location_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2840
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "devices": {
+          "name": "devices",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'both'"
+        },
+        "serp_depth": {
+          "name": "serp_depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_interval": {
+          "name": "schedule_interval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'weekly'"
+        },
+        "location_name": {
+          "name": "location_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_check_at": {
+          "name": "next_check_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_skip_reason": {
+          "name": "last_skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "rank_tracking_configs_project_active_created_idx": {
+          "name": "rank_tracking_configs_project_active_created_idx",
+          "columns": [
+            "project_id",
+            "is_active",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "rank_tracking_configs_national_idx": {
+          "name": "rank_tracking_configs_national_idx",
+          "columns": [
+            "project_id",
+            "domain",
+            "location_code"
+          ],
+          "isUnique": true,
+          "where": "\"rank_tracking_configs\".\"location_name\" IS NULL"
+        },
+        "rank_tracking_configs_local_idx": {
+          "name": "rank_tracking_configs_local_idx",
+          "columns": [
+            "project_id",
+            "domain",
+            "location_code",
+            "location_name"
+          ],
+          "isUnique": true,
+          "where": "\"rank_tracking_configs\".\"location_name\" IS NOT NULL"
+        }
+      },
+      "foreignKeys": {
+        "rank_tracking_configs_project_id_projects_id_fk": {
+          "name": "rank_tracking_configs_project_id_projects_id_fk",
+          "tableFrom": "rank_tracking_configs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rank_tracking_keywords": {
+      "name": "rank_tracking_keywords",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "search_volume": {
+          "name": "search_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "keyword_difficulty": {
+          "name": "keyword_difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cpc": {
+          "name": "cpc",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metrics_fetched_at": {
+          "name": "metrics_fetched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "rank_tracking_keywords_config_keyword_idx": {
+          "name": "rank_tracking_keywords_config_keyword_idx",
+          "columns": [
+            "config_id",
+            "keyword"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "rank_tracking_keywords_config_id_rank_tracking_configs_id_fk": {
+          "name": "rank_tracking_keywords_config_id_rank_tracking_configs_id_fk",
+          "tableFrom": "rank_tracking_keywords",
+          "tableTo": "rank_tracking_configs",
+          "columnsFrom": [
+            "config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "saved_keyword_tag_assignments": {
+      "name": "saved_keyword_tag_assignments",
+      "columns": {
+        "saved_keyword_id": {
+          "name": "saved_keyword_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "saved_keyword_tag_assignments_unique_idx": {
+          "name": "saved_keyword_tag_assignments_unique_idx",
+          "columns": [
+            "saved_keyword_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        },
+        "saved_keyword_tag_assignments_tag_idx": {
+          "name": "saved_keyword_tag_assignments_tag_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "saved_keyword_tag_assignments_saved_keyword_id_saved_keywords_id_fk": {
+          "name": "saved_keyword_tag_assignments_saved_keyword_id_saved_keywords_id_fk",
+          "tableFrom": "saved_keyword_tag_assignments",
+          "tableTo": "saved_keywords",
+          "columnsFrom": [
+            "saved_keyword_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "saved_keyword_tag_assignments_tag_id_saved_keyword_tags_id_fk": {
+          "name": "saved_keyword_tag_assignments_tag_id_saved_keyword_tags_id_fk",
+          "tableFrom": "saved_keyword_tag_assignments",
+          "tableTo": "saved_keyword_tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "saved_keyword_tags": {
+      "name": "saved_keyword_tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "saved_keyword_tags_project_normalized_name_idx": {
+          "name": "saved_keyword_tags_project_normalized_name_idx",
+          "columns": [
+            "project_id",
+            "normalized_name"
+          ],
+          "isUnique": true
+        },
+        "saved_keyword_tags_project_name_idx": {
+          "name": "saved_keyword_tags_project_name_idx",
+          "columns": [
+            "project_id",
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "saved_keyword_tags_project_id_projects_id_fk": {
+          "name": "saved_keyword_tags_project_id_projects_id_fk",
+          "tableFrom": "saved_keyword_tags",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "saved_keywords": {
+      "name": "saved_keywords",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_code": {
+          "name": "location_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2840
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "saved_keywords_unique_project_keyword_location_language": {
+          "name": "saved_keywords_unique_project_keyword_location_language",
+          "columns": [
+            "project_id",
+            "keyword",
+            "location_code",
+            "language_code"
+          ],
+          "isUnique": true
+        },
+        "saved_keywords_project_created_idx": {
+          "name": "saved_keywords_project_created_idx",
+          "columns": [
+            "project_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "saved_keywords_project_id_projects_id_fk": {
+          "name": "saved_keywords_project_id_projects_id_fk",
+          "tableFrom": "saved_keywords",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_onboarding_answers": {
+      "name": "user_onboarding_answers",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "interested_features": {
+          "name": "interested_features",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "work_for": {
+          "name": "work_for",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_website_count": {
+          "name": "client_website_count",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "found_via": {
+          "name": "found_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcp_setup_intent": {
+          "name": "mcp_setup_intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gsc_nudge_dismissed_at": {
+          "name": "gsc_nudge_dismissed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "user_onboarding_answers_organization_idx": {
+          "name": "user_onboarding_answers_organization_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_onboarding_answers_user_id_user_id_fk": {
+          "name": "user_onboarding_answers_user_id_user_id_fk",
+          "tableFrom": "user_onboarding_answers",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_onboarding_answers_organization_id_organization_id_fk": {
+          "name": "user_onboarding_answers_organization_id_organization_id_fk",
+          "tableFrom": "user_onboarding_answers",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_competitors": {
+      "name": "project_competitors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "project_competitors_project_domain_idx": {
+          "name": "project_competitors_project_domain_idx",
+          "columns": [
+            "project_id",
+            "domain"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "project_competitors_project_id_projects_id_fk": {
+          "name": "project_competitors_project_id_projects_id_fk",
+          "tableFrom": "project_competitors",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_context_sections": {
+      "name": "project_context_sections",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_context_sections_project_id_projects_id_fk": {
+          "name": "project_context_sections_project_id_projects_id_fk",
+          "tableFrom": "project_context_sections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_context_sections_project_id_key_pk": {
+          "columns": [
+            "project_id",
+            "key"
+          ],
+          "name": "project_context_sections_project_id_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_key_pages": {
+      "name": "project_key_pages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "project_key_pages_project_url_idx": {
+          "name": "project_key_pages_project_url_idx",
+          "columns": [
+            "project_id",
+            "url"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "project_key_pages_project_id_projects_id_fk": {
+          "name": "project_key_pages_project_id_projects_id_fk",
+          "tableFrom": "project_key_pages",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_research_log": {
+      "name": "project_research_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entry_date": {
+          "name": "entry_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ','now'))"
+        }
+      },
+      "indexes": {
+        "project_research_log_project_date_idx": {
+          "name": "project_research_log_project_date_idx",
+          "columns": [
+            "project_id",
+            "entry_date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "project_research_log_project_id_projects_id_fk": {
+          "name": "project_research_log_project_id_projects_id_fk",
+          "tableFrom": "project_research_log",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_issues": {
+      "name": "audit_issues",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audit_id": {
+          "name": "audit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "page_url": {
+          "name": "page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issue_type": {
+          "name": "issue_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'info'"
+        },
+        "details_json": {
+          "name": "details_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "audit_issues_audit_type_idx": {
+          "name": "audit_issues_audit_type_idx",
+          "columns": [
+            "audit_id",
+            "issue_type"
+          ],
+          "isUnique": false
+        },
+        "audit_issues_page_id_idx": {
+          "name": "audit_issues_page_id_idx",
+          "columns": [
+            "page_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audit_issues_audit_id_audits_id_fk": {
+          "name": "audit_issues_audit_id_audits_id_fk",
+          "tableFrom": "audit_issues",
+          "tableTo": "audits",
+          "columnsFrom": [
+            "audit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_issues_page_id_audit_pages_id_fk": {
+          "name": "audit_issues_page_id_audit_pages_id_fk",
+          "tableFrom": "audit_issues",
+          "tableTo": "audit_pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_lighthouse_results": {
+      "name": "audit_lighthouse_results",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audit_id": {
+          "name": "audit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "strategy": {
+          "name": "strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "performance_score": {
+          "name": "performance_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accessibility_score": {
+          "name": "accessibility_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "best_practices_score": {
+          "name": "best_practices_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seo_score": {
+          "name": "seo_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lcp_ms": {
+          "name": "lcp_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cls": {
+          "name": "cls",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inp_ms": {
+          "name": "inp_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ttfb_ms": {
+          "name": "ttfb_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload_size_bytes": {
+          "name": "payload_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "audit_lighthouse_results_audit_id_idx": {
+          "name": "audit_lighthouse_results_audit_id_idx",
+          "columns": [
+            "audit_id"
+          ],
+          "isUnique": false
+        },
+        "audit_lighthouse_results_page_id_idx": {
+          "name": "audit_lighthouse_results_page_id_idx",
+          "columns": [
+            "page_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audit_lighthouse_results_audit_id_audits_id_fk": {
+          "name": "audit_lighthouse_results_audit_id_audits_id_fk",
+          "tableFrom": "audit_lighthouse_results",
+          "tableTo": "audits",
+          "columnsFrom": [
+            "audit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_lighthouse_results_page_id_audit_pages_id_fk": {
+          "name": "audit_lighthouse_results_page_id_audit_pages_id_fk",
+          "tableFrom": "audit_lighthouse_results",
+          "tableTo": "audit_pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_pages": {
+      "name": "audit_pages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audit_id": {
+          "name": "audit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "canonical_url": {
+          "name": "canonical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "robots_meta": {
+          "name": "robots_meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_title": {
+          "name": "og_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_description": {
+          "name": "og_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_image": {
+          "name": "og_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "h1_count": {
+          "name": "h1_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "h2_count": {
+          "name": "h2_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "h3_count": {
+          "name": "h3_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "h4_count": {
+          "name": "h4_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "h5_count": {
+          "name": "h5_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "h6_count": {
+          "name": "h6_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "heading_order_json": {
+          "name": "heading_order_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "images_total": {
+          "name": "images_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "images_missing_alt": {
+          "name": "images_missing_alt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "images_json": {
+          "name": "images_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "internal_link_count": {
+          "name": "internal_link_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "external_link_count": {
+          "name": "external_link_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "has_structured_data": {
+          "name": "has_structured_data",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "hreflang_tags_json": {
+          "name": "hreflang_tags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_indexable": {
+          "name": "is_indexable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "x_robots_tag": {
+          "name": "x_robots_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "header_canonical_url": {
+          "name": "header_canonical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "crawl_depth": {
+          "name": "crawl_depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "in_sitemap": {
+          "name": "in_sitemap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fetch_class": {
+          "name": "fetch_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ok'"
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "audit_pages_audit_url_idx": {
+          "name": "audit_pages_audit_url_idx",
+          "columns": [
+            "audit_id",
+            "url"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audit_pages_audit_id_audits_id_fk": {
+          "name": "audit_pages_audit_id_audits_id_fk",
+          "tableFrom": "audit_pages",
+          "tableTo": "audits",
+          "columnsFrom": [
+            "audit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audits": {
+      "name": "audits",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_by_user_id": {
+          "name": "started_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_url": {
+          "name": "start_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "workflow_instance_id": {
+          "name": "workflow_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "pages_crawled": {
+          "name": "pages_crawled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "pages_total": {
+          "name": "pages_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lighthouse_total": {
+          "name": "lighthouse_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lighthouse_completed": {
+          "name": "lighthouse_completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lighthouse_failed": {
+          "name": "lighthouse_failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "current_phase": {
+          "name": "current_phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'discovery'"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_detail": {
+          "name": "error_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failed_phase": {
+          "name": "failed_phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "audits_project_id_idx": {
+          "name": "audits_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "audits_started_by_user_id_idx": {
+          "name": "audits_started_by_user_id_idx",
+          "columns": [
+            "started_by_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audits_project_id_projects_id_fk": {
+          "name": "audits_project_id_projects_id_fk",
+          "tableFrom": "audits",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sam_sessions": {
+      "name": "sam_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'New chat'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sam_sessions_project_updated_idx": {
+          "name": "sam_sessions_project_updated_idx",
+          "columns": [
+            "project_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sam_sessions_project_id_projects_id_fk": {
+          "name": "sam_sessions_project_id_projects_id_fk",
+          "tableFrom": "sam_sessions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sam_sessions_user_id_user_id_fk": {
+          "name": "sam_sessions_user_id_user_id_fk",
+          "tableFrom": "sam_sessions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "account_accountId_providerId_idx": {
+          "name": "account_accountId_providerId_idx",
+          "columns": [
+            "account_id",
+            "provider_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 60000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 120
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "apikey_configId_idx": {
+          "name": "apikey_configId_idx",
+          "columns": [
+            "config_id"
+          ],
+          "isUnique": false
+        },
+        "apikey_referenceId_idx": {
+          "name": "apikey_referenceId_idx",
+          "columns": [
+            "reference_id"
+          ],
+          "isUnique": false
+        },
+        "apikey_key_idx": {
+          "name": "apikey_key_idx",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invitation": {
+      "name": "invitation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "member": {
+      "name": "member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "member_organizationId_userId_uidx": {
+          "name": "member_organizationId_userId_uidx",
+          "columns": [
+            "organization_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization": {
+      "name": "organization",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "organization_slug_uidx": {
+          "name": "organization_slug_uidx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "analytics_opted_out": {
+          "name": "analytics_opted_out",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_active_organization_id": {
+          "name": "last_active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        },
+        "verification_expiresAt_idx": {
+          "name": "verification_expiresAt_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "billing_customer_status": {
+      "name": "billing_customer_status",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_paying": {
+          "name": "is_paying",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "paid_plan_id": {
+          "name": "paid_plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "paid_plan_status": {
+          "name": "paid_plan_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "customer_json": {
+          "name": "customer_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "billing_customer_status_organization_id_organization_id_fk": {
+          "name": "billing_customer_status_organization_id_organization_id_fk",
+          "tableFrom": "billing_customer_status",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ga4_connections": {
+      "name": "ga4_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "property_display_name": {
+          "name": "property_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "property_time_zone": {
+          "name": "property_time_zone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "property_currency_code": {
+          "name": "property_currency_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ga4_account_id": {
+          "name": "ga4_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connected_account_email": {
+          "name": "connected_account_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "ga4_connections_project_idx": {
+          "name": "ga4_connections_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": true
+        },
+        "ga4_connections_organization_idx": {
+          "name": "ga4_connections_organization_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "ga4_connections_connector_idx": {
+          "name": "ga4_connections_connector_idx",
+          "columns": [
+            "connected_by_user_id",
+            "ga4_account_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "ga4_connections_project_id_projects_id_fk": {
+          "name": "ga4_connections_project_id_projects_id_fk",
+          "tableFrom": "ga4_connections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ga4_connections_organization_id_organization_id_fk": {
+          "name": "ga4_connections_organization_id_organization_id_fk",
+          "tableFrom": "ga4_connections",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gsc_connections": {
+      "name": "gsc_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "site_url": {
+          "name": "site_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connected_by_user_id": {
+          "name": "connected_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gsc_account_id": {
+          "name": "gsc_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connected_account_email": {
+          "name": "connected_account_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "gsc_connections_project_idx": {
+          "name": "gsc_connections_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": true
+        },
+        "gsc_connections_organization_idx": {
+          "name": "gsc_connections_organization_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gsc_connections_project_id_projects_id_fk": {
+          "name": "gsc_connections_project_id_projects_id_fk",
+          "tableFrom": "gsc_connections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gsc_connections_organization_id_organization_id_fk": {
+          "name": "gsc_connections_organization_id_organization_id_fk",
+          "tableFrom": "gsc_connections",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "telemetry_state": {
+      "name": "telemetry_state",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "install_id": {
+          "name": "install_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_version": {
+          "name": "last_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcp_tool_call_count": {
+          "name": "mcp_tool_call_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "first_party_signal_batches": {
+      "name": "first_party_signal_batches",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload_digest": {
+          "name": "payload_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "processing_lease_id": {
+          "name": "processing_lease_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "processing_lease_expires_at": {
+          "name": "processing_lease_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "first_party_signal_batches_source_batch_idx": {
+          "name": "first_party_signal_batches_source_batch_idx",
+          "columns": [
+            "source_id",
+            "batch_id"
+          ],
+          "isUnique": true
+        },
+        "first_party_signal_batches_source_date_idx": {
+          "name": "first_party_signal_batches_source_date_idx",
+          "columns": [
+            "source_id",
+            "snapshot_date"
+          ],
+          "isUnique": true
+        },
+        "first_party_signal_batches_retention_idx": {
+          "name": "first_party_signal_batches_retention_idx",
+          "columns": [
+            "snapshot_date",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "first_party_signal_batches_source_id_first_party_signal_sources_id_fk": {
+          "name": "first_party_signal_batches_source_id_first_party_signal_sources_id_fk",
+          "tableFrom": "first_party_signal_batches",
+          "tableTo": "first_party_signal_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "first_party_signal_batches_status_check": {
+          "name": "first_party_signal_batches_status_check",
+          "value": "\"first_party_signal_batches\".\"status\" IN ('pending', 'complete', 'failed')"
+        }
+      }
+    },
+    "first_party_signal_daily_aggregates": {
+      "name": "first_party_signal_daily_aggregates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "batch_receipt_id": {
+          "name": "batch_receipt_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "processing_attempt_id": {
+          "name": "processing_attempt_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "landing_path": {
+          "name": "landing_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "search_started": {
+          "name": "search_started",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "search_completed": {
+          "name": "search_completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "search_no_results": {
+          "name": "search_no_results",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "registrations_completed": {
+          "name": "registrations_completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "checkout_started": {
+          "name": "checkout_started",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "payments_completed": {
+          "name": "payments_completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "first_party_signal_daily_batch_path_idx": {
+          "name": "first_party_signal_daily_batch_path_idx",
+          "columns": [
+            "batch_receipt_id",
+            "processing_attempt_id",
+            "landing_path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "first_party_signal_daily_aggregates_batch_receipt_id_first_party_signal_batches_id_fk": {
+          "name": "first_party_signal_daily_aggregates_batch_receipt_id_first_party_signal_batches_id_fk",
+          "tableFrom": "first_party_signal_daily_aggregates",
+          "tableTo": "first_party_signal_batches",
+          "columnsFrom": [
+            "batch_receipt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "first_party_signal_daily_nonnegative_check": {
+          "name": "first_party_signal_daily_nonnegative_check",
+          "value": "\"first_party_signal_daily_aggregates\".\"search_started\" >= 0 AND \"first_party_signal_daily_aggregates\".\"search_completed\" >= 0 AND \"first_party_signal_daily_aggregates\".\"search_no_results\" >= 0 AND \"first_party_signal_daily_aggregates\".\"registrations_completed\" >= 0 AND \"first_party_signal_daily_aggregates\".\"checkout_started\" >= 0 AND \"first_party_signal_daily_aggregates\".\"payments_completed\" >= 0"
+        }
+      }
+    },
+    "first_party_signal_source_paths": {
+      "name": "first_party_signal_source_paths",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "first_party_signal_source_paths_unique_idx": {
+          "name": "first_party_signal_source_paths_unique_idx",
+          "columns": [
+            "source_id",
+            "path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "first_party_signal_source_paths_source_id_first_party_signal_sources_id_fk": {
+          "name": "first_party_signal_source_paths_source_id_first_party_signal_sources_id_fk",
+          "tableFrom": "first_party_signal_source_paths",
+          "tableTo": "first_party_signal_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "first_party_signal_sources": {
+      "name": "first_party_signal_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_secret": {
+          "name": "encrypted_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_hint": {
+          "name": "secret_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(current_timestamp)"
+        }
+      },
+      "indexes": {
+        "first_party_signal_sources_project_idx": {
+          "name": "first_party_signal_sources_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": true
+        },
+        "first_party_signal_sources_org_idx": {
+          "name": "first_party_signal_sources_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "first_party_signal_sources_project_id_projects_id_fk": {
+          "name": "first_party_signal_sources_project_id_projects_id_fk",
+          "tableFrom": "first_party_signal_sources",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "first_party_signal_sources_organization_id_organization_id_fk": {
+          "name": "first_party_signal_sources_organization_id_organization_id_fk",
+          "tableFrom": "first_party_signal_sources",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "first_party_signal_sources_created_by_user_id_user_id_fk": {
+          "name": "first_party_signal_sources_created_by_user_id_user_id_fk",
+          "tableFrom": "first_party_signal_sources",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -323,6 +323,13 @@
       "when": 1788524448952,
       "tag": "0045_silent_cassandra_nova",
       "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "6",
+      "when": 1788527300645,
+      "tag": "0046_first_party_retention_index",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -316,6 +316,13 @@
       "when": 1787773498579,
       "tag": "0044_outstanding_sage",
       "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "6",
+      "when": 1788524448952,
+      "tag": "0045_silent_cassandra_nova",
+      "breakpoints": true
     }
   ]
 }

--- a/src/client/features/ai-mcp/AvailableTools.tsx
+++ b/src/client/features/ai-mcp/AvailableTools.tsx
@@ -250,6 +250,23 @@ const toolCategories: ToolCategory[] = [
       },
     ],
   },
+  {
+    label: "First-party Aggregates",
+    tools: [
+      {
+        name: "get_first_party_funnel",
+        title: "Get first-party funnel",
+        description:
+          "Read daily aggregate search, registration, checkout, and payment counts.",
+      },
+      {
+        name: "get_first_party_landing_conversions",
+        title: "Get landing conversions",
+        description:
+          "Compare privacy-safe funnel counts by allowlisted public landing page.",
+      },
+    ],
+  },
 ];
 
 export function AvailableTools() {

--- a/src/client/features/integrations/FirstPartySignalsConnectionCard.security.test.ts
+++ b/src/client/features/integrations/FirstPartySignalsConnectionCard.security.test.ts
@@ -1,0 +1,20 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+
+describe("FirstPartySignalsConnectionCard secret handling", () => {
+  it("masks the one-time credential and clears the mutation response", async () => {
+    const source = await readFile(
+      new URL("./FirstPartySignalsConnectionCard.tsx", import.meta.url),
+      "utf8",
+    );
+
+    expect(source).toMatch(
+      /className="[^"]*ph-no-capture[^"]*"\s+data-ph-mask/,
+    );
+    expect(source).toMatch(
+      /mutationFn: async \(\) => \{[\s\S]*setCredential\([\s\S]*onSuccess: \(\) => \{[\s\S]*configure\.reset\(\);/,
+    );
+    expect(source).not.toMatch(/setCredential\([\s\S]*return result/);
+    expect(source).not.toContain("credential ?? configure.data");
+  });
+});

--- a/src/client/features/integrations/FirstPartySignalsConnectionCard.tsx
+++ b/src/client/features/integrations/FirstPartySignalsConnectionCard.tsx
@@ -192,9 +192,10 @@ export function FirstPartySignalsConnectionCard({
       ) : null}
       <div className="mt-4 border-t border-base-300 pt-4 text-sm">
         <p className="text-base-content/70">
-          Cloudflare scheduled deployments clean one bounded retention page
-          daily. Docker and other self-hosted runtimes do not dispatch that cron
-          automatically; run the same project-scoped cleanup here.
+          Cloudflare scheduled deployments drain up to 5,000 expired snapshots
+          per run. Docker and other self-hosted runtimes do not dispatch that
+          cron automatically; run the same bounded, project-scoped cleanup here
+          and repeat only when it reports more work.
         </p>
         <button
           type="button"

--- a/src/client/features/integrations/FirstPartySignalsConnectionCard.tsx
+++ b/src/client/features/integrations/FirstPartySignalsConnectionCard.tsx
@@ -6,6 +6,7 @@ import { IntegrationConnectionCard } from "./IntegrationConnectionCard";
 import {
   configureFirstPartySignalSource,
   listFirstPartySignalSources,
+  purgeExpiredFirstPartySignalBatches,
   revokeFirstPartySignalSource,
 } from "@/serverFunctions/first-party-signals";
 
@@ -28,8 +29,8 @@ export function FirstPartySignalsConnectionCard({
   });
   const configure = useMutation({
     gcTime: 0,
-    mutationFn: () =>
-      configureFirstPartySignalSource({
+    mutationFn: async () => {
+      const result = await configureFirstPartySignalSource({
         data: {
           projectId,
           name,
@@ -38,9 +39,16 @@ export function FirstPartySignalsConnectionCard({
             .map((value) => value.trim())
             .filter(Boolean),
         },
-      }),
-    onSuccess: (result) => {
+      });
       setCredential({ sourceId: result.sourceId, secret: result.secret });
+      // Returning no value prevents React Query from ever caching the secret as
+      // mutation data. The only retained copy is the explicitly masked local UI
+      // state above, which the user dismisses after copying.
+    },
+    onSuccess: () => {
+      // The one-time secret lives only in local masked state after this tick;
+      // reset the mutation metadata as an additional defence in depth.
+      configure.reset();
       toast.success("Aggregate source configured");
       void queryClient.invalidateQueries({ queryKey });
     },
@@ -54,6 +62,20 @@ export function FirstPartySignalsConnectionCard({
       void queryClient.invalidateQueries({ queryKey });
     },
     onError: () => toast.error("Could not revoke aggregate source"),
+  });
+  const cleanup = useMutation({
+    gcTime: 0,
+    mutationFn: () =>
+      purgeExpiredFirstPartySignalBatches({ data: { projectId } }),
+    onSuccess: (result) => {
+      toast.success(
+        result.hasMore
+          ? `Deleted ${result.deleted} expired snapshots. Run cleanup again to continue.`
+          : `Retention cleanup complete: ${result.deleted} snapshots deleted.`,
+      );
+      cleanup.reset();
+    },
+    onError: () => toast.error("Could not run retention cleanup"),
   });
   const active = sources.data?.filter((source) => !source.revokedAt) ?? [];
 
@@ -75,7 +97,10 @@ export function FirstPartySignalsConnectionCard({
         identifier-shaped path segments.
       </p>
       {credential ? (
-        <div className="alert alert-warning mt-4 block text-sm">
+        <div
+          className="alert alert-warning ph-no-capture mt-4 block text-sm"
+          data-ph-mask
+        >
           <p className="font-medium">
             Copy this credential now. The 256-bit secret is shown once.
           </p>
@@ -165,6 +190,21 @@ export function FirstPartySignalsConnectionCard({
           ))}
         </div>
       ) : null}
+      <div className="mt-4 border-t border-base-300 pt-4 text-sm">
+        <p className="text-base-content/70">
+          Cloudflare scheduled deployments clean one bounded retention page
+          daily. Docker and other self-hosted runtimes do not dispatch that cron
+          automatically; run the same project-scoped cleanup here.
+        </p>
+        <button
+          type="button"
+          className="btn btn-ghost btn-sm mt-2"
+          onClick={() => cleanup.mutate()}
+          disabled={cleanup.isPending}
+        >
+          {cleanup.isPending ? "Cleaning…" : "Run 400-day cleanup"}
+        </button>
+      </div>
     </IntegrationConnectionCard>
   );
 }

--- a/src/client/features/integrations/FirstPartySignalsConnectionCard.tsx
+++ b/src/client/features/integrations/FirstPartySignalsConnectionCard.tsx
@@ -1,0 +1,170 @@
+import * as React from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { DatabaseZap } from "lucide-react";
+import { toast } from "sonner";
+import { IntegrationConnectionCard } from "./IntegrationConnectionCard";
+import {
+  configureFirstPartySignalSource,
+  listFirstPartySignalSources,
+  revokeFirstPartySignalSource,
+} from "@/serverFunctions/first-party-signals";
+
+export function FirstPartySignalsConnectionCard({
+  projectId,
+}: {
+  projectId: string;
+}) {
+  const queryClient = useQueryClient();
+  const [name, setName] = React.useState("website");
+  const [paths, setPaths] = React.useState("/");
+  const [credential, setCredential] = React.useState<{
+    sourceId: string;
+    secret: string;
+  } | null>(null);
+  const queryKey = ["firstPartySignalSources", projectId];
+  const sources = useQuery({
+    queryKey,
+    queryFn: () => listFirstPartySignalSources({ data: { projectId } }),
+  });
+  const configure = useMutation({
+    gcTime: 0,
+    mutationFn: () =>
+      configureFirstPartySignalSource({
+        data: {
+          projectId,
+          name,
+          allowedPaths: paths
+            .split(",")
+            .map((value) => value.trim())
+            .filter(Boolean),
+        },
+      }),
+    onSuccess: (result) => {
+      setCredential({ sourceId: result.sourceId, secret: result.secret });
+      toast.success("Aggregate source configured");
+      void queryClient.invalidateQueries({ queryKey });
+    },
+    onError: () => toast.error("Could not configure aggregate source"),
+  });
+  const revoke = useMutation({
+    mutationFn: (sourceId: string) =>
+      revokeFirstPartySignalSource({ data: { projectId, sourceId } }),
+    onSuccess: () => {
+      toast.success("Aggregate source revoked");
+      void queryClient.invalidateQueries({ queryKey });
+    },
+    onError: () => toast.error("Could not revoke aggregate source"),
+  });
+  const active = sources.data?.filter((source) => !source.revokedAt) ?? [];
+
+  return (
+    <IntegrationConnectionCard
+      title="First-party aggregates"
+      icon={<DatabaseZap className="size-5 text-emerald-500" />}
+      status={
+        sources.isLoading || sources.isError
+          ? undefined
+          : active.length
+            ? "connected"
+            : "disconnected"
+      }
+    >
+      <p className="text-sm text-base-content/70">
+        Send daily counts to <code>/api/site-signals/v1/aggregates</code>.
+        OpenSEO rejects unknown fields, query strings, private paths, and common
+        identifier-shaped path segments.
+      </p>
+      {credential ? (
+        <div className="alert alert-warning mt-4 block text-sm">
+          <p className="font-medium">
+            Copy this credential now. The 256-bit secret is shown once.
+          </p>
+          <p className="mt-2 break-all font-mono text-xs">
+            Source: {credential.sourceId}
+          </p>
+          <p className="mt-1 break-all font-mono text-xs">
+            Secret: {credential.secret}
+          </p>
+          <p className="mt-2 text-xs opacity-80">
+            Sign the exact request bytes as timestamp.rawBody with HMAC-SHA256
+            and send the hexadecimal digest in X-OpenSEO-Signature.
+          </p>
+          <button
+            type="button"
+            className="btn btn-ghost btn-xs mt-2"
+            onClick={() => {
+              setCredential(null);
+              configure.reset();
+            }}
+          >
+            I saved it
+          </button>
+        </div>
+      ) : null}
+      <form
+        className="mt-4 grid gap-3 md:grid-cols-2"
+        onSubmit={(event) => {
+          event.preventDefault();
+          configure.mutate();
+        }}
+      >
+        <label className="form-control gap-1">
+          <span className="text-xs font-medium">Source name</span>
+          <input
+            className="input input-bordered input-sm"
+            value={name}
+            maxLength={80}
+            onChange={(event) => setName(event.target.value)}
+          />
+        </label>
+        <label className="form-control gap-1">
+          <span className="text-xs font-medium">
+            Allowed public landing paths
+          </span>
+          <input
+            className="input input-bordered input-sm"
+            value={paths}
+            onChange={(event) => setPaths(event.target.value)}
+            placeholder="/, /pricing, /docs/getting-started"
+          />
+          <span className="text-xs opacity-60">
+            Comma-separated exact paths, never URL prefixes.
+          </span>
+        </label>
+        <button
+          className="btn btn-primary btn-sm md:col-span-2 md:w-fit"
+          disabled={configure.isPending || !name.trim() || !paths.trim()}
+        >
+          {configure.isPending
+            ? "Generating…"
+            : "Generate or rotate source secret"}
+        </button>
+      </form>
+      {active.length ? (
+        <div className="mt-4 space-y-2">
+          {active.map((source) => (
+            <div
+              key={source.id}
+              className="flex items-center justify-between gap-4 rounded-lg border border-base-300 p-3 text-sm"
+            >
+              <div className="min-w-0">
+                <p className="font-medium">{source.name}</p>
+                <p className="truncate text-xs opacity-60">
+                  {source.secretHint} · {source.allowedPaths.join(", ")}
+                </p>
+              </div>
+              <button
+                type="button"
+                className="btn btn-ghost btn-xs text-error"
+                onClick={() => revoke.mutate(source.id)}
+                disabled={revoke.isPending}
+              >
+                Revoke
+              </button>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </IntegrationConnectionCard>
+  );
+}

--- a/src/db/d1/schema.ts
+++ b/src/db/d1/schema.ts
@@ -10,3 +10,4 @@ export * from "../billing.schema";
 export * from "../ga4.schema";
 export * from "../gsc.schema";
 export * from "../telemetry.schema";
+export * from "../first-party-signals.schema";

--- a/src/db/first-party-signals.schema.ts
+++ b/src/db/first-party-signals.schema.ts
@@ -83,6 +83,10 @@ export const firstPartySignalBatches = sqliteTable(
       table.sourceId,
       table.snapshotDate,
     ),
+    index("first_party_signal_batches_retention_idx").on(
+      table.snapshotDate,
+      table.id,
+    ),
     check(
       "first_party_signal_batches_status_check",
       sql`${table.status} IN ('pending', 'complete', 'failed')`,

--- a/src/db/first-party-signals.schema.ts
+++ b/src/db/first-party-signals.schema.ts
@@ -1,0 +1,123 @@
+import { sql } from "drizzle-orm";
+import {
+  check,
+  index,
+  integer,
+  sqliteTable,
+  text,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core";
+import { projects } from "./app.schema";
+import { organization, user } from "./better-auth-schema";
+
+const isoNow = sql`(current_timestamp)`;
+
+export const firstPartySignalSources = sqliteTable(
+  "first_party_signal_sources",
+  {
+    id: text("id").primaryKey(),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    name: text("name").notNull(),
+    encryptedSecret: text("encrypted_secret").notNull(),
+    secretHint: text("secret_hint").notNull(),
+    createdByUserId: text("created_by_user_id").references(() => user.id, {
+      onDelete: "set null",
+    }),
+    revokedAt: text("revoked_at"),
+    createdAt: text("created_at").notNull().default(isoNow),
+    updatedAt: text("updated_at").notNull().default(isoNow),
+  },
+  (table) => [
+    uniqueIndex("first_party_signal_sources_project_idx").on(table.projectId),
+    index("first_party_signal_sources_org_idx").on(table.organizationId),
+  ],
+);
+
+export const firstPartySignalSourcePaths = sqliteTable(
+  "first_party_signal_source_paths",
+  {
+    id: text("id").primaryKey(),
+    sourceId: text("source_id")
+      .notNull()
+      .references(() => firstPartySignalSources.id, { onDelete: "cascade" }),
+    path: text("path").notNull(),
+    createdAt: text("created_at").notNull().default(isoNow),
+  },
+  (table) => [
+    uniqueIndex("first_party_signal_source_paths_unique_idx").on(
+      table.sourceId,
+      table.path,
+    ),
+  ],
+);
+
+export const firstPartySignalBatches = sqliteTable(
+  "first_party_signal_batches",
+  {
+    id: text("id").primaryKey(),
+    sourceId: text("source_id")
+      .notNull()
+      .references(() => firstPartySignalSources.id, { onDelete: "cascade" }),
+    batchId: text("batch_id").notNull(),
+    snapshotDate: text("snapshot_date").notNull(),
+    payloadDigest: text("payload_digest").notNull(),
+    status: text("status", { enum: ["pending", "complete", "failed"] })
+      .notNull()
+      .default("pending"),
+    processingLeaseId: text("processing_lease_id"),
+    processingLeaseExpiresAt: text("processing_lease_expires_at"),
+    receivedAt: text("received_at").notNull().default(isoNow),
+    completedAt: text("completed_at"),
+  },
+  (table) => [
+    uniqueIndex("first_party_signal_batches_source_batch_idx").on(
+      table.sourceId,
+      table.batchId,
+    ),
+    uniqueIndex("first_party_signal_batches_source_date_idx").on(
+      table.sourceId,
+      table.snapshotDate,
+    ),
+    check(
+      "first_party_signal_batches_status_check",
+      sql`${table.status} IN ('pending', 'complete', 'failed')`,
+    ),
+  ],
+);
+
+export const firstPartySignalDailyAggregates = sqliteTable(
+  "first_party_signal_daily_aggregates",
+  {
+    id: text("id").primaryKey(),
+    batchReceiptId: text("batch_receipt_id")
+      .notNull()
+      .references(() => firstPartySignalBatches.id, { onDelete: "cascade" }),
+    processingAttemptId: text("processing_attempt_id").notNull(),
+    landingPath: text("landing_path").notNull(),
+    searchStarted: integer("search_started").notNull().default(0),
+    searchCompleted: integer("search_completed").notNull().default(0),
+    searchNoResults: integer("search_no_results").notNull().default(0),
+    registrationsCompleted: integer("registrations_completed")
+      .notNull()
+      .default(0),
+    checkoutStarted: integer("checkout_started").notNull().default(0),
+    paymentsCompleted: integer("payments_completed").notNull().default(0),
+    receivedAt: text("received_at").notNull().default(isoNow),
+  },
+  (table) => [
+    uniqueIndex("first_party_signal_daily_batch_path_idx").on(
+      table.batchReceiptId,
+      table.processingAttemptId,
+      table.landingPath,
+    ),
+    check(
+      "first_party_signal_daily_nonnegative_check",
+      sql`${table.searchStarted} >= 0 AND ${table.searchCompleted} >= 0 AND ${table.searchNoResults} >= 0 AND ${table.registrationsCompleted} >= 0 AND ${table.checkoutStarted} >= 0 AND ${table.paymentsCompleted} >= 0`,
+    ),
+  ],
+);

--- a/src/db/pg/first-party-signals.schema.ts
+++ b/src/db/pg/first-party-signals.schema.ts
@@ -1,0 +1,123 @@
+import { sql } from "drizzle-orm";
+import {
+  check,
+  index,
+  integer,
+  pgTable,
+  text,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
+import { projects } from "./app.schema";
+import { organization, user } from "./better-auth-schema";
+
+const isoNow = sql`to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')`;
+
+export const firstPartySignalSources = pgTable(
+  "first_party_signal_sources",
+  {
+    id: text("id").primaryKey(),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    name: text("name").notNull(),
+    encryptedSecret: text("encrypted_secret").notNull(),
+    secretHint: text("secret_hint").notNull(),
+    createdByUserId: text("created_by_user_id").references(() => user.id, {
+      onDelete: "set null",
+    }),
+    revokedAt: text("revoked_at"),
+    createdAt: text("created_at").notNull().default(isoNow),
+    updatedAt: text("updated_at").notNull().default(isoNow),
+  },
+  (table) => [
+    uniqueIndex("first_party_signal_sources_project_idx").on(table.projectId),
+    index("first_party_signal_sources_org_idx").on(table.organizationId),
+  ],
+);
+
+export const firstPartySignalSourcePaths = pgTable(
+  "first_party_signal_source_paths",
+  {
+    id: text("id").primaryKey(),
+    sourceId: text("source_id")
+      .notNull()
+      .references(() => firstPartySignalSources.id, { onDelete: "cascade" }),
+    path: text("path").notNull(),
+    createdAt: text("created_at").notNull().default(isoNow),
+  },
+  (table) => [
+    uniqueIndex("first_party_signal_source_paths_unique_idx").on(
+      table.sourceId,
+      table.path,
+    ),
+  ],
+);
+
+export const firstPartySignalBatches = pgTable(
+  "first_party_signal_batches",
+  {
+    id: text("id").primaryKey(),
+    sourceId: text("source_id")
+      .notNull()
+      .references(() => firstPartySignalSources.id, { onDelete: "cascade" }),
+    batchId: text("batch_id").notNull(),
+    snapshotDate: text("snapshot_date").notNull(),
+    payloadDigest: text("payload_digest").notNull(),
+    status: text("status", { enum: ["pending", "complete", "failed"] })
+      .notNull()
+      .default("pending"),
+    processingLeaseId: text("processing_lease_id"),
+    processingLeaseExpiresAt: text("processing_lease_expires_at"),
+    receivedAt: text("received_at").notNull().default(isoNow),
+    completedAt: text("completed_at"),
+  },
+  (table) => [
+    uniqueIndex("first_party_signal_batches_source_batch_idx").on(
+      table.sourceId,
+      table.batchId,
+    ),
+    uniqueIndex("first_party_signal_batches_source_date_idx").on(
+      table.sourceId,
+      table.snapshotDate,
+    ),
+    check(
+      "first_party_signal_batches_status_check",
+      sql`${table.status} IN ('pending', 'complete', 'failed')`,
+    ),
+  ],
+);
+
+export const firstPartySignalDailyAggregates = pgTable(
+  "first_party_signal_daily_aggregates",
+  {
+    id: text("id").primaryKey(),
+    batchReceiptId: text("batch_receipt_id")
+      .notNull()
+      .references(() => firstPartySignalBatches.id, { onDelete: "cascade" }),
+    processingAttemptId: text("processing_attempt_id").notNull(),
+    landingPath: text("landing_path").notNull(),
+    searchStarted: integer("search_started").notNull().default(0),
+    searchCompleted: integer("search_completed").notNull().default(0),
+    searchNoResults: integer("search_no_results").notNull().default(0),
+    registrationsCompleted: integer("registrations_completed")
+      .notNull()
+      .default(0),
+    checkoutStarted: integer("checkout_started").notNull().default(0),
+    paymentsCompleted: integer("payments_completed").notNull().default(0),
+    receivedAt: text("received_at").notNull().default(isoNow),
+  },
+  (table) => [
+    uniqueIndex("first_party_signal_daily_batch_path_idx").on(
+      table.batchReceiptId,
+      table.processingAttemptId,
+      table.landingPath,
+    ),
+    check(
+      "first_party_signal_daily_nonnegative_check",
+      sql`${table.searchStarted} >= 0 AND ${table.searchCompleted} >= 0 AND ${table.searchNoResults} >= 0 AND ${table.registrationsCompleted} >= 0 AND ${table.checkoutStarted} >= 0 AND ${table.paymentsCompleted} >= 0`,
+    ),
+  ],
+);

--- a/src/db/pg/first-party-signals.schema.ts
+++ b/src/db/pg/first-party-signals.schema.ts
@@ -83,6 +83,10 @@ export const firstPartySignalBatches = pgTable(
       table.sourceId,
       table.snapshotDate,
     ),
+    index("first_party_signal_batches_retention_idx").on(
+      table.snapshotDate,
+      table.id,
+    ),
     check(
       "first_party_signal_batches_status_check",
       sql`${table.status} IN ('pending', 'complete', 'failed')`,

--- a/src/db/pg/schema.ts
+++ b/src/db/pg/schema.ts
@@ -7,3 +7,4 @@ export * from "./billing.schema";
 export * from "./ga4.schema";
 export * from "./gsc.schema";
 export * from "./telemetry.schema";
+export * from "./first-party-signals.schema";

--- a/src/db/schema-parity.test.ts
+++ b/src/db/schema-parity.test.ts
@@ -14,6 +14,7 @@ import * as sqliteBilling from "./billing.schema";
 import * as sqliteGa4 from "./ga4.schema";
 import * as sqliteGsc from "./gsc.schema";
 import * as sqliteTelemetry from "./telemetry.schema";
+import * as sqliteFirstPartySignals from "./first-party-signals.schema";
 import * as pgApp from "./pg/app.schema";
 import * as pgProjectContext from "./pg/project-context.schema";
 import * as pgAudit from "./pg/audit.schema";
@@ -23,6 +24,7 @@ import * as pgBilling from "./pg/billing.schema";
 import * as pgGa4 from "./pg/ga4.schema";
 import * as pgGsc from "./pg/gsc.schema";
 import * as pgTelemetry from "./pg/telemetry.schema";
+import * as pgFirstPartySignals from "./pg/first-party-signals.schema";
 
 // Guards the ONE structural artifact `db:generate` does not regenerate: the
 // hand-written Postgres schema. The provider-aware `db`/`@/db/schema` barrel
@@ -153,6 +155,7 @@ const sqliteAppTables = tablesFrom(
   sqliteGa4,
   sqliteGsc,
   sqliteTelemetry,
+  sqliteFirstPartySignals,
 );
 const pgAppTables = tablesFrom(
   pgApp,
@@ -163,6 +166,7 @@ const pgAppTables = tablesFrom(
   pgGa4,
   pgGsc,
   pgTelemetry,
+  pgFirstPartySignals,
 );
 const sqliteAuthTables = tablesFrom(sqliteAuth);
 const pgAuthTables = tablesFrom(pgAuth);
@@ -205,6 +209,34 @@ describe("schema parity: application tables", () => {
           checkNames(sqliteTable, "sqlite"),
         );
       });
+    });
+  }
+});
+
+describe("first-party aggregate storage invariants", () => {
+  for (const [dialect, tables] of [
+    ["sqlite", sqliteAppTables],
+    ["pg", pgAppTables],
+  ] as const) {
+    it(`${dialect} allows only one receipt per source and UTC day`, () => {
+      const batches = tables.get("first_party_signal_batches");
+      expect(batches).toBeDefined();
+      if (!batches) return;
+      expect(uniqueColumnTuples(batches, dialect)).toContain(
+        "snapshot_date,source_id",
+      );
+    });
+
+    it(`${dialect} derives project and source ownership through the receipt`, () => {
+      const aggregates = tables.get("first_party_signal_daily_aggregates");
+      expect(aggregates).toBeDefined();
+      if (!aggregates) return;
+      expect(columnsOf(aggregates).map((column) => column.name)).not.toEqual(
+        expect.arrayContaining(["project_id", "source_id", "snapshot_date"]),
+      );
+      expect(foreignKeys(aggregates, dialect)).toEqual([
+        "batch_receipt_id->first_party_signal_batches.id onDelete=cascade",
+      ]);
     });
   }
 });

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -8,6 +8,7 @@ import * as sqliteBilling from "./billing.schema";
 import * as sqliteGa4 from "./ga4.schema";
 import * as sqliteGsc from "./gsc.schema";
 import * as sqliteTelemetry from "./telemetry.schema";
+import * as sqliteFirstPartySignals from "./first-party-signals.schema";
 import * as pgApp from "./pg/app.schema";
 import * as pgProjectContext from "./pg/project-context.schema";
 import * as pgAudit from "./pg/audit.schema";
@@ -17,6 +18,7 @@ import * as pgBilling from "./pg/billing.schema";
 import * as pgGa4 from "./pg/ga4.schema";
 import * as pgGsc from "./pg/gsc.schema";
 import * as pgTelemetry from "./pg/telemetry.schema";
+import * as pgFirstPartySignals from "./pg/first-party-signals.schema";
 
 // Canonical schema barrel. Repositories import their tables from here and the
 // provider-aware `db` from "@/db", so each repository is written ONCE for both
@@ -36,7 +38,8 @@ type AppSchema = typeof sqliteApp &
   typeof sqliteBilling &
   typeof sqliteGa4 &
   typeof sqliteGsc &
-  typeof sqliteTelemetry;
+  typeof sqliteTelemetry &
+  typeof sqliteFirstPartySignals;
 
 const runtimeSchema =
   getDatabaseProvider() === "postgres"
@@ -50,6 +53,7 @@ const runtimeSchema =
         ...pgGa4,
         ...pgGsc,
         ...pgTelemetry,
+        ...pgFirstPartySignals,
       }
     : {
         ...sqliteApp,
@@ -61,6 +65,7 @@ const runtimeSchema =
         ...sqliteGa4,
         ...sqliteGsc,
         ...sqliteTelemetry,
+        ...sqliteFirstPartySignals,
       };
 
 // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- guarded by schema-parity.test.ts
@@ -101,4 +106,8 @@ export const {
   ga4Connections,
   gscConnections,
   telemetryState,
+  firstPartySignalSources,
+  firstPartySignalSourcePaths,
+  firstPartySignalBatches,
+  firstPartySignalDailyAggregates,
 } = schema;

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -53,6 +53,7 @@ declare namespace Cloudflare {
     // Alchemy-hosted public aggregate-ingest abuse controls. Portable Docker
     // runtimes omit the complete set and rely on their reverse proxy instead.
     FIRST_PARTY_INGEST_EDGE_LIMITS_REQUIRED?: string;
+    FIRST_PARTY_INGEST_RATE_LIMIT_SCOPE?: string;
     FIRST_PARTY_INGEST_GLOBAL_RATE_LIMIT?: RateLimit;
     FIRST_PARTY_INGEST_CLAIMED_SOURCE_RATE_LIMIT?: RateLimit;
     FIRST_PARTY_INGEST_RATE_LIMIT?: RateLimit;

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -50,6 +50,13 @@ declare namespace Cloudflare {
     // HMAC secret for the operator-only GDPR storage-erasure endpoint.
     GDPR_ERASURE_SECRET?: string;
 
+    // Alchemy-hosted public aggregate-ingest abuse controls. Portable Docker
+    // runtimes omit the complete set and rely on their reverse proxy instead.
+    FIRST_PARTY_INGEST_EDGE_LIMITS_REQUIRED?: string;
+    FIRST_PARTY_INGEST_GLOBAL_RATE_LIMIT?: RateLimit;
+    FIRST_PARTY_INGEST_CLAIMED_SOURCE_RATE_LIMIT?: RateLimit;
+    FIRST_PARTY_INGEST_RATE_LIMIT?: RateLimit;
+
     // Cloudflare Turnstile — signup captcha (hosted only). Secret verifies
     // tokens server-side; site key is public and inlined into the client build.
     TURNSTILE_SECRET_KEY?: string;

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -41,6 +41,7 @@ import { Route as AppHelpOpenrouterApiKeyRouteImport } from './routes/_app/help/
 import { Route as AppHelpDataforseoApiKeyRouteImport } from './routes/_app/help/dataforseo-api-key'
 import { Route as ProjectPProjectIdRouteRouteImport } from './routes/_project/p/$projectId/route'
 import { Route as ProjectPProjectIdIndexRouteImport } from './routes/_project/p/$projectId/index'
+import { Route as ApiSiteSignalsV1AggregatesRouteImport } from './routes/api/site-signals/v1/aggregates'
 import { Route as ApiGscOauthCallbackRouteImport } from './routes/api/gsc/oauth/callback'
 import { Route as ApiGa4OauthCallbackRouteImport } from './routes/api/ga4/oauth/callback'
 import { Route as ProjectPProjectIdSettingsRouteImport } from './routes/_project/p/$projectId/settings'
@@ -222,6 +223,12 @@ const ProjectPProjectIdIndexRoute = ProjectPProjectIdIndexRouteImport.update({
   path: '/',
   getParentRoute: () => ProjectPProjectIdRouteRoute,
 } as any)
+const ApiSiteSignalsV1AggregatesRoute =
+  ApiSiteSignalsV1AggregatesRouteImport.update({
+    id: '/api/site-signals/v1/aggregates',
+    path: '/api/site-signals/v1/aggregates',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ApiGscOauthCallbackRoute = ApiGscOauthCallbackRouteImport.update({
   id: '/api/gsc/oauth/callback',
   path: '/api/gsc/oauth/callback',
@@ -378,6 +385,7 @@ export interface FileRoutesByFullPath {
   '/p/$projectId/settings': typeof ProjectPProjectIdSettingsRouteWithChildren
   '/api/ga4/oauth/callback': typeof ApiGa4OauthCallbackRoute
   '/api/gsc/oauth/callback': typeof ApiGscOauthCallbackRoute
+  '/api/site-signals/v1/aggregates': typeof ApiSiteSignalsV1AggregatesRoute
   '/p/$projectId/': typeof ProjectPProjectIdIndexRoute
   '/p/$projectId/rank-tracking/$configId': typeof ProjectPProjectIdRankTrackingConfigIdRoute
   '/p/$projectId/settings/context': typeof ProjectPProjectIdSettingsContextRoute
@@ -423,6 +431,7 @@ export interface FileRoutesByTo {
   '/p/$projectId/search-performance': typeof ProjectPProjectIdSearchPerformanceRoute
   '/api/ga4/oauth/callback': typeof ApiGa4OauthCallbackRoute
   '/api/gsc/oauth/callback': typeof ApiGscOauthCallbackRoute
+  '/api/site-signals/v1/aggregates': typeof ApiSiteSignalsV1AggregatesRoute
   '/p/$projectId': typeof ProjectPProjectIdIndexRoute
   '/p/$projectId/rank-tracking/$configId': typeof ProjectPProjectIdRankTrackingConfigIdRoute
   '/p/$projectId/settings/context': typeof ProjectPProjectIdSettingsContextRoute
@@ -478,6 +487,7 @@ export interface FileRoutesById {
   '/_project/p/$projectId/settings': typeof ProjectPProjectIdSettingsRouteWithChildren
   '/api/ga4/oauth/callback': typeof ApiGa4OauthCallbackRoute
   '/api/gsc/oauth/callback': typeof ApiGscOauthCallbackRoute
+  '/api/site-signals/v1/aggregates': typeof ApiSiteSignalsV1AggregatesRoute
   '/_project/p/$projectId/': typeof ProjectPProjectIdIndexRoute
   '/_project/p/$projectId/rank-tracking/$configId': typeof ProjectPProjectIdRankTrackingConfigIdRoute
   '/_project/p/$projectId/settings/context': typeof ProjectPProjectIdSettingsContextRoute
@@ -530,6 +540,7 @@ export interface FileRouteTypes {
     | '/p/$projectId/settings'
     | '/api/ga4/oauth/callback'
     | '/api/gsc/oauth/callback'
+    | '/api/site-signals/v1/aggregates'
     | '/p/$projectId/'
     | '/p/$projectId/rank-tracking/$configId'
     | '/p/$projectId/settings/context'
@@ -575,6 +586,7 @@ export interface FileRouteTypes {
     | '/p/$projectId/search-performance'
     | '/api/ga4/oauth/callback'
     | '/api/gsc/oauth/callback'
+    | '/api/site-signals/v1/aggregates'
     | '/p/$projectId'
     | '/p/$projectId/rank-tracking/$configId'
     | '/p/$projectId/settings/context'
@@ -629,6 +641,7 @@ export interface FileRouteTypes {
     | '/_project/p/$projectId/settings'
     | '/api/ga4/oauth/callback'
     | '/api/gsc/oauth/callback'
+    | '/api/site-signals/v1/aggregates'
     | '/_project/p/$projectId/'
     | '/_project/p/$projectId/rank-tracking/$configId'
     | '/_project/p/$projectId/settings/context'
@@ -655,6 +668,7 @@ export interface RootRouteChildren {
   ApiAutumnSplatRoute: typeof ApiAutumnSplatRoute
   ApiGa4OauthCallbackRoute: typeof ApiGa4OauthCallbackRoute
   ApiGscOauthCallbackRoute: typeof ApiGscOauthCallbackRoute
+  ApiSiteSignalsV1AggregatesRoute: typeof ApiSiteSignalsV1AggregatesRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -882,6 +896,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/p/$projectId/'
       preLoaderRoute: typeof ProjectPProjectIdIndexRouteImport
       parentRoute: typeof ProjectPProjectIdRouteRoute
+    }
+    '/api/site-signals/v1/aggregates': {
+      id: '/api/site-signals/v1/aggregates'
+      path: '/api/site-signals/v1/aggregates'
+      fullPath: '/api/site-signals/v1/aggregates'
+      preLoaderRoute: typeof ApiSiteSignalsV1AggregatesRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/api/gsc/oauth/callback': {
       id: '/api/gsc/oauth/callback'
@@ -1220,6 +1241,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiAutumnSplatRoute: ApiAutumnSplatRoute,
   ApiGa4OauthCallbackRoute: ApiGa4OauthCallbackRoute,
   ApiGscOauthCallbackRoute: ApiGscOauthCallbackRoute,
+  ApiSiteSignalsV1AggregatesRoute: ApiSiteSignalsV1AggregatesRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/_project/p/$projectId/settings/integrations.tsx
+++ b/src/routes/_project/p/$projectId/settings/integrations.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { SearchConsoleConnectionCard } from "@/client/features/gsc/SearchConsoleConnectionCard";
 import { GoogleAnalyticsConnectionCard } from "@/client/features/ga4/GoogleAnalyticsConnectionCard";
+import { FirstPartySignalsConnectionCard } from "@/client/features/integrations/FirstPartySignalsConnectionCard";
 
 export const Route = createFileRoute(
   "/_project/p/$projectId/settings/integrations",
@@ -31,6 +32,13 @@ function ProjectIntegrationsRoute() {
             </h2>
           }
         />
+      </section>
+
+      <section id="first-party-aggregates" className="scroll-mt-6 space-y-3">
+        <h2 className="text-sm font-medium text-base-content/50">
+          Business signals
+        </h2>
+        <FirstPartySignalsConnectionCard projectId={projectId} />
       </section>
     </div>
   );

--- a/src/routes/api/site-signals/v1/aggregates.ts
+++ b/src/routes/api/site-signals/v1/aggregates.ts
@@ -1,0 +1,11 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { handleFirstPartyAggregateRequest } from "@/server/features/first-party-signals/handleAggregateRequest";
+
+export const Route = createFileRoute("/api/site-signals/v1/aggregates")({
+  server: {
+    handlers: {
+      POST: ({ request }: { request: Request }) =>
+        handleFirstPartyAggregateRequest(request),
+    },
+  },
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -208,10 +208,12 @@ export default {
           count: firstPartyPurge.deleted,
           hasMore: firstPartyPurge.hasMore,
           limit: firstPartyPurge.limit,
+          pages: firstPartyPurge.pages,
+          capacity: firstPartyPurge.capacity,
         });
         if (firstPartyPurge.hasMore) {
-          console.warn(
-            "[first-party-signals] retention purge reached its bounded page; another invocation is required",
+          throw new Error(
+            "First-party retention reached its bounded drain capacity; the next cron or a manual cleanup must continue it.",
           );
         }
       } catch (error) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -27,6 +27,7 @@ import { sweepDubReferredOrganizations } from "@/server/referrals/dub";
 import { maybeSendSelfHostHeartbeat } from "@/server/lib/self-host-telemetry";
 import { handleGdprStorageErasure } from "@/server/gdpr/storage-erasure";
 import { GDPR_STORAGE_ERASURE_PATH } from "@/shared/gdpr-erasure";
+import { FirstPartySignalsService } from "@/server/features/first-party-signals/FirstPartySignalsService";
 
 const appFetch = createStartHandler(defaultStreamHandler);
 const openSeoOAuthProvider = createOpenSeoOAuthProvider(appFetch);
@@ -198,6 +199,21 @@ export default {
     _ctx: ExecutionContext,
   ) {
     if (controller.cron === MCP_OAUTH_PURGE_CRON) {
+      let firstPartyPurgeError: unknown;
+      try {
+        const purgedFirstPartyBatches = await withPgClient(() =>
+          FirstPartySignalsService.purgeExpired(),
+        );
+        console.log("[first-party-signals] purged expired batches", {
+          count: purgedFirstPartyBatches,
+        });
+      } catch (error) {
+        firstPartyPurgeError = error;
+        console.error("[first-party-signals] retention purge failed", {
+          errorName: error instanceof Error ? error.name : "UnknownError",
+        });
+      }
+
       // Only hosted mode runs the OAuth provider (and has OAUTH_KV bound).
       if (isHostedAuthMode(getAuthMode(env.AUTH_MODE))) {
         const result = await openSeoOAuthProvider.purgeExpiredData(
@@ -218,6 +234,7 @@ export default {
           console.error("[cron] Dub referral sale sweep failed:", err);
         }
       }
+      if (firstPartyPurgeError) throw firstPartyPurgeError;
       return;
     }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -201,12 +201,19 @@ export default {
     if (controller.cron === MCP_OAUTH_PURGE_CRON) {
       let firstPartyPurgeError: unknown;
       try {
-        const purgedFirstPartyBatches = await withPgClient(() =>
+        const firstPartyPurge = await withPgClient(() =>
           FirstPartySignalsService.purgeExpired(),
         );
         console.log("[first-party-signals] purged expired batches", {
-          count: purgedFirstPartyBatches,
+          count: firstPartyPurge.deleted,
+          hasMore: firstPartyPurge.hasMore,
+          limit: firstPartyPurge.limit,
         });
+        if (firstPartyPurge.hasMore) {
+          console.warn(
+            "[first-party-signals] retention purge reached its bounded page; another invocation is required",
+          );
+        }
       } catch (error) {
         firstPartyPurgeError = error;
         console.error("[first-party-signals] retention purge failed", {

--- a/src/server/features/first-party-signals/FirstPartyCredentialVault.ts
+++ b/src/server/features/first-party-signals/FirstPartyCredentialVault.ts
@@ -1,0 +1,21 @@
+import { symmetricDecrypt, symmetricEncrypt } from "better-auth/crypto";
+import { getAuth } from "@/lib/auth";
+import { getOptionalEnvValue } from "@/server/lib/runtime-env";
+import { MIN_BETTER_AUTH_SECRET_LENGTH } from "@/shared/selfhost-checks";
+
+async function isConfigured(): Promise<boolean> {
+  const secret = (await getOptionalEnvValue("BETTER_AUTH_SECRET"))?.trim();
+  return Boolean(secret && secret.length >= MIN_BETTER_AUTH_SECRET_LENGTH);
+}
+
+async function encrypt(value: string): Promise<string> {
+  const context = await getAuth().$context;
+  return symmetricEncrypt({ key: context.secretConfig, data: value });
+}
+
+async function decrypt(value: string): Promise<string> {
+  const context = await getAuth().$context;
+  return symmetricDecrypt({ key: context.secretConfig, data: value });
+}
+
+export const FirstPartyCredentialVault = { isConfigured, encrypt, decrypt };

--- a/src/server/features/first-party-signals/FirstPartyIngestRateLimit.ts
+++ b/src/server/features/first-party-signals/FirstPartyIngestRateLimit.ts
@@ -9,6 +9,7 @@ type RateLimitBinding = {
 
 type FirstPartyIngestRateLimitEnv = {
   FIRST_PARTY_INGEST_EDGE_LIMITS_REQUIRED?: string;
+  FIRST_PARTY_INGEST_RATE_LIMIT_SCOPE?: string;
   FIRST_PARTY_INGEST_GLOBAL_RATE_LIMIT?: RateLimitBinding;
   FIRST_PARTY_INGEST_CLAIMED_SOURCE_RATE_LIMIT?: RateLimitBinding;
   FIRST_PARTY_INGEST_RATE_LIMIT?: RateLimitBinding;
@@ -22,6 +23,7 @@ export type FirstPartyIngestRateLimitDecision =
 function bindingsAreExpected(env: FirstPartyIngestRateLimitEnv): boolean {
   return (
     env.FIRST_PARTY_INGEST_EDGE_LIMITS_REQUIRED === "true" ||
+    Boolean(env.FIRST_PARTY_INGEST_RATE_LIMIT_SCOPE?.trim()) ||
     Boolean(env.FIRST_PARTY_INGEST_GLOBAL_RATE_LIMIT) ||
     Boolean(env.FIRST_PARTY_INGEST_CLAIMED_SOURCE_RATE_LIMIT) ||
     Boolean(env.FIRST_PARTY_INGEST_RATE_LIMIT)
@@ -34,6 +36,15 @@ function hasCompleteBindingSet(env: FirstPartyIngestRateLimitEnv): boolean {
     env.FIRST_PARTY_INGEST_CLAIMED_SOURCE_RATE_LIMIT &&
     env.FIRST_PARTY_INGEST_RATE_LIMIT,
   );
+}
+
+function getRateLimitScope(env: FirstPartyIngestRateLimitEnv): string | null {
+  const scope = env.FIRST_PARTY_INGEST_RATE_LIMIT_SCOPE?.trim();
+  return scope ? scope : null;
+}
+
+function scopedKey(scope: string, key: string): string {
+  return `${scope}:${key}`;
 }
 
 async function applyLimit(
@@ -53,6 +64,8 @@ async function applyLimit(
  * Applies two non-identifying edge guards before body reads, database access,
  * secret decryption, or HMAC work. The constant key bounds random UUID sprays;
  * the opaque claimed-source key bounds repeated abuse without IP persistence.
+ * A trusted deployment scope isolates counters when namespace IDs are reused
+ * by other Workers in the same Cloudflare account.
  */
 export async function enforceFirstPartyPreAuthRateLimits(
   env: FirstPartyIngestRateLimitEnv,
@@ -61,15 +74,24 @@ export async function enforceFirstPartyPreAuthRateLimits(
   if (!bindingsAreExpected(env)) return "allowed";
   const globalLimit = env.FIRST_PARTY_INGEST_GLOBAL_RATE_LIMIT;
   const claimedSourceLimit = env.FIRST_PARTY_INGEST_CLAIMED_SOURCE_RATE_LIMIT;
-  if (!hasCompleteBindingSet(env) || !globalLimit || !claimedSourceLimit) {
+  const scope = getRateLimitScope(env);
+  if (
+    !hasCompleteBindingSet(env) ||
+    !globalLimit ||
+    !claimedSourceLimit ||
+    !scope
+  ) {
     return "unavailable";
   }
 
-  const globalDecision = await applyLimit(globalLimit, GLOBAL_RECEIVER_KEY);
+  const globalDecision = await applyLimit(
+    globalLimit,
+    scopedKey(scope, GLOBAL_RECEIVER_KEY),
+  );
   if (globalDecision !== "allowed") return globalDecision;
   return applyLimit(
     claimedSourceLimit,
-    claimedSourceId ?? INVALID_CLAIMED_SOURCE_KEY,
+    scopedKey(scope, claimedSourceId ?? INVALID_CLAIMED_SOURCE_KEY),
   );
 }
 
@@ -80,8 +102,9 @@ export async function enforceFirstPartyAuthenticatedRateLimit(
 ): Promise<FirstPartyIngestRateLimitDecision> {
   if (!bindingsAreExpected(env)) return "allowed";
   const authenticatedLimit = env.FIRST_PARTY_INGEST_RATE_LIMIT;
-  if (!hasCompleteBindingSet(env) || !authenticatedLimit) {
+  const scope = getRateLimitScope(env);
+  if (!hasCompleteBindingSet(env) || !authenticatedLimit || !scope) {
     return "unavailable";
   }
-  return applyLimit(authenticatedLimit, sourceId);
+  return applyLimit(authenticatedLimit, scopedKey(scope, sourceId));
 }

--- a/src/server/features/first-party-signals/FirstPartyIngestRateLimit.ts
+++ b/src/server/features/first-party-signals/FirstPartyIngestRateLimit.ts
@@ -1,0 +1,87 @@
+export const FIRST_PARTY_INGEST_RETRY_AFTER_SECONDS = 60;
+
+const GLOBAL_RECEIVER_KEY = "aggregate-receiver";
+const INVALID_CLAIMED_SOURCE_KEY = "invalid-or-missing-source";
+
+type RateLimitBinding = {
+  limit: (input: { key: string }) => Promise<{ success: boolean }>;
+};
+
+type FirstPartyIngestRateLimitEnv = {
+  FIRST_PARTY_INGEST_EDGE_LIMITS_REQUIRED?: string;
+  FIRST_PARTY_INGEST_GLOBAL_RATE_LIMIT?: RateLimitBinding;
+  FIRST_PARTY_INGEST_CLAIMED_SOURCE_RATE_LIMIT?: RateLimitBinding;
+  FIRST_PARTY_INGEST_RATE_LIMIT?: RateLimitBinding;
+};
+
+export type FirstPartyIngestRateLimitDecision =
+  | "allowed"
+  | "rate_limited"
+  | "unavailable";
+
+function bindingsAreExpected(env: FirstPartyIngestRateLimitEnv): boolean {
+  return (
+    env.FIRST_PARTY_INGEST_EDGE_LIMITS_REQUIRED === "true" ||
+    Boolean(env.FIRST_PARTY_INGEST_GLOBAL_RATE_LIMIT) ||
+    Boolean(env.FIRST_PARTY_INGEST_CLAIMED_SOURCE_RATE_LIMIT) ||
+    Boolean(env.FIRST_PARTY_INGEST_RATE_LIMIT)
+  );
+}
+
+function hasCompleteBindingSet(env: FirstPartyIngestRateLimitEnv): boolean {
+  return Boolean(
+    env.FIRST_PARTY_INGEST_GLOBAL_RATE_LIMIT &&
+    env.FIRST_PARTY_INGEST_CLAIMED_SOURCE_RATE_LIMIT &&
+    env.FIRST_PARTY_INGEST_RATE_LIMIT,
+  );
+}
+
+async function applyLimit(
+  binding: RateLimitBinding,
+  key: string,
+): Promise<FirstPartyIngestRateLimitDecision> {
+  try {
+    return (await binding.limit({ key })).success ? "allowed" : "rate_limited";
+  } catch {
+    // The receiver is public by design. A configured edge guard becoming
+    // unavailable must not silently turn an outage into an unbounded path.
+    return "unavailable";
+  }
+}
+
+/**
+ * Applies two non-identifying edge guards before body reads, database access,
+ * secret decryption, or HMAC work. The constant key bounds random UUID sprays;
+ * the opaque claimed-source key bounds repeated abuse without IP persistence.
+ */
+export async function enforceFirstPartyPreAuthRateLimits(
+  env: FirstPartyIngestRateLimitEnv,
+  claimedSourceId: string | null,
+): Promise<FirstPartyIngestRateLimitDecision> {
+  if (!bindingsAreExpected(env)) return "allowed";
+  const globalLimit = env.FIRST_PARTY_INGEST_GLOBAL_RATE_LIMIT;
+  const claimedSourceLimit = env.FIRST_PARTY_INGEST_CLAIMED_SOURCE_RATE_LIMIT;
+  if (!hasCompleteBindingSet(env) || !globalLimit || !claimedSourceLimit) {
+    return "unavailable";
+  }
+
+  const globalDecision = await applyLimit(globalLimit, GLOBAL_RECEIVER_KEY);
+  if (globalDecision !== "allowed") return globalDecision;
+  return applyLimit(
+    claimedSourceLimit,
+    claimedSourceId ?? INVALID_CLAIMED_SOURCE_KEY,
+  );
+}
+
+/** Preserves the stricter authenticated per-source limiter after HMAC. */
+export async function enforceFirstPartyAuthenticatedRateLimit(
+  env: FirstPartyIngestRateLimitEnv,
+  sourceId: string,
+): Promise<FirstPartyIngestRateLimitDecision> {
+  if (!bindingsAreExpected(env)) return "allowed";
+  const authenticatedLimit = env.FIRST_PARTY_INGEST_RATE_LIMIT;
+  if (!hasCompleteBindingSet(env) || !authenticatedLimit) {
+    return "unavailable";
+  }
+  return applyLimit(authenticatedLimit, sourceId);
+}

--- a/src/server/features/first-party-signals/FirstPartyPathPolicy.ts
+++ b/src/server/features/first-party-signals/FirstPartyPathPolicy.ts
@@ -4,11 +4,33 @@ const ALWAYS_PRIVATE_PREFIXES = [
   "/admin",
   "/auth",
   "/account",
+  "/accounts",
+  "/billing",
+  "/callback",
   "/checkout",
+  "/dashboard",
   "/login",
+  "/oauth",
+  "/order",
+  "/orders",
   "/p",
+  "/payment",
+  "/payments",
+  "/profile",
+  "/profiles",
+  "/register",
+  "/session",
+  "/sessions",
+  "/sign-in",
+  "/sign-up",
+  "/signin",
+  "/signup",
   "/settings",
+  "/user",
+  "/users",
 ] as const;
+
+const MAX_PERCENT_DECODE_PASSES = 8;
 
 function projectOrigin(domain: string): string | null {
   const value = domain.trim();
@@ -49,35 +71,54 @@ function looksLikeOpaqueIdentifier(segment: string): boolean {
   );
 }
 
-export function hasSensitivePathIdentifier(path: string): boolean {
-  let decoded = path;
-  try {
-    for (let pass = 0; pass < 8; pass += 1) {
-      const next = decodeURIComponent(decoded);
-      if (next === decoded) break;
-      decoded = next;
-    }
-    if (/%[0-9a-f]{2}/i.test(decoded)) return true;
-    decoded = decoded.normalize("NFKC");
-  } catch {
-    return true;
+function hasControlCharacter(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit <= 0x1f || codeUnit === 0x7f) return true;
   }
-
-  return decoded
-    .split("/")
-    .filter(Boolean)
-    .some((segment) => {
-      return (
-        segment.includes("@") ||
-        looksLikeOpaqueIdentifier(segment) ||
-        /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
-          segment,
-        )
-      );
-    });
+  return false;
 }
 
-function normalizePath(value: string, origin: string): string | null {
+function canonicalizeSegment(value: string): string | null {
+  let decoded = value;
+  try {
+    let stable = false;
+    for (let pass = 0; pass < MAX_PERCENT_DECODE_PASSES; pass += 1) {
+      const next = decodeURIComponent(decoded);
+      if (next === decoded) {
+        stable = true;
+        break;
+      }
+      decoded = next;
+    }
+    decoded = decoded.normalize("NFKC");
+    if (
+      !stable ||
+      /%[0-9a-f]{2}/i.test(decoded) ||
+      decoded.includes("/") ||
+      decoded.includes("\\") ||
+      decoded === "." ||
+      decoded === ".." ||
+      hasControlCharacter(decoded)
+    ) {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+
+  // Re-encode each segment after decoding so equivalent spellings such as
+  // `/pr%69cing` and `/pricing` have one allowlist identity. Uppercase escapes
+  // make the representation deterministic across runtimes.
+  return encodeURIComponent(decoded)
+    .replace(
+      /[!'()*]/g,
+      (character) => `%${character.charCodeAt(0).toString(16).toUpperCase()}`,
+    )
+    .replace(/%[0-9a-f]{2}/gi, (escape) => escape.toUpperCase());
+}
+
+function canonicalizePath(value: string): string | null {
   const trimmed = value.trim();
   if (
     !trimmed.startsWith("/") ||
@@ -89,17 +130,34 @@ function normalizePath(value: string, origin: string): string | null {
   ) {
     return null;
   }
-  try {
-    const url = new URL(trimmed, origin);
-    if (url.origin !== origin) return null;
-    return url.pathname;
-  } catch {
-    return null;
-  }
+
+  const segments = trimmed.slice(1).split("/");
+  const canonical = segments.map(canonicalizeSegment);
+  if (canonical.some((segment) => segment === null)) return null;
+  return `/${canonical.join("/")}`;
+}
+
+export function hasSensitivePathIdentifier(path: string): boolean {
+  const canonical = canonicalizePath(path);
+  if (!canonical) return true;
+
+  return canonical
+    .split("/")
+    .filter(Boolean)
+    .some((segment) => {
+      const decoded = decodeURIComponent(segment);
+      return (
+        decoded.includes("@") ||
+        looksLikeOpaqueIdentifier(decoded) ||
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+          decoded,
+        )
+      );
+    });
 }
 
 function normalizeAllowedPath(value: string): string | null {
-  const path = normalizePath(value, "https://paths.invalid");
+  const path = canonicalizePath(value);
   if (!path || isAlwaysPrivatePath(path) || hasSensitivePathIdentifier(path)) {
     return null;
   }
@@ -127,7 +185,7 @@ export function normalizePublicLandingPath(input: {
 }): string | null {
   const origin = projectOrigin(input.projectDomain);
   if (!origin) return null;
-  const path = normalizePath(input.value, origin);
+  const path = canonicalizePath(input.value);
   if (!path || isAlwaysPrivatePath(path) || hasSensitivePathIdentifier(path)) {
     return null;
   }

--- a/src/server/features/first-party-signals/FirstPartyPathPolicy.ts
+++ b/src/server/features/first-party-signals/FirstPartyPathPolicy.ts
@@ -1,0 +1,135 @@
+const ALWAYS_PRIVATE_PREFIXES = [
+  "/api",
+  "/_",
+  "/admin",
+  "/auth",
+  "/account",
+  "/checkout",
+  "/login",
+  "/p",
+  "/settings",
+] as const;
+
+function projectOrigin(domain: string): string | null {
+  const value = domain.trim();
+  if (!value) return null;
+  try {
+    const url = new URL(
+      /^https?:\/\//i.test(value) ? value : `https://${value}`,
+    );
+    if (!["http:", "https:"].includes(url.protocol) || !url.hostname)
+      return null;
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+function pathMatchesPrefix(path: string, prefix: string): boolean {
+  return prefix === "/"
+    ? path === "/"
+    : path === prefix || path.startsWith(`${prefix}/`);
+}
+
+function isAlwaysPrivatePath(path: string): boolean {
+  return ALWAYS_PRIVATE_PREFIXES.some((prefix) =>
+    pathMatchesPrefix(path.toLowerCase(), prefix),
+  );
+}
+
+function looksLikeOpaqueIdentifier(segment: string): boolean {
+  const compact = segment.replace(/[.\s()+-]/g, "");
+  return (
+    /^\d{7,15}$/.test(compact) ||
+    /^(?:[a-z]{3}\d{3}|[a-z]{2}\d{3}[a-z]{2})$/i.test(compact) ||
+    /^(?=[a-z\d_-]*[a-z])(?=[a-z\d_-]*\d)[a-z\d_-]{16,}$/i.test(segment) ||
+    /^(?:user|usr|session|sess|order|ord|account|acct)[_-](?=[a-z\d_-]*\d)[a-z\d_-]{4,}$/i.test(
+      segment,
+    )
+  );
+}
+
+export function hasSensitivePathIdentifier(path: string): boolean {
+  let decoded = path;
+  try {
+    for (let pass = 0; pass < 8; pass += 1) {
+      const next = decodeURIComponent(decoded);
+      if (next === decoded) break;
+      decoded = next;
+    }
+    if (/%[0-9a-f]{2}/i.test(decoded)) return true;
+    decoded = decoded.normalize("NFKC");
+  } catch {
+    return true;
+  }
+
+  return decoded
+    .split("/")
+    .filter(Boolean)
+    .some((segment) => {
+      return (
+        segment.includes("@") ||
+        looksLikeOpaqueIdentifier(segment) ||
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+          segment,
+        )
+      );
+    });
+}
+
+function normalizePath(value: string, origin: string): string | null {
+  const trimmed = value.trim();
+  if (
+    !trimmed.startsWith("/") ||
+    trimmed.startsWith("//") ||
+    trimmed.includes("?") ||
+    trimmed.includes("#") ||
+    trimmed.includes("\\") ||
+    trimmed.length > 1_024
+  ) {
+    return null;
+  }
+  try {
+    const url = new URL(trimmed, origin);
+    if (url.origin !== origin) return null;
+    return url.pathname;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeAllowedPath(value: string): string | null {
+  const path = normalizePath(value, "https://paths.invalid");
+  if (!path || isAlwaysPrivatePath(path) || hasSensitivePathIdentifier(path)) {
+    return null;
+  }
+  return path;
+}
+
+export function normalizeAllowedPaths(values: string[]): string[] {
+  const normalized = values.map(normalizeAllowedPath);
+  if (
+    normalized.some((path) => path === null) ||
+    new Set(normalized).size !== normalized.length ||
+    normalized.length === 0
+  ) {
+    throw new Error(
+      "Every allowed landing path must be unique, public, and identifier-free.",
+    );
+  }
+  return normalized.filter((path): path is string => path !== null);
+}
+
+export function normalizePublicLandingPath(input: {
+  value: string;
+  projectDomain: string;
+  allowedPaths: string[];
+}): string | null {
+  const origin = projectOrigin(input.projectDomain);
+  if (!origin) return null;
+  const path = normalizePath(input.value, origin);
+  if (!path || isAlwaysPrivatePath(path) || hasSensitivePathIdentifier(path)) {
+    return null;
+  }
+  return input.allowedPaths.includes(path) ? path : null;
+}

--- a/src/server/features/first-party-signals/FirstPartyReportingRepository.query.test.ts
+++ b/src/server/features/first-party-signals/FirstPartyReportingRepository.query.test.ts
@@ -146,7 +146,12 @@ describe("FirstPartyReportingRepository query boundaries", () => {
     ).resolves.toBe(true);
   });
 
-  it("purges one bounded project-scoped retention page at a time", async () => {
+  it("paginates more than 250 expired receipts within one project", async () => {
+    const projectRows = Array.from(
+      { length: 251 },
+      (_, index) =>
+        `('cleanup_bulk_a_${String(index).padStart(3, "0")}', 'source_cleanup_a', '2025-01-01', 'complete', 'attempt_bulk_a_${index}')`,
+    ).join(",\n");
     await client.executeMultiple(`
       INSERT INTO first_party_signal_sources (id, project_id)
         VALUES
@@ -155,9 +160,7 @@ describe("FirstPartyReportingRepository query boundaries", () => {
       INSERT INTO first_party_signal_batches
         (id, source_id, snapshot_date, status, processing_lease_id)
         VALUES
-          ('cleanup_a_1', 'source_cleanup_a', '2025-01-01', 'complete', 'attempt_1'),
-          ('cleanup_a_2', 'source_cleanup_a', '2025-01-02', 'complete', 'attempt_2'),
-          ('cleanup_a_3', 'source_cleanup_a', '2025-01-03', 'complete', 'attempt_3'),
+          ${projectRows},
           ('cleanup_a_current', 'source_cleanup_a', '2026-09-01', 'complete', 'attempt_4'),
           ('cleanup_b_1', 'source_cleanup_b', '2025-01-01', 'complete', 'attempt_5');
     `);
@@ -165,14 +168,14 @@ describe("FirstPartyReportingRepository query boundaries", () => {
     await expect(
       FirstPartySignalsRepository.purgeOlderThan({
         cutoffDate: "2025-07-31",
-        limit: 2,
+        limit: 250,
         projectId: "project_cleanup_a",
       }),
-    ).resolves.toEqual({ deleted: 2, hasMore: true });
+    ).resolves.toEqual({ deleted: 250, hasMore: true });
     await expect(
       FirstPartySignalsRepository.purgeOlderThan({
         cutoffDate: "2025-07-31",
-        limit: 2,
+        limit: 250,
         projectId: "project_cleanup_a",
       }),
     ).resolves.toEqual({ deleted: 1, hasMore: false });

--- a/src/server/features/first-party-signals/FirstPartyReportingRepository.query.test.ts
+++ b/src/server/features/first-party-signals/FirstPartyReportingRepository.query.test.ts
@@ -1,0 +1,148 @@
+import { createClient, type Client } from "@libsql/client";
+import { drizzle } from "drizzle-orm/libsql";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import type * as ReportingRepositoryModule from "./FirstPartyReportingRepository";
+import type * as SignalsRepositoryModule from "./FirstPartySignalsRepository";
+
+vi.mock("cloudflare:workers", () => ({
+  env: { DATABASE_PROVIDER: "d1" },
+}));
+
+let client: Client;
+let FirstPartyReportingRepository: typeof ReportingRepositoryModule.FirstPartyReportingRepository;
+let FirstPartySignalsRepository: typeof SignalsRepositoryModule.FirstPartySignalsRepository;
+
+beforeAll(async () => {
+  client = createClient({ url: "file::memory:" });
+  const testDb = drizzle(client);
+  vi.doMock("@/db", () => ({ db: testDb }));
+
+  await client.executeMultiple(`
+    CREATE TABLE first_party_signal_sources (
+      id TEXT PRIMARY KEY,
+      project_id TEXT NOT NULL
+    );
+    CREATE TABLE first_party_signal_batches (
+      id TEXT PRIMARY KEY,
+      source_id TEXT NOT NULL,
+      snapshot_date TEXT NOT NULL,
+      status TEXT NOT NULL,
+      processing_lease_id TEXT,
+      completed_at TEXT
+    );
+    CREATE TABLE first_party_signal_daily_aggregates (
+      id TEXT PRIMARY KEY,
+      batch_receipt_id TEXT NOT NULL,
+      processing_attempt_id TEXT NOT NULL,
+      landing_path TEXT NOT NULL,
+      search_started INTEGER NOT NULL,
+      search_completed INTEGER NOT NULL,
+      search_no_results INTEGER NOT NULL,
+      registrations_completed INTEGER NOT NULL,
+      checkout_started INTEGER NOT NULL,
+      payments_completed INTEGER NOT NULL,
+      received_at TEXT NOT NULL
+    );
+  `);
+
+  ({ FirstPartyReportingRepository } =
+    await import("./FirstPartyReportingRepository"));
+  ({ FirstPartySignalsRepository } =
+    await import("./FirstPartySignalsRepository"));
+});
+
+afterAll(() => client.close());
+
+async function insertAggregate(input: {
+  id: string;
+  batchReceiptId: string;
+  attemptId: string;
+  searches: number;
+}) {
+  await client.execute({
+    sql: `INSERT INTO first_party_signal_daily_aggregates
+      (id, batch_receipt_id, processing_attempt_id, landing_path,
+       search_started, search_completed, search_no_results,
+       registrations_completed, checkout_started, payments_completed,
+       received_at)
+      VALUES (?, ?, ?, '/pricing', ?, ?, 0, 0, 0, 0, '2026-09-04T12:00:00.000Z')`,
+    args: [
+      input.id,
+      input.batchReceiptId,
+      input.attemptId,
+      input.searches,
+      input.searches,
+    ],
+  });
+}
+
+describe("FirstPartyReportingRepository query boundaries", () => {
+  it("reads only the winning attempt owned by the requested project", async () => {
+    await client.executeMultiple(`
+      INSERT INTO first_party_signal_sources (id, project_id)
+        VALUES ('source_a', 'project_a'), ('source_b', 'project_b');
+      INSERT INTO first_party_signal_batches
+        (id, source_id, snapshot_date, status, processing_lease_id)
+        VALUES
+          ('batch_a', 'source_a', '2026-09-04', 'complete', 'attempt_winner'),
+          ('batch_b', 'source_b', '2026-09-04', 'complete', 'attempt_b');
+    `);
+    await insertAggregate({
+      id: "row_winner",
+      batchReceiptId: "batch_a",
+      attemptId: "attempt_winner",
+      searches: 5,
+    });
+    await insertAggregate({
+      id: "row_stale",
+      batchReceiptId: "batch_a",
+      attemptId: "attempt_expired",
+      searches: 999,
+    });
+    await insertAggregate({
+      id: "row_other_project",
+      batchReceiptId: "batch_b",
+      attemptId: "attempt_b",
+      searches: 777,
+    });
+
+    const funnel = await FirstPartyReportingRepository.getFunnel(
+      "project_a",
+      "2026-09-01",
+      "2026-09-30",
+    );
+    const landings = await FirstPartyReportingRepository.getLandingConversions(
+      "project_a",
+      "2026-09-01",
+      "2026-09-30",
+      10,
+    );
+
+    expect(Number(funnel?.searchStarted)).toBe(5);
+    expect(landings).toHaveLength(1);
+    expect(Number(landings[0]?.searchStarted)).toBe(5);
+  });
+
+  it("publishes a receipt only for its current processing attempt", async () => {
+    await client.executeMultiple(`
+      INSERT INTO first_party_signal_batches
+        (id, source_id, snapshot_date, status, processing_lease_id)
+        VALUES ('batch_c', 'source_a', '2026-09-05', 'pending', 'attempt_current');
+    `);
+
+    await expect(
+      FirstPartySignalsRepository.completeBatch({
+        batchReceiptId: "batch_c",
+        leaseId: "attempt_expired",
+        now: "2026-09-05T12:00:00.000Z",
+      }),
+    ).resolves.toBe(false);
+    await expect(
+      FirstPartySignalsRepository.completeBatch({
+        batchReceiptId: "batch_c",
+        leaseId: "attempt_current",
+        now: "2026-09-05T12:00:01.000Z",
+      }),
+    ).resolves.toBe(true);
+  });
+});

--- a/src/server/features/first-party-signals/FirstPartyReportingRepository.query.test.ts
+++ b/src/server/features/first-party-signals/FirstPartyReportingRepository.query.test.ts
@@ -145,4 +145,45 @@ describe("FirstPartyReportingRepository query boundaries", () => {
       }),
     ).resolves.toBe(true);
   });
+
+  it("purges one bounded project-scoped retention page at a time", async () => {
+    await client.executeMultiple(`
+      INSERT INTO first_party_signal_sources (id, project_id)
+        VALUES
+          ('source_cleanup_a', 'project_cleanup_a'),
+          ('source_cleanup_b', 'project_cleanup_b');
+      INSERT INTO first_party_signal_batches
+        (id, source_id, snapshot_date, status, processing_lease_id)
+        VALUES
+          ('cleanup_a_1', 'source_cleanup_a', '2025-01-01', 'complete', 'attempt_1'),
+          ('cleanup_a_2', 'source_cleanup_a', '2025-01-02', 'complete', 'attempt_2'),
+          ('cleanup_a_3', 'source_cleanup_a', '2025-01-03', 'complete', 'attempt_3'),
+          ('cleanup_a_current', 'source_cleanup_a', '2026-09-01', 'complete', 'attempt_4'),
+          ('cleanup_b_1', 'source_cleanup_b', '2025-01-01', 'complete', 'attempt_5');
+    `);
+
+    await expect(
+      FirstPartySignalsRepository.purgeOlderThan({
+        cutoffDate: "2025-07-31",
+        limit: 2,
+        projectId: "project_cleanup_a",
+      }),
+    ).resolves.toEqual({ deleted: 2, hasMore: true });
+    await expect(
+      FirstPartySignalsRepository.purgeOlderThan({
+        cutoffDate: "2025-07-31",
+        limit: 2,
+        projectId: "project_cleanup_a",
+      }),
+    ).resolves.toEqual({ deleted: 1, hasMore: false });
+
+    const remaining = await client.execute({
+      sql: "SELECT id FROM first_party_signal_batches WHERE id LIKE 'cleanup_%' ORDER BY id",
+      args: [],
+    });
+    expect(remaining.rows.map((row) => row.id)).toEqual([
+      "cleanup_a_current",
+      "cleanup_b_1",
+    ]);
+  });
 });

--- a/src/server/features/first-party-signals/FirstPartyReportingRepository.ts
+++ b/src/server/features/first-party-signals/FirstPartyReportingRepository.ts
@@ -1,0 +1,109 @@
+import { and, desc, eq, sql } from "drizzle-orm";
+import { db } from "@/db";
+import {
+  firstPartySignalBatches,
+  firstPartySignalDailyAggregates,
+  firstPartySignalSources,
+} from "@/db/schema";
+
+const aggregateSelection = {
+  searchStarted: sql<number>`coalesce(sum(${firstPartySignalDailyAggregates.searchStarted}), 0)`,
+  searchCompleted: sql<number>`coalesce(sum(${firstPartySignalDailyAggregates.searchCompleted}), 0)`,
+  searchNoResults: sql<number>`coalesce(sum(${firstPartySignalDailyAggregates.searchNoResults}), 0)`,
+  registrationsCompleted: sql<number>`coalesce(sum(${firstPartySignalDailyAggregates.registrationsCompleted}), 0)`,
+  checkoutStarted: sql<number>`coalesce(sum(${firstPartySignalDailyAggregates.checkoutStarted}), 0)`,
+  paymentsCompleted: sql<number>`coalesce(sum(${firstPartySignalDailyAggregates.paymentsCompleted}), 0)`,
+};
+
+function currentAggregateWhere(
+  projectId: string,
+  startDate: string,
+  endDate: string,
+) {
+  return and(
+    eq(firstPartySignalSources.projectId, projectId),
+    eq(firstPartySignalBatches.status, "complete"),
+    sql`${firstPartySignalBatches.snapshotDate} >= ${startDate}`,
+    sql`${firstPartySignalBatches.snapshotDate} <= ${endDate}`,
+  );
+}
+
+async function getFunnel(
+  projectId: string,
+  startDate: string,
+  endDate: string,
+) {
+  const [row] = await db
+    .select({
+      ...aggregateSelection,
+      observedAt: sql<
+        string | null
+      >`max(${firstPartySignalBatches.snapshotDate})`,
+      receivedAt: sql<
+        string | null
+      >`max(${firstPartySignalDailyAggregates.receivedAt})`,
+    })
+    .from(firstPartySignalDailyAggregates)
+    .innerJoin(
+      firstPartySignalBatches,
+      and(
+        eq(
+          firstPartySignalBatches.id,
+          firstPartySignalDailyAggregates.batchReceiptId,
+        ),
+        eq(
+          firstPartySignalBatches.processingLeaseId,
+          firstPartySignalDailyAggregates.processingAttemptId,
+        ),
+      ),
+    )
+    .innerJoin(
+      firstPartySignalSources,
+      eq(firstPartySignalSources.id, firstPartySignalBatches.sourceId),
+    )
+    .where(currentAggregateWhere(projectId, startDate, endDate));
+  return row ?? null;
+}
+
+async function getLandingConversions(
+  projectId: string,
+  startDate: string,
+  endDate: string,
+  limit: number,
+) {
+  return db
+    .select({
+      landingPath: firstPartySignalDailyAggregates.landingPath,
+      ...aggregateSelection,
+    })
+    .from(firstPartySignalDailyAggregates)
+    .innerJoin(
+      firstPartySignalBatches,
+      and(
+        eq(
+          firstPartySignalBatches.id,
+          firstPartySignalDailyAggregates.batchReceiptId,
+        ),
+        eq(
+          firstPartySignalBatches.processingLeaseId,
+          firstPartySignalDailyAggregates.processingAttemptId,
+        ),
+      ),
+    )
+    .innerJoin(
+      firstPartySignalSources,
+      eq(firstPartySignalSources.id, firstPartySignalBatches.sourceId),
+    )
+    .where(currentAggregateWhere(projectId, startDate, endDate))
+    .groupBy(firstPartySignalDailyAggregates.landingPath)
+    .orderBy(
+      desc(aggregateSelection.paymentsCompleted),
+      desc(aggregateSelection.searchStarted),
+    )
+    .limit(limit);
+}
+
+export const FirstPartyReportingRepository = {
+  getFunnel,
+  getLandingConversions,
+};

--- a/src/server/features/first-party-signals/FirstPartyReportingService.test.ts
+++ b/src/server/features/first-party-signals/FirstPartyReportingService.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FirstPartyReportingService } from "./FirstPartyReportingService";
+
+const mocks = vi.hoisted(() => ({
+  getFunnel: vi.fn(),
+  getLandingConversions: vi.fn(),
+}));
+
+vi.mock("./FirstPartyReportingRepository", () => ({
+  FirstPartyReportingRepository: mocks,
+}));
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("FirstPartyReportingService", () => {
+  it("returns no_data rather than invented zeroes when no snapshot exists", async () => {
+    mocks.getFunnel.mockResolvedValue({
+      searchStarted: 0,
+      searchCompleted: 0,
+      searchNoResults: 0,
+      registrationsCompleted: 0,
+      checkoutStarted: 0,
+      paymentsCompleted: 0,
+      observedAt: null,
+      receivedAt: null,
+    });
+
+    await expect(
+      FirstPartyReportingService.getFunnel({
+        projectId: "project_1",
+        startDate: "2026-09-01",
+        endDate: "2026-09-04",
+      }),
+    ).resolves.toMatchObject({
+      status: "no_data",
+      totals: null,
+      conversion: null,
+    });
+  });
+
+  it("normalizes cross-dialect totals and computes explicit rates", async () => {
+    mocks.getFunnel.mockResolvedValue({
+      searchStarted: "10",
+      searchCompleted: "8",
+      searchNoResults: "2",
+      registrationsCompleted: "4",
+      checkoutStarted: "2",
+      paymentsCompleted: "1",
+      observedAt: "2026-09-04",
+      receivedAt: "2026-09-04T12:00:00.000Z",
+    });
+
+    await expect(
+      FirstPartyReportingService.getFunnel({
+        projectId: "project_1",
+        startDate: "2026-09-01",
+        endDate: "2026-09-04",
+      }),
+    ).resolves.toMatchObject({
+      status: "ok",
+      totals: {
+        searchStarted: 10,
+        searchCompleted: 8,
+        paymentsCompleted: 1,
+      },
+      conversion: {
+        searchCompletionRate: 0.8,
+        noResultRate: 0.25,
+        paymentPerCheckoutRate: 0.5,
+      },
+    });
+  });
+
+  it("returns aggregate landing rows without user-level dimensions", async () => {
+    mocks.getLandingConversions.mockResolvedValue([
+      {
+        landingPath: "/pricing",
+        searchStarted: 20,
+        searchCompleted: 10,
+        searchNoResults: 1,
+        registrationsCompleted: 5,
+        checkoutStarted: 4,
+        paymentsCompleted: 2,
+      },
+    ]);
+
+    const result = await FirstPartyReportingService.getLandingConversions({
+      projectId: "project_1",
+      startDate: "2026-09-01",
+      endDate: "2026-09-04",
+      limit: 50,
+    });
+    expect(result.status).toBe("ok");
+    expect(result.rows[0]).toEqual({
+      landingPath: "/pricing",
+      searchStarted: 20,
+      searchCompleted: 10,
+      searchNoResults: 1,
+      registrationsCompleted: 5,
+      checkoutStarted: 4,
+      paymentsCompleted: 2,
+      conversion: {
+        searchCompletionRate: 0.5,
+        noResultRate: 0.1,
+        registrationPerSearchRate: 0.5,
+        checkoutPerSearchRate: 0.4,
+        paymentPerCheckoutRate: 0.5,
+      },
+    });
+  });
+});

--- a/src/server/features/first-party-signals/FirstPartyReportingService.ts
+++ b/src/server/features/first-party-signals/FirstPartyReportingService.ts
@@ -1,0 +1,123 @@
+import { AppError } from "@/server/lib/errors";
+import { FirstPartyReportingRepository } from "./FirstPartyReportingRepository";
+
+type FirstPartyFunnelTotals = {
+  searchStarted: number;
+  searchCompleted: number;
+  searchNoResults: number;
+  registrationsCompleted: number;
+  checkoutStarted: number;
+  paymentsCompleted: number;
+};
+
+function numericTotals(
+  value: Partial<FirstPartyFunnelTotals> | null,
+): FirstPartyFunnelTotals {
+  return {
+    searchStarted: Number(value?.searchStarted ?? 0),
+    searchCompleted: Number(value?.searchCompleted ?? 0),
+    searchNoResults: Number(value?.searchNoResults ?? 0),
+    registrationsCompleted: Number(value?.registrationsCompleted ?? 0),
+    checkoutStarted: Number(value?.checkoutStarted ?? 0),
+    paymentsCompleted: Number(value?.paymentsCompleted ?? 0),
+  };
+}
+
+function ratio(numerator: number, denominator: number): number | null {
+  return denominator === 0 ? null : numerator / denominator;
+}
+
+function conversionRates(totals: FirstPartyFunnelTotals) {
+  return {
+    searchCompletionRate: ratio(totals.searchCompleted, totals.searchStarted),
+    noResultRate: ratio(totals.searchNoResults, totals.searchCompleted),
+    registrationPerSearchRate: ratio(
+      totals.registrationsCompleted,
+      totals.searchCompleted,
+    ),
+    checkoutPerSearchRate: ratio(
+      totals.checkoutStarted,
+      totals.searchCompleted,
+    ),
+    paymentPerCheckoutRate: ratio(
+      totals.paymentsCompleted,
+      totals.checkoutStarted,
+    ),
+  };
+}
+
+function validateDateRange(startDate: string, endDate: string) {
+  if (startDate > endDate) {
+    throw new AppError(
+      "VALIDATION_ERROR",
+      "startDate must be on or before endDate.",
+    );
+  }
+}
+
+async function getFunnel(input: {
+  projectId: string;
+  startDate: string;
+  endDate: string;
+}) {
+  validateDateRange(input.startDate, input.endDate);
+  const row = await FirstPartyReportingRepository.getFunnel(
+    input.projectId,
+    input.startDate,
+    input.endDate,
+  );
+  const hasData = Boolean(row?.observedAt);
+  const totals = numericTotals(row);
+  return {
+    status: hasData ? ("ok" as const) : ("no_data" as const),
+    period: {
+      startDate: input.startDate,
+      endDate: input.endDate,
+      timezone: "UTC" as const,
+    },
+    observedAt: row?.observedAt ?? null,
+    receivedAt: row?.receivedAt ?? null,
+    totals: hasData ? totals : null,
+    conversion: hasData ? conversionRates(totals) : null,
+    privacy:
+      "Daily aggregate counts only; no users, sessions, identifiers, search terms, or amounts.",
+  };
+}
+
+async function getLandingConversions(input: {
+  projectId: string;
+  startDate: string;
+  endDate: string;
+  limit: number;
+}) {
+  validateDateRange(input.startDate, input.endDate);
+  const rows = await FirstPartyReportingRepository.getLandingConversions(
+    input.projectId,
+    input.startDate,
+    input.endDate,
+    input.limit,
+  );
+  return {
+    status: rows.length > 0 ? ("ok" as const) : ("no_data" as const),
+    period: {
+      startDate: input.startDate,
+      endDate: input.endDate,
+      timezone: "UTC" as const,
+    },
+    rows: rows.map((row) => {
+      const totals = numericTotals(row);
+      return {
+        landingPath: row.landingPath,
+        ...totals,
+        conversion: conversionRates(totals),
+      };
+    }),
+    privacy:
+      "Only explicitly allowlisted public pathnames and aggregate counts are returned.",
+  };
+}
+
+export const FirstPartyReportingService = {
+  getFunnel,
+  getLandingConversions,
+};

--- a/src/server/features/first-party-signals/FirstPartySecurity.test.ts
+++ b/src/server/features/first-party-signals/FirstPartySecurity.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import { firstPartyAggregateSnapshotSchema } from "@/shared/first-party-signals";
+import { bytesToHex } from "./encoding";
+import {
+  hasSensitivePathIdentifier,
+  normalizeAllowedPaths,
+  normalizePublicLandingPath,
+} from "./FirstPartyPathPolicy";
+import {
+  parseSignatureTimestamp,
+  verifyFirstPartySignature,
+} from "./FirstPartySignature";
+
+async function sign(secret: string, timestamp: string, body: Uint8Array) {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const prefix = new TextEncoder().encode(`${timestamp}.`);
+  const message = new Uint8Array(prefix.length + body.length);
+  message.set(prefix);
+  message.set(body, prefix.length);
+  return bytesToHex(
+    new Uint8Array(await crypto.subtle.sign("HMAC", key, message)),
+  );
+}
+
+describe("first-party aggregate signatures", () => {
+  it("verifies HMAC-SHA256 over timestamp and the exact raw bytes", async () => {
+    const secret = "secret";
+    const timestamp = "1788500000000";
+    const rawBody = new TextEncoder().encode('{"value":1}');
+    const signature = await sign(secret, timestamp, rawBody);
+
+    await expect(
+      verifyFirstPartySignature({ secret, timestamp, rawBody, signature }),
+    ).resolves.toBe(true);
+    await expect(
+      verifyFirstPartySignature({
+        secret,
+        timestamp,
+        rawBody: new TextEncoder().encode('{ "value": 1 }'),
+        signature,
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it("accepts only 10 or 13 digit timestamps within five minutes", () => {
+    const now = Date.UTC(2026, 8, 4, 12, 0, 0);
+    expect(parseSignatureTimestamp(String(now), now)).toBe(String(now));
+    expect(parseSignatureTimestamp(String(now / 1_000), now)).toBe(
+      String(now / 1_000),
+    );
+    expect(parseSignatureTimestamp(String(now - 300_001), now)).toBeNull();
+    expect(parseSignatureTimestamp("not-a-timestamp", now)).toBeNull();
+  });
+});
+
+describe("first-party landing path policy", () => {
+  it("requires an exact allowlisted public path", () => {
+    const allowedPaths = normalizeAllowedPaths(["/", "/pricing"]);
+    expect(
+      normalizePublicLandingPath({
+        value: "/pricing",
+        projectDomain: "www.example.com",
+        allowedPaths,
+      }),
+    ).toBe("/pricing");
+    expect(
+      normalizePublicLandingPath({
+        value: "/pricing/team",
+        projectDomain: "www.example.com",
+        allowedPaths,
+      }),
+    ).toBeNull();
+    expect(
+      normalizePublicLandingPath({
+        value: "/pricing?email=person@example.com",
+        projectDomain: "www.example.com",
+        allowedPaths,
+      }),
+    ).toBeNull();
+  });
+
+  it("fails closed on private and identifier-shaped paths", () => {
+    expect(() => normalizeAllowedPaths(["/checkout"])).toThrow();
+    expect(() => normalizeAllowedPaths(["/orders/12345678"])).toThrow();
+    expect(() => normalizeAllowedPaths(["/consulta/AB123CD"])).toThrow();
+    expect(() => normalizeAllowedPaths(["/profiles/user_abcd1234"])).toThrow();
+    expect(() =>
+      normalizeAllowedPaths(["/profiles/clx9ag2z50000qwerty123456"]),
+    ).toThrow();
+    expect(() =>
+      normalizeAllowedPaths(["/people/6ba7b810-9dad-11d1-80b4-00c04fd430c8"]),
+    ).toThrow();
+    expect(hasSensitivePathIdentifier("/person%2540example.com")).toBe(true);
+  });
+});
+
+describe("first-party aggregate payload", () => {
+  const row = {
+    landingPath: "/pricing",
+    searchStarted: 10,
+    searchCompleted: 8,
+    searchNoResults: 1,
+    registrationsCompleted: 3,
+    checkoutStarted: 2,
+    paymentsCompleted: 1,
+  };
+
+  it("accepts only the six nonnegative counters", () => {
+    expect(
+      firstPartyAggregateSnapshotSchema.safeParse({
+        schemaVersion: 1,
+        batchId: "f1a2ae17-b157-4bb9-b1a1-960ce8d4c01d",
+        snapshotDate: "2026-09-04",
+        rows: [row],
+      }).success,
+    ).toBe(true);
+    expect(
+      firstPartyAggregateSnapshotSchema.safeParse({
+        schemaVersion: 1,
+        batchId: "user-or-order-derived-id",
+        snapshotDate: "2026-09-04",
+        rows: [row],
+      }).success,
+    ).toBe(false);
+    for (const forbidden of [
+      { userId: "user_1" },
+      { email: "person@example.com" },
+      { amount: 100 },
+      { searchTerm: "private query" },
+      { sessionId: "session_1" },
+    ]) {
+      expect(
+        firstPartyAggregateSnapshotSchema.safeParse({
+          schemaVersion: 1,
+          batchId: "f1a2ae17-b157-4bb9-b1a1-960ce8d4c01d",
+          snapshotDate: "2026-09-04",
+          rows: [{ ...row, ...forbidden }],
+        }).success,
+      ).toBe(false);
+    }
+  });
+});

--- a/src/server/features/first-party-signals/FirstPartySecurity.test.ts
+++ b/src/server/features/first-party-signals/FirstPartySecurity.test.ts
@@ -71,6 +71,13 @@ describe("first-party landing path policy", () => {
     ).toBe("/pricing");
     expect(
       normalizePublicLandingPath({
+        value: "/pr%69cing",
+        projectDomain: "www.example.com",
+        allowedPaths,
+      }),
+    ).toBe("/pricing");
+    expect(
+      normalizePublicLandingPath({
         value: "/pricing/team",
         projectDomain: "www.example.com",
         allowedPaths,
@@ -97,6 +104,35 @@ describe("first-party landing path policy", () => {
       normalizeAllowedPaths(["/people/6ba7b810-9dad-11d1-80b4-00c04fd430c8"]),
     ).toThrow();
     expect(hasSensitivePathIdentifier("/person%2540example.com")).toBe(true);
+  });
+
+  it("canonicalizes percent encoding before private-path and uniqueness checks", () => {
+    for (const path of [
+      "/%61dmin",
+      "/%2561dmin",
+      "/d%61shboard",
+      "/profiles",
+      "/orders",
+      "/oauth/callback",
+    ]) {
+      expect(() => normalizeAllowedPaths([path])).toThrow();
+    }
+    expect(() => normalizeAllowedPaths(["/pricing", "/pr%69cing"])).toThrow();
+  });
+
+  it("rejects encoded separators and dot traversal at every decode depth", () => {
+    for (const path of [
+      "/public/%2Fadmin",
+      "/public/%252fadmin",
+      "/public/%5Cadmin",
+      "/public/%255cadmin",
+      "/public/%2e%2e/admin",
+      "/public/%252e%252e/admin",
+      "/public/../admin",
+      "/public/%EF%BC%8Fadmin",
+    ]) {
+      expect(() => normalizeAllowedPaths([path])).toThrow();
+    }
   });
 });
 

--- a/src/server/features/first-party-signals/FirstPartySignalsRepository.ts
+++ b/src/server/features/first-party-signals/FirstPartySignalsRepository.ts
@@ -344,12 +344,42 @@ async function failBatch(batchReceiptId: string, leaseId: string, now: string) {
     );
 }
 
-async function purgeOlderThan(cutoffDate: string) {
+async function purgeOlderThan(input: {
+  cutoffDate: string;
+  limit: number;
+  projectId?: string;
+}) {
+  const candidates = await db
+    .select({ id: firstPartySignalBatches.id })
+    .from(firstPartySignalBatches)
+    .innerJoin(
+      firstPartySignalSources,
+      eq(firstPartySignalSources.id, firstPartySignalBatches.sourceId),
+    )
+    .where(
+      and(
+        lt(firstPartySignalBatches.snapshotDate, input.cutoffDate),
+        input.projectId
+          ? eq(firstPartySignalSources.projectId, input.projectId)
+          : undefined,
+      ),
+    )
+    .orderBy(
+      asc(firstPartySignalBatches.snapshotDate),
+      asc(firstPartySignalBatches.id),
+    )
+    .limit(input.limit + 1);
+  const ids = candidates.slice(0, input.limit).map((row) => row.id);
+  if (ids.length === 0) return { deleted: 0, hasMore: false };
+
   const deleted = await db
     .delete(firstPartySignalBatches)
-    .where(lt(firstPartySignalBatches.snapshotDate, cutoffDate))
+    .where(inArray(firstPartySignalBatches.id, ids))
     .returning({ id: firstPartySignalBatches.id });
-  return deleted.length;
+  return {
+    deleted: deleted.length,
+    hasMore: candidates.length > input.limit,
+  };
 }
 
 export const FirstPartySignalsRepository = {

--- a/src/server/features/first-party-signals/FirstPartySignalsRepository.ts
+++ b/src/server/features/first-party-signals/FirstPartySignalsRepository.ts
@@ -1,0 +1,369 @@
+import { and, asc, eq, gt, inArray, isNull, lt, or } from "drizzle-orm";
+import { sort } from "remeda";
+import { db } from "@/db";
+import { executeInBatches, runBatch } from "@/db/runBatch";
+import {
+  firstPartySignalBatches,
+  firstPartySignalDailyAggregates,
+  firstPartySignalSourcePaths,
+  firstPartySignalSources,
+  projects,
+} from "@/db/schema";
+
+async function getSourceByProject(projectId: string) {
+  const [row] = await db
+    .select()
+    .from(firstPartySignalSources)
+    .where(eq(firstPartySignalSources.projectId, projectId))
+    .limit(1);
+  return row ?? null;
+}
+
+async function upsertSource(input: {
+  projectId: string;
+  organizationId: string;
+  name: string;
+  encryptedSecret: string;
+  secretHint: string;
+  createdByUserId: string;
+  allowedPaths: string[];
+  now: string;
+}): Promise<string> {
+  const existing = await getSourceByProject(input.projectId);
+  const sourceId = existing?.id ?? crypto.randomUUID();
+  await runBatch((tx) => [
+    tx
+      .insert(firstPartySignalSources)
+      .values({
+        id: sourceId,
+        projectId: input.projectId,
+        organizationId: input.organizationId,
+        name: input.name,
+        encryptedSecret: input.encryptedSecret,
+        secretHint: input.secretHint,
+        createdByUserId: input.createdByUserId,
+        revokedAt: null,
+        createdAt: existing?.createdAt ?? input.now,
+        updatedAt: input.now,
+      })
+      .onConflictDoUpdate({
+        target: firstPartySignalSources.projectId,
+        set: {
+          name: input.name,
+          encryptedSecret: input.encryptedSecret,
+          secretHint: input.secretHint,
+          createdByUserId: input.createdByUserId,
+          revokedAt: null,
+          updatedAt: input.now,
+        },
+      }),
+    tx
+      .delete(firstPartySignalSourcePaths)
+      .where(eq(firstPartySignalSourcePaths.sourceId, sourceId)),
+    ...input.allowedPaths.map((path) =>
+      tx.insert(firstPartySignalSourcePaths).values({
+        id: crypto.randomUUID(),
+        sourceId,
+        path,
+        createdAt: input.now,
+      }),
+    ),
+  ]);
+  return sourceId;
+}
+
+async function listSources(projectId: string) {
+  const rows = await db
+    .select({
+      id: firstPartySignalSources.id,
+      name: firstPartySignalSources.name,
+      secretHint: firstPartySignalSources.secretHint,
+      revokedAt: firstPartySignalSources.revokedAt,
+      createdAt: firstPartySignalSources.createdAt,
+      updatedAt: firstPartySignalSources.updatedAt,
+    })
+    .from(firstPartySignalSources)
+    .where(eq(firstPartySignalSources.projectId, projectId))
+    .orderBy(asc(firstPartySignalSources.name));
+  if (rows.length === 0) return [];
+  const paths = await db
+    .select({
+      sourceId: firstPartySignalSourcePaths.sourceId,
+      path: firstPartySignalSourcePaths.path,
+    })
+    .from(firstPartySignalSourcePaths)
+    .where(
+      inArray(
+        firstPartySignalSourcePaths.sourceId,
+        rows.map((row) => row.id),
+      ),
+    );
+  return rows.map((row) => ({
+    ...row,
+    allowedPaths: sort(
+      paths.filter((path) => path.sourceId === row.id).map((path) => path.path),
+      (a, b) => a.localeCompare(b),
+    ),
+  }));
+}
+
+async function revokeSource(projectId: string, sourceId: string, now: string) {
+  const rows = await db
+    .update(firstPartySignalSources)
+    .set({ encryptedSecret: "", revokedAt: now, updatedAt: now })
+    .where(
+      and(
+        eq(firstPartySignalSources.id, sourceId),
+        eq(firstPartySignalSources.projectId, projectId),
+      ),
+    )
+    .returning({ id: firstPartySignalSources.id });
+  return rows.length > 0;
+}
+
+async function getActiveSourceForIngest(sourceId: string) {
+  const [source] = await db
+    .select({
+      id: firstPartySignalSources.id,
+      projectId: firstPartySignalSources.projectId,
+      encryptedSecret: firstPartySignalSources.encryptedSecret,
+      projectDomain: projects.domain,
+    })
+    .from(firstPartySignalSources)
+    .innerJoin(projects, eq(projects.id, firstPartySignalSources.projectId))
+    .where(
+      and(
+        eq(firstPartySignalSources.id, sourceId),
+        isNull(firstPartySignalSources.revokedAt),
+      ),
+    )
+    .limit(1);
+  if (!source || !source.projectDomain) return null;
+  const paths = await db
+    .select({ path: firstPartySignalSourcePaths.path })
+    .from(firstPartySignalSourcePaths)
+    .where(eq(firstPartySignalSourcePaths.sourceId, sourceId));
+  return {
+    ...source,
+    projectDomain: source.projectDomain,
+    allowedPaths: paths.map((row) => row.path),
+  };
+}
+
+async function getBatch(sourceId: string, batchId: string) {
+  const [row] = await db
+    .select()
+    .from(firstPartySignalBatches)
+    .where(
+      and(
+        eq(firstPartySignalBatches.sourceId, sourceId),
+        eq(firstPartySignalBatches.batchId, batchId),
+      ),
+    )
+    .limit(1);
+  return row ?? null;
+}
+
+async function getBatchForDate(sourceId: string, snapshotDate: string) {
+  const [row] = await db
+    .select()
+    .from(firstPartySignalBatches)
+    .where(
+      and(
+        eq(firstPartySignalBatches.sourceId, sourceId),
+        eq(firstPartySignalBatches.snapshotDate, snapshotDate),
+      ),
+    )
+    .limit(1);
+  return row ?? null;
+}
+
+async function createBatch(input: {
+  sourceId: string;
+  batchId: string;
+  snapshotDate: string;
+  payloadDigest: string;
+  leaseId: string;
+  leaseExpiresAt: string;
+  now: string;
+}) {
+  const id = crypto.randomUUID();
+  await db.insert(firstPartySignalBatches).values({
+    id,
+    sourceId: input.sourceId,
+    batchId: input.batchId,
+    snapshotDate: input.snapshotDate,
+    payloadDigest: input.payloadDigest,
+    status: "pending",
+    processingLeaseId: input.leaseId,
+    processingLeaseExpiresAt: input.leaseExpiresAt,
+    receivedAt: input.now,
+  });
+  return id;
+}
+
+async function claimBatchForProcessing(input: {
+  id: string;
+  payloadDigest: string;
+  leaseId: string;
+  leaseExpiresAt: string;
+  now: string;
+}) {
+  const rows = await db
+    .update(firstPartySignalBatches)
+    .set({
+      status: "pending",
+      receivedAt: input.now,
+      completedAt: null,
+      processingLeaseId: input.leaseId,
+      processingLeaseExpiresAt: input.leaseExpiresAt,
+    })
+    .where(
+      and(
+        eq(firstPartySignalBatches.id, input.id),
+        eq(firstPartySignalBatches.payloadDigest, input.payloadDigest),
+        or(
+          eq(firstPartySignalBatches.status, "failed"),
+          and(
+            eq(firstPartySignalBatches.status, "pending"),
+            or(
+              isNull(firstPartySignalBatches.processingLeaseId),
+              isNull(firstPartySignalBatches.processingLeaseExpiresAt),
+              lt(firstPartySignalBatches.processingLeaseExpiresAt, input.now),
+            ),
+          ),
+        ),
+      ),
+    )
+    .returning({ id: firstPartySignalBatches.id });
+  return rows.length > 0;
+}
+
+async function renewBatchLease(input: {
+  id: string;
+  leaseId: string;
+  now: string;
+  leaseExpiresAt: string;
+}) {
+  const rows = await db
+    .update(firstPartySignalBatches)
+    .set({ processingLeaseExpiresAt: input.leaseExpiresAt })
+    .where(
+      and(
+        eq(firstPartySignalBatches.id, input.id),
+        eq(firstPartySignalBatches.status, "pending"),
+        eq(firstPartySignalBatches.processingLeaseId, input.leaseId),
+        gt(firstPartySignalBatches.processingLeaseExpiresAt, input.now),
+      ),
+    )
+    .returning({ id: firstPartySignalBatches.id });
+  return rows.length > 0;
+}
+
+type AggregateInput = {
+  landingPath: string;
+  searchStarted: number;
+  searchCompleted: number;
+  searchNoResults: number;
+  registrationsCompleted: number;
+  checkoutStarted: number;
+  paymentsCompleted: number;
+};
+
+async function replaceBatchRows(input: {
+  batchReceiptId: string;
+  processingAttemptId: string;
+  rows: AggregateInput[];
+  now: string;
+}) {
+  await db
+    .delete(firstPartySignalDailyAggregates)
+    .where(
+      and(
+        eq(
+          firstPartySignalDailyAggregates.batchReceiptId,
+          input.batchReceiptId,
+        ),
+        eq(
+          firstPartySignalDailyAggregates.processingAttemptId,
+          input.processingAttemptId,
+        ),
+      ),
+    );
+  await executeInBatches(input.rows, (tx, row) =>
+    tx.insert(firstPartySignalDailyAggregates).values({
+      id: crypto.randomUUID(),
+      batchReceiptId: input.batchReceiptId,
+      processingAttemptId: input.processingAttemptId,
+      landingPath: row.landingPath,
+      searchStarted: row.searchStarted,
+      searchCompleted: row.searchCompleted,
+      searchNoResults: row.searchNoResults,
+      registrationsCompleted: row.registrationsCompleted,
+      checkoutStarted: row.checkoutStarted,
+      paymentsCompleted: row.paymentsCompleted,
+      receivedAt: input.now,
+    }),
+  );
+}
+
+async function completeBatch(input: {
+  batchReceiptId: string;
+  leaseId: string;
+  now: string;
+}) {
+  const completed = await db
+    .update(firstPartySignalBatches)
+    .set({ status: "complete", completedAt: input.now })
+    .where(
+      and(
+        eq(firstPartySignalBatches.id, input.batchReceiptId),
+        eq(firstPartySignalBatches.status, "pending"),
+        eq(firstPartySignalBatches.processingLeaseId, input.leaseId),
+      ),
+    )
+    .returning({ id: firstPartySignalBatches.id });
+  return completed.length > 0;
+}
+
+async function failBatch(batchReceiptId: string, leaseId: string, now: string) {
+  await db
+    .update(firstPartySignalBatches)
+    .set({
+      status: "failed",
+      completedAt: now,
+      processingLeaseId: null,
+      processingLeaseExpiresAt: null,
+    })
+    .where(
+      and(
+        eq(firstPartySignalBatches.id, batchReceiptId),
+        eq(firstPartySignalBatches.status, "pending"),
+        eq(firstPartySignalBatches.processingLeaseId, leaseId),
+      ),
+    );
+}
+
+async function purgeOlderThan(cutoffDate: string) {
+  const deleted = await db
+    .delete(firstPartySignalBatches)
+    .where(lt(firstPartySignalBatches.snapshotDate, cutoffDate))
+    .returning({ id: firstPartySignalBatches.id });
+  return deleted.length;
+}
+
+export const FirstPartySignalsRepository = {
+  upsertSource,
+  listSources,
+  revokeSource,
+  getActiveSourceForIngest,
+  getBatch,
+  getBatchForDate,
+  createBatch,
+  claimBatchForProcessing,
+  renewBatchLease,
+  replaceBatchRows,
+  completeBatch,
+  failBatch,
+  purgeOlderThan,
+};

--- a/src/server/features/first-party-signals/FirstPartySignalsService.test.ts
+++ b/src/server/features/first-party-signals/FirstPartySignalsService.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   FirstPartyBatchConflictError,
+  FirstPartyBatchInProgressError,
   FirstPartySignalsService,
 } from "./FirstPartySignalsService";
 
@@ -83,6 +84,7 @@ beforeEach(() => {
   mocks.getBatch.mockResolvedValue(null);
   mocks.getBatchForDate.mockResolvedValue(null);
   mocks.createBatch.mockResolvedValue("receipt_1");
+  mocks.claimBatchForProcessing.mockResolvedValue(false);
   mocks.renewBatchLease.mockResolvedValue(true);
   mocks.completeBatch.mockResolvedValue(true);
 });
@@ -162,6 +164,64 @@ describe("FirstPartySignalsService", () => {
       }),
     ).resolves.toEqual({ accepted: true, duplicate: true, rowCount: 1 });
     expect(mocks.createBatch).not.toHaveBeenCalled();
+    expect(mocks.replaceBatchRows).not.toHaveBeenCalled();
+  });
+
+  it("reports an exact active pending retry as in progress, not a conflict", async () => {
+    mocks.getBatch.mockResolvedValue({
+      id: "receipt_1",
+      status: "pending",
+      payloadDigest: "digest_1",
+      batchId: snapshot.batchId,
+      snapshotDate: snapshot.snapshotDate,
+      processingLeaseExpiresAt: "2026-09-04T12:00:47.000Z",
+    });
+
+    const result = FirstPartySignalsService.saveSnapshot({
+      source,
+      snapshot,
+      payloadDigest: "digest_1",
+      now: new Date("2026-09-04T12:00:00.000Z"),
+    });
+
+    await expect(result).rejects.toMatchObject({
+      name: "FirstPartyBatchInProgressError",
+      retryAfterSeconds: 47,
+      rowCount: 1,
+    });
+    await expect(result).rejects.toBeInstanceOf(FirstPartyBatchInProgressError);
+    expect(mocks.createBatch).not.toHaveBeenCalled();
+    expect(mocks.replaceBatchRows).not.toHaveBeenCalled();
+  });
+
+  it("reports an exact create race as in progress when the winner is pending", async () => {
+    const racedReceipt = {
+      id: "receipt_raced",
+      status: "pending",
+      payloadDigest: "digest_1",
+      batchId: snapshot.batchId,
+      snapshotDate: snapshot.snapshotDate,
+      processingLeaseExpiresAt: "2026-09-04T12:00:30.000Z",
+    };
+    mocks.getBatch
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(racedReceipt);
+    mocks.getBatchForDate
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(racedReceipt);
+    mocks.createBatch.mockRejectedValue(new Error("unique constraint"));
+
+    await expect(
+      FirstPartySignalsService.saveSnapshot({
+        source,
+        snapshot,
+        payloadDigest: "digest_1",
+        now: new Date("2026-09-04T12:00:00.000Z"),
+      }),
+    ).rejects.toMatchObject({
+      name: "FirstPartyBatchInProgressError",
+      retryAfterSeconds: 30,
+    });
     expect(mocks.replaceBatchRows).not.toHaveBeenCalled();
   });
 
@@ -249,13 +309,27 @@ describe("FirstPartySignalsService", () => {
   });
 
   it("enforces and purges the 400-day retention window", async () => {
-    mocks.purgeOlderThan.mockResolvedValue(4);
+    mocks.purgeOlderThan.mockResolvedValue({ deleted: 4, hasMore: false });
     await expect(
-      FirstPartySignalsService.purgeExpired(
-        new Date("2026-09-04T12:00:00.000Z"),
-      ),
-    ).resolves.toBe(4);
-    expect(mocks.purgeOlderThan).toHaveBeenCalledWith("2025-07-31");
+      FirstPartySignalsService.purgeExpired({
+        now: new Date("2026-09-04T12:00:00.000Z"),
+        limit: 25,
+        projectId: "project_1",
+      }),
+    ).resolves.toEqual({
+      deleted: 4,
+      hasMore: false,
+      cutoffDate: "2025-07-31",
+      limit: 25,
+    });
+    expect(mocks.purgeOlderThan).toHaveBeenCalledWith({
+      cutoffDate: "2025-07-31",
+      limit: 25,
+      projectId: "project_1",
+    });
+    await expect(
+      FirstPartySignalsService.purgeExpired({ limit: 501 }),
+    ).rejects.toMatchObject({ name: "AppError", code: "VALIDATION_ERROR" });
 
     await expect(
       FirstPartySignalsService.saveSnapshot({

--- a/src/server/features/first-party-signals/FirstPartySignalsService.test.ts
+++ b/src/server/features/first-party-signals/FirstPartySignalsService.test.ts
@@ -1,0 +1,269 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  FirstPartyBatchConflictError,
+  FirstPartySignalsService,
+} from "./FirstPartySignalsService";
+
+vi.mock("cloudflare:workers", () => ({ env: {} }));
+
+const mocks = vi.hoisted(() => ({
+  isConfigured: vi.fn(),
+  encrypt: vi.fn(),
+  upsertSource: vi.fn(),
+  listSources: vi.fn(),
+  revokeSource: vi.fn(),
+  getBatch: vi.fn(),
+  getBatchForDate: vi.fn(),
+  createBatch: vi.fn(),
+  claimBatchForProcessing: vi.fn(),
+  renewBatchLease: vi.fn(),
+  replaceBatchRows:
+    vi.fn<(input: { processingAttemptId: string }) => Promise<void>>(),
+  completeBatch: vi.fn<(input: { leaseId: string }) => Promise<boolean>>(),
+  failBatch: vi.fn(),
+  purgeOlderThan: vi.fn(),
+}));
+
+vi.mock("./FirstPartyCredentialVault", () => ({
+  FirstPartyCredentialVault: {
+    isConfigured: mocks.isConfigured,
+    encrypt: mocks.encrypt,
+  },
+}));
+
+vi.mock("./FirstPartySignalsRepository", () => ({
+  FirstPartySignalsRepository: {
+    upsertSource: mocks.upsertSource,
+    listSources: mocks.listSources,
+    revokeSource: mocks.revokeSource,
+    getBatch: mocks.getBatch,
+    getBatchForDate: mocks.getBatchForDate,
+    createBatch: mocks.createBatch,
+    claimBatchForProcessing: mocks.claimBatchForProcessing,
+    renewBatchLease: mocks.renewBatchLease,
+    replaceBatchRows: mocks.replaceBatchRows,
+    completeBatch: mocks.completeBatch,
+    failBatch: mocks.failBatch,
+    purgeOlderThan: mocks.purgeOlderThan,
+  },
+}));
+
+const source = {
+  id: "2d7b09d4-884c-4b99-a2ca-56fd514fb710",
+  projectId: "project_1",
+  encryptedSecret: "encrypted",
+  projectDomain: "www.example.com",
+  allowedPaths: ["/pricing"],
+};
+
+const snapshot = {
+  schemaVersion: 1 as const,
+  batchId: "f1a2ae17-b157-4bb9-b1a1-960ce8d4c01d",
+  snapshotDate: "2026-09-04",
+  rows: [
+    {
+      landingPath: "/pricing",
+      searchStarted: 10,
+      searchCompleted: 8,
+      searchNoResults: 1,
+      registrationsCompleted: 3,
+      checkoutStarted: 2,
+      paymentsCompleted: 1,
+    },
+  ],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.isConfigured.mockResolvedValue(true);
+  mocks.encrypt.mockImplementation((secret: string) =>
+    Promise.resolve(`encrypted:${secret}`),
+  );
+  mocks.upsertSource.mockResolvedValue(source.id);
+  mocks.getBatch.mockResolvedValue(null);
+  mocks.getBatchForDate.mockResolvedValue(null);
+  mocks.createBatch.mockResolvedValue("receipt_1");
+  mocks.renewBatchLease.mockResolvedValue(true);
+  mocks.completeBatch.mockResolvedValue(true);
+});
+
+describe("FirstPartySignalsService", () => {
+  it("creates a 256-bit secret and returns it only in the creation response", async () => {
+    const result = await FirstPartySignalsService.configureSource({
+      projectId: "project_1",
+      organizationId: "org_1",
+      userId: "user_1",
+      name: "website",
+      allowedPaths: ["/", "/pricing"],
+    });
+
+    expect(result.secret).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(result.secretShownOnce).toBe(true);
+    expect(mocks.encrypt).toHaveBeenCalledWith(result.secret);
+    expect(mocks.upsertSource).toHaveBeenCalledWith(
+      expect.objectContaining({
+        encryptedSecret: `encrypted:${result.secret}`,
+        allowedPaths: ["/", "/pricing"],
+      }),
+    );
+  });
+
+  it("persists one recoverable, current snapshot", async () => {
+    const result = await FirstPartySignalsService.saveSnapshot({
+      source,
+      snapshot,
+      payloadDigest: "digest_1",
+      now: new Date("2026-09-04T12:00:00.000Z"),
+    });
+
+    expect(result).toEqual({
+      accepted: true,
+      duplicate: false,
+      rowCount: 1,
+    });
+    expect(mocks.createBatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceId: source.id,
+        snapshotDate: "2026-09-04",
+        payloadDigest: "digest_1",
+      }),
+    );
+    expect(mocks.replaceBatchRows).toHaveBeenCalledWith(
+      expect.objectContaining({
+        batchReceiptId: "receipt_1",
+        rows: snapshot.rows,
+      }),
+    );
+    expect(mocks.completeBatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        batchReceiptId: "receipt_1",
+      }),
+    );
+    expect(mocks.replaceBatchRows.mock.calls[0]?.[0].processingAttemptId).toBe(
+      mocks.completeBatch.mock.calls[0]?.[0].leaseId,
+    );
+  });
+
+  it("treats an already-complete exact batch as an idempotent replay", async () => {
+    mocks.getBatch.mockResolvedValue({
+      id: "receipt_1",
+      status: "complete",
+      payloadDigest: "digest_1",
+      batchId: snapshot.batchId,
+      snapshotDate: snapshot.snapshotDate,
+    });
+
+    await expect(
+      FirstPartySignalsService.saveSnapshot({
+        source,
+        snapshot,
+        payloadDigest: "digest_1",
+        now: new Date("2026-09-04T12:00:00.000Z"),
+      }),
+    ).resolves.toEqual({ accepted: true, duplicate: true, rowCount: 1 });
+    expect(mocks.createBatch).not.toHaveBeenCalled();
+    expect(mocks.replaceBatchRows).not.toHaveBeenCalled();
+  });
+
+  it("rejects reusing a batch id with different exact bytes", async () => {
+    mocks.getBatch.mockResolvedValue({
+      id: "receipt_1",
+      status: "complete",
+      payloadDigest: "different_digest",
+      batchId: snapshot.batchId,
+      snapshotDate: snapshot.snapshotDate,
+    });
+
+    await expect(
+      FirstPartySignalsService.saveSnapshot({
+        source,
+        snapshot,
+        payloadDigest: "digest_1",
+        now: new Date("2026-09-04T12:00:00.000Z"),
+      }),
+    ).rejects.toBeInstanceOf(FirstPartyBatchConflictError);
+  });
+
+  it("accepts only one immutable batch per source and UTC day", async () => {
+    mocks.getBatchForDate.mockResolvedValue({
+      id: "receipt_existing",
+      status: "complete",
+      payloadDigest: "digest_existing",
+      batchId: "d86f8d99-b59d-486a-a47c-ab790dece71c",
+      snapshotDate: snapshot.snapshotDate,
+    });
+
+    await expect(
+      FirstPartySignalsService.saveSnapshot({
+        source,
+        snapshot,
+        payloadDigest: "digest_1",
+        now: new Date("2026-09-04T12:00:00.000Z"),
+      }),
+    ).rejects.toBeInstanceOf(FirstPartyBatchConflictError);
+    expect(mocks.createBatch).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-allowlisted and identifier-shaped landing paths", async () => {
+    for (const landingPath of [
+      "/account",
+      "/orders/12345678",
+      "/people/6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+    ]) {
+      await expect(
+        FirstPartySignalsService.saveSnapshot({
+          source: { ...source, allowedPaths: [landingPath] },
+          snapshot: {
+            ...snapshot,
+            rows: [{ ...snapshot.rows[0], landingPath }],
+          },
+          payloadDigest: "digest_1",
+          now: new Date("2026-09-04T12:00:00.000Z"),
+        }),
+      ).rejects.toMatchObject({ name: "AppError", code: "VALIDATION_ERROR" });
+    }
+    await expect(
+      FirstPartySignalsService.saveSnapshot({
+        source,
+        snapshot: {
+          ...snapshot,
+          rows: [{ ...snapshot.rows[0], landingPath: "/pricing/team" }],
+        },
+        payloadDigest: "digest_1",
+        now: new Date("2026-09-04T12:00:00.000Z"),
+      }),
+    ).rejects.toMatchObject({ name: "AppError", code: "VALIDATION_ERROR" });
+    expect(mocks.getBatch).not.toHaveBeenCalled();
+  });
+
+  it("rejects a partial daily snapshot", async () => {
+    await expect(
+      FirstPartySignalsService.saveSnapshot({
+        source: { ...source, allowedPaths: ["/", "/pricing"] },
+        snapshot,
+        payloadDigest: "digest_1",
+        now: new Date("2026-09-04T12:00:00.000Z"),
+      }),
+    ).rejects.toMatchObject({ name: "AppError", code: "VALIDATION_ERROR" });
+    expect(mocks.getBatch).not.toHaveBeenCalled();
+  });
+
+  it("enforces and purges the 400-day retention window", async () => {
+    mocks.purgeOlderThan.mockResolvedValue(4);
+    await expect(
+      FirstPartySignalsService.purgeExpired(
+        new Date("2026-09-04T12:00:00.000Z"),
+      ),
+    ).resolves.toBe(4);
+    expect(mocks.purgeOlderThan).toHaveBeenCalledWith("2025-07-31");
+
+    await expect(
+      FirstPartySignalsService.saveSnapshot({
+        source,
+        snapshot: { ...snapshot, snapshotDate: "2025-07-30" },
+        payloadDigest: "digest_1",
+        now: new Date("2026-09-04T12:00:00.000Z"),
+      }),
+    ).rejects.toMatchObject({ name: "AppError", code: "VALIDATION_ERROR" });
+  });
+});

--- a/src/server/features/first-party-signals/FirstPartySignalsService.test.ts
+++ b/src/server/features/first-party-signals/FirstPartySignalsService.test.ts
@@ -309,7 +309,9 @@ describe("FirstPartySignalsService", () => {
   });
 
   it("enforces and purges the 400-day retention window", async () => {
-    mocks.purgeOlderThan.mockResolvedValue({ deleted: 4, hasMore: false });
+    mocks.purgeOlderThan
+      .mockResolvedValueOnce({ deleted: 25, hasMore: true })
+      .mockResolvedValueOnce({ deleted: 4, hasMore: false });
     await expect(
       FirstPartySignalsService.purgeExpired({
         now: new Date("2026-09-04T12:00:00.000Z"),
@@ -317,12 +319,22 @@ describe("FirstPartySignalsService", () => {
         projectId: "project_1",
       }),
     ).resolves.toEqual({
-      deleted: 4,
+      deleted: 29,
+      pages: 2,
       hasMore: false,
+      stalled: false,
       cutoffDate: "2025-07-31",
       limit: 25,
+      maxPages: 20,
+      capacity: 500,
     });
-    expect(mocks.purgeOlderThan).toHaveBeenCalledWith({
+    expect(mocks.purgeOlderThan).toHaveBeenCalledTimes(2);
+    expect(mocks.purgeOlderThan).toHaveBeenNthCalledWith(1, {
+      cutoffDate: "2025-07-31",
+      limit: 25,
+      projectId: "project_1",
+    });
+    expect(mocks.purgeOlderThan).toHaveBeenNthCalledWith(2, {
       cutoffDate: "2025-07-31",
       limit: 25,
       projectId: "project_1",

--- a/src/server/features/first-party-signals/FirstPartySignalsService.test.ts
+++ b/src/server/features/first-party-signals/FirstPartySignalsService.test.ts
@@ -90,6 +90,32 @@ beforeEach(() => {
 });
 
 describe("FirstPartySignalsService", () => {
+  it("accepts the oldest of exactly 400 inclusive UTC snapshot dates", async () => {
+    await expect(
+      FirstPartySignalsService.saveSnapshot({
+        source,
+        snapshot: { ...snapshot, snapshotDate: "2025-08-01" },
+        payloadDigest: "digest_1",
+        now: new Date("2026-09-04T23:59:59.999Z"),
+      }),
+    ).resolves.toMatchObject({ accepted: true, duplicate: false });
+    expect(mocks.createBatch).toHaveBeenCalledWith(
+      expect.objectContaining({ snapshotDate: "2025-08-01" }),
+    );
+  });
+
+  it("rejects the UTC snapshot date immediately before the retention window", async () => {
+    await expect(
+      FirstPartySignalsService.saveSnapshot({
+        source,
+        snapshot: { ...snapshot, snapshotDate: "2025-07-31" },
+        payloadDigest: "digest_1",
+        now: new Date("2026-09-04T00:00:00.000Z"),
+      }),
+    ).rejects.toThrow("between 2025-08-01 and 2026-09-04");
+    expect(mocks.createBatch).not.toHaveBeenCalled();
+  });
+
   it("creates a 256-bit secret and returns it only in the creation response", async () => {
     const result = await FirstPartySignalsService.configureSource({
       projectId: "project_1",
@@ -323,19 +349,19 @@ describe("FirstPartySignalsService", () => {
       pages: 2,
       hasMore: false,
       stalled: false,
-      cutoffDate: "2025-07-31",
+      cutoffDate: "2025-08-01",
       limit: 25,
       maxPages: 20,
       capacity: 500,
     });
     expect(mocks.purgeOlderThan).toHaveBeenCalledTimes(2);
     expect(mocks.purgeOlderThan).toHaveBeenNthCalledWith(1, {
-      cutoffDate: "2025-07-31",
+      cutoffDate: "2025-08-01",
       limit: 25,
       projectId: "project_1",
     });
     expect(mocks.purgeOlderThan).toHaveBeenNthCalledWith(2, {
-      cutoffDate: "2025-07-31",
+      cutoffDate: "2025-08-01",
       limit: 25,
       projectId: "project_1",
     });

--- a/src/server/features/first-party-signals/FirstPartySignalsService.ts
+++ b/src/server/features/first-party-signals/FirstPartySignalsService.ts
@@ -13,6 +13,9 @@ import { FirstPartySignalsRepository } from "./FirstPartySignalsRepository";
 import { randomBase64Url } from "./encoding";
 
 const BATCH_LEASE_MS = 5 * 60_000;
+const MIN_RETRY_AFTER_SECONDS = 1;
+const FIRST_PARTY_RETENTION_PURGE_PAGE_SIZE = 250;
+const MAX_RETENTION_PURGE_PAGE_SIZE = 500;
 
 export class FirstPartyBatchConflictError extends Error {
   constructor(message: string) {
@@ -21,8 +24,45 @@ export class FirstPartyBatchConflictError extends Error {
   }
 }
 
+export class FirstPartyBatchInProgressError extends Error {
+  readonly retryAfterSeconds: number;
+  readonly rowCount: number;
+
+  constructor(input: {
+    retryAfterSeconds: number;
+    rowCount: number;
+    message?: string;
+  }) {
+    super(input.message ?? "This exact batch is still being processed.");
+    this.name = "FirstPartyBatchInProgressError";
+    this.retryAfterSeconds = Math.max(
+      MIN_RETRY_AFTER_SECONDS,
+      Math.ceil(input.retryAfterSeconds),
+    );
+    this.rowCount = input.rowCount;
+  }
+}
+
 function batchLeaseExpiry(now: Date) {
   return new Date(now.getTime() + BATCH_LEASE_MS).toISOString();
+}
+
+function retryAfterSeconds(receipt: BatchReceipt | null, now: Date): number {
+  const expiresAt = receipt?.processingLeaseExpiresAt
+    ? Date.parse(receipt.processingLeaseExpiresAt)
+    : Number.NaN;
+  if (!Number.isFinite(expiresAt)) return MIN_RETRY_AFTER_SECONDS;
+  return Math.max(
+    MIN_RETRY_AFTER_SECONDS,
+    Math.ceil((expiresAt - now.getTime()) / 1_000),
+  );
+}
+
+function inProgress(receipt: BatchReceipt | null, rowCount: number, now: Date) {
+  return new FirstPartyBatchInProgressError({
+    retryAfterSeconds: retryAfterSeconds(receipt, now),
+    rowCount,
+  });
 }
 
 function isoDay(date: Date): string {
@@ -212,9 +252,7 @@ async function saveSnapshot(input: {
         now: nowIso,
       }))
     ) {
-      throw new FirstPartyBatchConflictError(
-        "This batch is already being processed.",
-      );
+      throw inProgress(receipt, normalizedRows.length, now);
     }
   } else {
     try {
@@ -270,9 +308,7 @@ async function saveSnapshot(input: {
       ) {
         receiptId = raced.id;
       } else if (raced) {
-        throw new FirstPartyBatchConflictError(
-          "This batch is already being processed.",
-        );
+        throw inProgress(raced, normalizedRows.length, now);
       } else {
         throw error;
       }
@@ -289,9 +325,7 @@ async function saveSnapshot(input: {
         leaseExpiresAt: batchLeaseExpiry(now),
       }))
     ) {
-      throw new FirstPartyBatchConflictError(
-        "This batch processing lease was lost before persistence.",
-      );
+      throw inProgress(receipt, normalizedRows.length, now);
     }
     await FirstPartySignalsRepository.replaceBatchRows({
       batchReceiptId: receiptId,
@@ -308,9 +342,7 @@ async function saveSnapshot(input: {
         leaseExpiresAt: batchLeaseExpiry(completionNow),
       }))
     ) {
-      throw new FirstPartyBatchConflictError(
-        "This batch processing lease was lost before completion.",
-      );
+      throw inProgress(receipt, normalizedRows.length, completionNow);
     }
     if (
       !(await FirstPartySignalsRepository.completeBatch({
@@ -319,9 +351,7 @@ async function saveSnapshot(input: {
         now: completionNow.toISOString(),
       }))
     ) {
-      throw new FirstPartyBatchConflictError(
-        "This batch processing lease was lost before the snapshot became current.",
-      );
+      throw inProgress(receipt, normalizedRows.length, completionNow);
     }
   } catch (error) {
     await FirstPartySignalsRepository.failBatch(
@@ -338,8 +368,35 @@ async function saveSnapshot(input: {
   };
 }
 
-async function purgeExpired(now = new Date()) {
-  return FirstPartySignalsRepository.purgeOlderThan(oldestRetainedDay(now));
+async function purgeExpired(
+  input: {
+    now?: Date;
+    limit?: number;
+    projectId?: string;
+  } = {},
+) {
+  const now = input.now ?? new Date();
+  const limit = input.limit ?? FIRST_PARTY_RETENTION_PURGE_PAGE_SIZE;
+  if (
+    !Number.isInteger(limit) ||
+    limit < 1 ||
+    limit > MAX_RETENTION_PURGE_PAGE_SIZE
+  ) {
+    throw new AppError(
+      "VALIDATION_ERROR",
+      `Retention cleanup limit must be between 1 and ${MAX_RETENTION_PURGE_PAGE_SIZE}.`,
+    );
+  }
+  const result = await FirstPartySignalsRepository.purgeOlderThan({
+    cutoffDate: oldestRetainedDay(now),
+    limit,
+    projectId: input.projectId,
+  });
+  return {
+    ...result,
+    cutoffDate: oldestRetainedDay(now),
+    limit,
+  };
 }
 
 export const FirstPartySignalsService = {

--- a/src/server/features/first-party-signals/FirstPartySignalsService.ts
+++ b/src/server/features/first-party-signals/FirstPartySignalsService.ts
@@ -1,0 +1,352 @@
+import { AppError } from "@/server/lib/errors";
+import {
+  FIRST_PARTY_RETENTION_DAYS,
+  type FirstPartyAggregateSnapshot,
+} from "@/shared/first-party-signals";
+import { FirstPartyCredentialVault } from "./FirstPartyCredentialVault";
+import { FirstPartyReportingService } from "./FirstPartyReportingService";
+import {
+  normalizeAllowedPaths,
+  normalizePublicLandingPath,
+} from "./FirstPartyPathPolicy";
+import { FirstPartySignalsRepository } from "./FirstPartySignalsRepository";
+import { randomBase64Url } from "./encoding";
+
+const BATCH_LEASE_MS = 5 * 60_000;
+
+export class FirstPartyBatchConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "FirstPartyBatchConflictError";
+  }
+}
+
+function batchLeaseExpiry(now: Date) {
+  return new Date(now.getTime() + BATCH_LEASE_MS).toISOString();
+}
+
+function isoDay(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function oldestRetainedDay(now: Date): string {
+  const oldest = new Date(now);
+  oldest.setUTCDate(oldest.getUTCDate() - FIRST_PARTY_RETENTION_DAYS);
+  return isoDay(oldest);
+}
+
+function validateSnapshotDate(snapshotDate: string, now: Date) {
+  const oldest = oldestRetainedDay(now);
+  const today = isoDay(now);
+  if (snapshotDate > today || snapshotDate < oldest) {
+    throw new AppError(
+      "VALIDATION_ERROR",
+      `snapshotDate must be between ${oldest} and ${today}.`,
+    );
+  }
+}
+
+type IngestSource = NonNullable<
+  Awaited<
+    ReturnType<typeof FirstPartySignalsRepository.getActiveSourceForIngest>
+  >
+>;
+type BatchReceipt = NonNullable<
+  Awaited<ReturnType<typeof FirstPartySignalsRepository.getBatch>>
+>;
+
+function normalizeCompleteRows(
+  source: IngestSource,
+  snapshot: FirstPartyAggregateSnapshot,
+) {
+  const normalizedRows = snapshot.rows.map((row) => {
+    const landingPath = normalizePublicLandingPath({
+      value: row.landingPath,
+      projectDomain: source.projectDomain,
+      allowedPaths: source.allowedPaths,
+    });
+    if (!landingPath) {
+      throw new AppError(
+        "VALIDATION_ERROR",
+        "Every landingPath must be an allowlisted public pathname without identifiers.",
+      );
+    }
+    return { ...row, landingPath };
+  });
+  const receivedPaths = new Set(normalizedRows.map((row) => row.landingPath));
+  if (receivedPaths.size !== normalizedRows.length) {
+    throw new AppError(
+      "VALIDATION_ERROR",
+      "A snapshot cannot contain duplicate canonical landing paths.",
+    );
+  }
+  if (
+    receivedPaths.size !== source.allowedPaths.length ||
+    source.allowedPaths.some((path) => !receivedPaths.has(path))
+  ) {
+    throw new AppError(
+      "VALIDATION_ERROR",
+      "A complete daily snapshot must contain every configured landing path exactly once.",
+    );
+  }
+  return normalizedRows;
+}
+
+function compatibleReceipt(
+  byBatch: BatchReceipt | null,
+  byDate: BatchReceipt | null,
+  snapshot: FirstPartyAggregateSnapshot,
+): BatchReceipt | null {
+  if (
+    (byBatch && byBatch.snapshotDate !== snapshot.snapshotDate) ||
+    (byDate && byDate.batchId !== snapshot.batchId) ||
+    (byBatch && byDate && byBatch.id !== byDate.id)
+  ) {
+    throw new FirstPartyBatchConflictError(
+      "Each source accepts exactly one immutable batch per UTC day.",
+    );
+  }
+  return byBatch ?? byDate;
+}
+
+async function configureSource(input: {
+  projectId: string;
+  organizationId: string;
+  userId: string;
+  name: string;
+  allowedPaths: string[];
+}) {
+  if (!(await FirstPartyCredentialVault.isConfigured())) {
+    throw new AppError(
+      "AUTH_CONFIG_MISSING",
+      "Set BETTER_AUTH_SECRET to at least 32 characters before creating an aggregate source.",
+    );
+  }
+  let allowedPaths: string[];
+  try {
+    allowedPaths = normalizeAllowedPaths(input.allowedPaths);
+  } catch (error) {
+    throw new AppError(
+      "VALIDATION_ERROR",
+      error instanceof Error ? error.message : "Invalid public landing paths.",
+    );
+  }
+  const secret = randomBase64Url(32);
+  const now = new Date().toISOString();
+  const sourceId = await FirstPartySignalsRepository.upsertSource({
+    projectId: input.projectId,
+    organizationId: input.organizationId,
+    name: input.name.trim(),
+    encryptedSecret: await FirstPartyCredentialVault.encrypt(secret),
+    secretHint: `••••${secret.slice(-6)}`,
+    createdByUserId: input.userId,
+    allowedPaths,
+    now,
+  });
+  return {
+    sourceId,
+    secret,
+    secretShownOnce: true as const,
+    allowedPaths,
+    signature: "hex(HMAC-SHA256(secret, timestamp + '.' + exactRawBody))",
+  };
+}
+
+async function listSources(projectId: string) {
+  return FirstPartySignalsRepository.listSources(projectId);
+}
+
+async function revokeSource(projectId: string, sourceId: string) {
+  const revoked = await FirstPartySignalsRepository.revokeSource(
+    projectId,
+    sourceId,
+    new Date().toISOString(),
+  );
+  if (!revoked) throw new AppError("NOT_FOUND", "Aggregate source not found.");
+}
+
+async function saveSnapshot(input: {
+  source: IngestSource;
+  snapshot: FirstPartyAggregateSnapshot;
+  payloadDigest: string;
+  now?: Date;
+}) {
+  const now = input.now ?? new Date();
+  validateSnapshotDate(input.snapshot.snapshotDate, now);
+  const normalizedRows = normalizeCompleteRows(input.source, input.snapshot);
+  const [byBatch, byDate] = await Promise.all([
+    FirstPartySignalsRepository.getBatch(
+      input.source.id,
+      input.snapshot.batchId,
+    ),
+    FirstPartySignalsRepository.getBatchForDate(
+      input.source.id,
+      input.snapshot.snapshotDate,
+    ),
+  ]);
+  const receipt = compatibleReceipt(byBatch, byDate, input.snapshot);
+  if (receipt && receipt.payloadDigest !== input.payloadDigest) {
+    throw new FirstPartyBatchConflictError(
+      "batchId was already used with a different exact payload.",
+    );
+  }
+  if (receipt?.status === "complete") {
+    return {
+      accepted: true as const,
+      duplicate: true as const,
+      rowCount: normalizedRows.length,
+    };
+  }
+
+  const nowIso = now.toISOString();
+  const leaseId = crypto.randomUUID();
+  const leaseExpiresAt = batchLeaseExpiry(now);
+  let receiptId = receipt?.id;
+  if (receipt) {
+    if (
+      !(await FirstPartySignalsRepository.claimBatchForProcessing({
+        id: receipt.id,
+        payloadDigest: input.payloadDigest,
+        leaseId,
+        leaseExpiresAt,
+        now: nowIso,
+      }))
+    ) {
+      throw new FirstPartyBatchConflictError(
+        "This batch is already being processed.",
+      );
+    }
+  } else {
+    try {
+      receiptId = await FirstPartySignalsRepository.createBatch({
+        sourceId: input.source.id,
+        batchId: input.snapshot.batchId,
+        snapshotDate: input.snapshot.snapshotDate,
+        payloadDigest: input.payloadDigest,
+        leaseId,
+        leaseExpiresAt,
+        now: nowIso,
+      });
+    } catch (error) {
+      const [racedByBatch, racedByDate] = await Promise.all([
+        FirstPartySignalsRepository.getBatch(
+          input.source.id,
+          input.snapshot.batchId,
+        ),
+        FirstPartySignalsRepository.getBatchForDate(
+          input.source.id,
+          input.snapshot.snapshotDate,
+        ),
+      ]);
+      const raced = compatibleReceipt(
+        racedByBatch,
+        racedByDate,
+        input.snapshot,
+      );
+      if (
+        raced?.payloadDigest === input.payloadDigest &&
+        raced.status === "complete"
+      ) {
+        return {
+          accepted: true as const,
+          duplicate: true as const,
+          rowCount: normalizedRows.length,
+        };
+      }
+      if (raced && raced.payloadDigest !== input.payloadDigest) {
+        throw new FirstPartyBatchConflictError(
+          "batchId was already used with a different exact payload.",
+        );
+      }
+      if (
+        raced?.payloadDigest === input.payloadDigest &&
+        (await FirstPartySignalsRepository.claimBatchForProcessing({
+          id: raced.id,
+          payloadDigest: input.payloadDigest,
+          leaseId,
+          leaseExpiresAt,
+          now: nowIso,
+        }))
+      ) {
+        receiptId = raced.id;
+      } else if (raced) {
+        throw new FirstPartyBatchConflictError(
+          "This batch is already being processed.",
+        );
+      } else {
+        throw error;
+      }
+    }
+  }
+  if (!receiptId) throw new Error("Aggregate batch receipt was not created.");
+
+  try {
+    if (
+      !(await FirstPartySignalsRepository.renewBatchLease({
+        id: receiptId,
+        leaseId,
+        now: nowIso,
+        leaseExpiresAt: batchLeaseExpiry(now),
+      }))
+    ) {
+      throw new FirstPartyBatchConflictError(
+        "This batch processing lease was lost before persistence.",
+      );
+    }
+    await FirstPartySignalsRepository.replaceBatchRows({
+      batchReceiptId: receiptId,
+      processingAttemptId: leaseId,
+      rows: normalizedRows,
+      now: nowIso,
+    });
+    const completionNow = new Date();
+    if (
+      !(await FirstPartySignalsRepository.renewBatchLease({
+        id: receiptId,
+        leaseId,
+        now: completionNow.toISOString(),
+        leaseExpiresAt: batchLeaseExpiry(completionNow),
+      }))
+    ) {
+      throw new FirstPartyBatchConflictError(
+        "This batch processing lease was lost before completion.",
+      );
+    }
+    if (
+      !(await FirstPartySignalsRepository.completeBatch({
+        batchReceiptId: receiptId,
+        leaseId,
+        now: completionNow.toISOString(),
+      }))
+    ) {
+      throw new FirstPartyBatchConflictError(
+        "This batch processing lease was lost before the snapshot became current.",
+      );
+    }
+  } catch (error) {
+    await FirstPartySignalsRepository.failBatch(
+      receiptId,
+      leaseId,
+      new Date().toISOString(),
+    );
+    throw error;
+  }
+  return {
+    accepted: true as const,
+    duplicate: false as const,
+    rowCount: normalizedRows.length,
+  };
+}
+
+async function purgeExpired(now = new Date()) {
+  return FirstPartySignalsRepository.purgeOlderThan(oldestRetainedDay(now));
+}
+
+export const FirstPartySignalsService = {
+  configureSource,
+  listSources,
+  revokeSource,
+  saveSnapshot,
+  purgeExpired,
+  ...FirstPartyReportingService,
+};

--- a/src/server/features/first-party-signals/FirstPartySignalsService.ts
+++ b/src/server/features/first-party-signals/FirstPartySignalsService.ts
@@ -1,6 +1,6 @@
 import { AppError } from "@/server/lib/errors";
 import {
-  FIRST_PARTY_RETENTION_DAYS,
+  firstPartyOldestRetainedSnapshotDate,
   type FirstPartyAggregateSnapshot,
 } from "@/shared/first-party-signals";
 import { FirstPartyCredentialVault } from "./FirstPartyCredentialVault";
@@ -73,14 +73,8 @@ function isoDay(date: Date): string {
   return date.toISOString().slice(0, 10);
 }
 
-function oldestRetainedDay(now: Date): string {
-  const oldest = new Date(now);
-  oldest.setUTCDate(oldest.getUTCDate() - FIRST_PARTY_RETENTION_DAYS);
-  return isoDay(oldest);
-}
-
 function validateSnapshotDate(snapshotDate: string, now: Date) {
-  const oldest = oldestRetainedDay(now);
+  const oldest = firstPartyOldestRetainedSnapshotDate(now);
   const today = isoDay(now);
   if (snapshotDate > today || snapshotDate < oldest) {
     throw new AppError(
@@ -391,7 +385,7 @@ async function purgeExpired(
       `Retention cleanup limit must be between 1 and ${MAX_RETENTION_PURGE_PAGE_SIZE}.`,
     );
   }
-  const cutoffDate = oldestRetainedDay(now);
+  const cutoffDate = firstPartyOldestRetainedSnapshotDate(now);
   const result = await drainRetentionPages({
     purgePage: () =>
       FirstPartySignalsRepository.purgeOlderThan({

--- a/src/server/features/first-party-signals/FirstPartySignalsService.ts
+++ b/src/server/features/first-party-signals/FirstPartySignalsService.ts
@@ -11,10 +11,14 @@ import {
 } from "./FirstPartyPathPolicy";
 import { FirstPartySignalsRepository } from "./FirstPartySignalsRepository";
 import { randomBase64Url } from "./encoding";
+import {
+  drainRetentionPages,
+  RETENTION_DRAIN_MAX_PAGES,
+  RETENTION_DRAIN_PAGE_SIZE,
+} from "./RetentionDrain";
 
 const BATCH_LEASE_MS = 5 * 60_000;
 const MIN_RETRY_AFTER_SECONDS = 1;
-const FIRST_PARTY_RETENTION_PURGE_PAGE_SIZE = 250;
 const MAX_RETENTION_PURGE_PAGE_SIZE = 500;
 
 export class FirstPartyBatchConflictError extends Error {
@@ -376,7 +380,7 @@ async function purgeExpired(
   } = {},
 ) {
   const now = input.now ?? new Date();
-  const limit = input.limit ?? FIRST_PARTY_RETENTION_PURGE_PAGE_SIZE;
+  const limit = input.limit ?? RETENTION_DRAIN_PAGE_SIZE;
   if (
     !Number.isInteger(limit) ||
     limit < 1 ||
@@ -387,15 +391,21 @@ async function purgeExpired(
       `Retention cleanup limit must be between 1 and ${MAX_RETENTION_PURGE_PAGE_SIZE}.`,
     );
   }
-  const result = await FirstPartySignalsRepository.purgeOlderThan({
-    cutoffDate: oldestRetainedDay(now),
-    limit,
-    projectId: input.projectId,
+  const cutoffDate = oldestRetainedDay(now);
+  const result = await drainRetentionPages({
+    purgePage: () =>
+      FirstPartySignalsRepository.purgeOlderThan({
+        cutoffDate,
+        limit,
+        projectId: input.projectId,
+      }),
   });
   return {
     ...result,
-    cutoffDate: oldestRetainedDay(now),
+    cutoffDate,
     limit,
+    maxPages: RETENTION_DRAIN_MAX_PAGES,
+    capacity: limit * RETENTION_DRAIN_MAX_PAGES,
   };
 }
 

--- a/src/server/features/first-party-signals/FirstPartySignature.ts
+++ b/src/server/features/first-party-signals/FirstPartySignature.ts
@@ -1,0 +1,50 @@
+import { hexToBytes } from "./encoding";
+import { FIRST_PARTY_SIGNATURE_MAX_SKEW_MS } from "@/shared/first-party-signals";
+
+export function parseSignatureTimestamp(
+  value: string | null,
+  now = Date.now(),
+): string | null {
+  if (!value || !/^\d{10}(?:\d{3})?$/.test(value)) return null;
+  const numeric = Number(value);
+  const timestampMs = value.length === 10 ? numeric * 1_000 : numeric;
+  if (
+    !Number.isSafeInteger(timestampMs) ||
+    Math.abs(now - timestampMs) > FIRST_PARTY_SIGNATURE_MAX_SKEW_MS
+  ) {
+    return null;
+  }
+  return value;
+}
+
+function signedBytes(timestamp: string, rawBody: Uint8Array): Uint8Array {
+  const prefix = new TextEncoder().encode(`${timestamp}.`);
+  const message = new Uint8Array(prefix.length + rawBody.length);
+  message.set(prefix);
+  message.set(rawBody, prefix.length);
+  return message;
+}
+
+export async function verifyFirstPartySignature(input: {
+  secret: string;
+  timestamp: string;
+  rawBody: Uint8Array;
+  signature: string | null;
+}): Promise<boolean> {
+  const normalized = input.signature?.replace(/^sha256=/i, "") ?? "";
+  const signature = hexToBytes(normalized);
+  if (!signature || signature.byteLength !== 32) return false;
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(input.secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["verify"],
+  );
+  return crypto.subtle.verify(
+    "HMAC",
+    key,
+    new Uint8Array(signature).buffer,
+    new Uint8Array(signedBytes(input.timestamp, input.rawBody)).buffer,
+  );
+}

--- a/src/server/features/first-party-signals/RetentionDrain.test.ts
+++ b/src/server/features/first-party-signals/RetentionDrain.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  drainRetentionPages,
+  RETENTION_DRAIN_MAX_PAGES,
+  RETENTION_DRAIN_PAGE_SIZE,
+} from "./RetentionDrain";
+
+describe("retention drain", () => {
+  it("stops at a stable capacity and preserves hasMore for continuation", async () => {
+    const purgePage = vi.fn().mockResolvedValue({
+      deleted: RETENTION_DRAIN_PAGE_SIZE,
+      hasMore: true,
+    });
+
+    await expect(drainRetentionPages({ purgePage })).resolves.toEqual({
+      deleted: RETENTION_DRAIN_PAGE_SIZE * RETENTION_DRAIN_MAX_PAGES,
+      pages: RETENTION_DRAIN_MAX_PAGES,
+      hasMore: true,
+      stalled: false,
+    });
+    expect(purgePage).toHaveBeenCalledTimes(RETENTION_DRAIN_MAX_PAGES);
+  });
+
+  it("does not spin when a contested page reports more work without progress", async () => {
+    const purgePage = vi.fn().mockResolvedValue({
+      deleted: 0,
+      hasMore: true,
+    });
+
+    await expect(drainRetentionPages({ purgePage })).resolves.toEqual({
+      deleted: 0,
+      pages: 1,
+      hasMore: true,
+      stalled: true,
+    });
+    expect(purgePage).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a caller-supplied page budget above the stable bound", async () => {
+    await expect(
+      drainRetentionPages({
+        maxPages: RETENTION_DRAIN_MAX_PAGES + 1,
+        purgePage: vi.fn(),
+      }),
+    ).rejects.toThrow("between 1 and 20");
+  });
+});

--- a/src/server/features/first-party-signals/RetentionDrain.ts
+++ b/src/server/features/first-party-signals/RetentionDrain.ts
@@ -1,0 +1,52 @@
+export const RETENTION_DRAIN_PAGE_SIZE = 250;
+export const RETENTION_DRAIN_MAX_PAGES = 20;
+
+type RetentionPurgePage = {
+  deleted: number;
+  hasMore: boolean;
+};
+
+type RetentionDrainResult = RetentionPurgePage & {
+  pages: number;
+  stalled: boolean;
+};
+
+/**
+ * Drains deterministic delete pages up to a fixed per-invocation budget.
+ * Deleting from the oldest ordered rows makes a repeated cron/manual call a
+ * safe continuation without storing a cursor that could become stale.
+ */
+export async function drainRetentionPages(input: {
+  maxPages?: number;
+  purgePage: () => Promise<RetentionPurgePage>;
+}): Promise<RetentionDrainResult> {
+  const maxPages = input.maxPages ?? RETENTION_DRAIN_MAX_PAGES;
+  if (
+    !Number.isInteger(maxPages) ||
+    maxPages < 1 ||
+    maxPages > RETENTION_DRAIN_MAX_PAGES
+  ) {
+    throw new Error(
+      `Retention maxPages must be between 1 and ${RETENTION_DRAIN_MAX_PAGES}.`,
+    );
+  }
+
+  let deleted = 0;
+  let pages = 0;
+  let hasMore = false;
+  let stalled = false;
+  while (pages < maxPages) {
+    const page = await input.purgePage();
+    pages += 1;
+    deleted += page.deleted;
+    hasMore = page.hasMore;
+    if (!hasMore) break;
+    if (page.deleted === 0) {
+      // Preserve hasMore so monitoring/manual callers know continuation is
+      // required, while preventing a contention race from spinning in-place.
+      stalled = true;
+      break;
+    }
+  }
+  return { deleted, pages, hasMore, stalled };
+}

--- a/src/server/features/first-party-signals/encoding.ts
+++ b/src/server/features/first-party-signals/encoding.ts
@@ -1,0 +1,31 @@
+function bytesToBase64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary)
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replaceAll("=", "");
+}
+
+export function bytesToHex(bytes: Uint8Array): string {
+  return [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+export function hexToBytes(value: string): Uint8Array | null {
+  if (!/^[a-f\d]+$/i.test(value) || value.length % 2 !== 0) return null;
+  return Uint8Array.from(value.match(/.{2}/g) ?? [], (pair) =>
+    Number.parseInt(pair, 16),
+  );
+}
+
+export async function sha256Hex(value: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new Uint8Array(value).buffer,
+  );
+  return bytesToHex(new Uint8Array(digest));
+}
+
+export function randomBase64Url(byteLength: number): string {
+  return bytesToBase64Url(crypto.getRandomValues(new Uint8Array(byteLength)));
+}

--- a/src/server/features/first-party-signals/handleAggregateRequest.rate-limit.test.ts
+++ b/src/server/features/first-party-signals/handleAggregateRequest.rate-limit.test.ts
@@ -1,0 +1,262 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { bytesToHex } from "./encoding";
+import { handleFirstPartyAggregateRequest } from "./handleAggregateRequest";
+
+type RateLimitFn = (input: { key: string }) => Promise<{ success: boolean }>;
+
+const runtime = vi.hoisted(() => ({
+  env: {} as {
+    FIRST_PARTY_INGEST_EDGE_LIMITS_REQUIRED?: string;
+    FIRST_PARTY_INGEST_RATE_LIMIT_SCOPE?: string;
+    FIRST_PARTY_INGEST_GLOBAL_RATE_LIMIT?: { limit: RateLimitFn };
+    FIRST_PARTY_INGEST_CLAIMED_SOURCE_RATE_LIMIT?: { limit: RateLimitFn };
+    FIRST_PARTY_INGEST_RATE_LIMIT?: { limit: RateLimitFn };
+  },
+}));
+
+vi.mock("cloudflare:workers", () => runtime);
+
+const mocks = vi.hoisted(() => ({
+  getActiveSourceForIngest: vi.fn(),
+  decrypt: vi.fn(),
+  saveSnapshot: vi.fn(),
+}));
+
+vi.mock("./FirstPartySignalsRepository", () => ({
+  FirstPartySignalsRepository: {
+    getActiveSourceForIngest: mocks.getActiveSourceForIngest,
+  },
+}));
+vi.mock("./FirstPartyCredentialVault", () => ({
+  FirstPartyCredentialVault: { decrypt: mocks.decrypt },
+}));
+vi.mock("./FirstPartySignalsService", () => ({
+  FirstPartyBatchConflictError: class extends Error {},
+  FirstPartyBatchInProgressError: class extends Error {},
+  FirstPartySignalsService: { saveSnapshot: mocks.saveSnapshot },
+}));
+
+const sourceId = "2d7b09d4-884c-4b99-a2ca-56fd514fb710";
+const secret = "test-secret";
+const rateLimitScope = "open-seo-test-stage";
+const payload = {
+  schemaVersion: 1,
+  batchId: "f1a2ae17-b157-4bb9-b1a1-960ce8d4c01d",
+  snapshotDate: "2026-09-04",
+  rows: [
+    {
+      landingPath: "/pricing",
+      searchStarted: 10,
+      searchCompleted: 8,
+      searchNoResults: 1,
+      registrationsCompleted: 3,
+      checkoutStarted: 2,
+      paymentsCompleted: 1,
+    },
+  ],
+};
+
+async function signedRequest() {
+  const rawBody = new TextEncoder().encode(JSON.stringify(payload));
+  const timestamp = String(Date.now());
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const prefix = new TextEncoder().encode(`${timestamp}.`);
+  const message = new Uint8Array(prefix.length + rawBody.length);
+  message.set(prefix);
+  message.set(rawBody, prefix.length);
+  const signature = bytesToHex(
+    new Uint8Array(await crypto.subtle.sign("HMAC", key, message)),
+  );
+  return new Request("https://app.example.com/api/site-signals/v1/aggregates", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-OpenSEO-Source": sourceId,
+      "X-OpenSEO-Timestamp": timestamp,
+      "X-OpenSEO-Signature": signature,
+    },
+    body: rawBody,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete runtime.env.FIRST_PARTY_INGEST_EDGE_LIMITS_REQUIRED;
+  delete runtime.env.FIRST_PARTY_INGEST_RATE_LIMIT_SCOPE;
+  delete runtime.env.FIRST_PARTY_INGEST_GLOBAL_RATE_LIMIT;
+  delete runtime.env.FIRST_PARTY_INGEST_CLAIMED_SOURCE_RATE_LIMIT;
+  delete runtime.env.FIRST_PARTY_INGEST_RATE_LIMIT;
+  mocks.getActiveSourceForIngest.mockResolvedValue({
+    id: sourceId,
+    projectId: "project_1",
+    encryptedSecret: "encrypted",
+    projectDomain: "example.com",
+    allowedPaths: ["/pricing"],
+  });
+  mocks.decrypt.mockResolvedValue(secret);
+});
+
+describe("first-party aggregate edge rate limits", () => {
+  it("scopes the authenticated source key by trusted Worker stage", async () => {
+    const authenticatedLimit = vi.fn().mockResolvedValue({ success: false });
+    runtime.env.FIRST_PARTY_INGEST_EDGE_LIMITS_REQUIRED = "true";
+    runtime.env.FIRST_PARTY_INGEST_RATE_LIMIT_SCOPE = rateLimitScope;
+    runtime.env.FIRST_PARTY_INGEST_GLOBAL_RATE_LIMIT = {
+      limit: vi.fn().mockResolvedValue({ success: true }),
+    };
+    runtime.env.FIRST_PARTY_INGEST_CLAIMED_SOURCE_RATE_LIMIT = {
+      limit: vi.fn().mockResolvedValue({ success: true }),
+    };
+    runtime.env.FIRST_PARTY_INGEST_RATE_LIMIT = { limit: authenticatedLimit };
+
+    const response = await handleFirstPartyAggregateRequest(
+      await signedRequest(),
+    );
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("Retry-After")).toBe("60");
+    expect(authenticatedLimit).toHaveBeenCalledWith({
+      key: `${rateLimitScope}:${sourceId}`,
+    });
+    expect(mocks.saveSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("scopes coarse keys and bounds random UUIDs before body or secret work", async () => {
+    const globalLimit = vi
+      .fn<RateLimitFn>()
+      .mockResolvedValueOnce({ success: true })
+      .mockResolvedValueOnce({ success: true })
+      .mockResolvedValue({ success: false });
+    const claimedLimit = vi.fn<RateLimitFn>().mockResolvedValue({
+      success: true,
+    });
+    runtime.env.FIRST_PARTY_INGEST_EDGE_LIMITS_REQUIRED = "true";
+    runtime.env.FIRST_PARTY_INGEST_RATE_LIMIT_SCOPE = rateLimitScope;
+    runtime.env.FIRST_PARTY_INGEST_GLOBAL_RATE_LIMIT = { limit: globalLimit };
+    runtime.env.FIRST_PARTY_INGEST_CLAIMED_SOURCE_RATE_LIMIT = {
+      limit: claimedLimit,
+    };
+    runtime.env.FIRST_PARTY_INGEST_RATE_LIMIT = {
+      limit: vi.fn().mockResolvedValue({ success: true }),
+    };
+
+    let bodyPulls = 0;
+    const responses: Response[] = [];
+    for (let index = 0; index < 6; index += 1) {
+      const body = new ReadableStream<Uint8Array>(
+        {
+          pull(controller) {
+            bodyPulls += 1;
+            controller.enqueue(new TextEncoder().encode("{}"));
+            controller.close();
+          },
+        },
+        { highWaterMark: 0 },
+      );
+      responses.push(
+        await handleFirstPartyAggregateRequest(
+          new Request(
+            "https://app.example.com/api/site-signals/v1/aggregates",
+            {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                "X-OpenSEO-Source": crypto.randomUUID(),
+              },
+              body,
+              duplex: "half",
+            } as RequestInit & { duplex: "half" },
+          ),
+        ),
+      );
+    }
+
+    expect(responses.map((response) => response.status)).toEqual([
+      401, 401, 429, 429, 429, 429,
+    ]);
+    expect(globalLimit.mock.calls.map(([input]) => input.key)).toEqual(
+      Array.from({ length: 6 }, () => `${rateLimitScope}:aggregate-receiver`),
+    );
+    const claimedKeys = claimedLimit.mock.calls.map(([input]) => input.key);
+    expect(new Set(claimedKeys).size).toBe(2);
+    expect(
+      claimedKeys.every((key) =>
+        new RegExp(`^${rateLimitScope}:[0-9a-f-]{36}$`).test(key),
+      ),
+    ).toBe(true);
+    expect(bodyPulls).toBe(0);
+    expect(mocks.getActiveSourceForIngest).not.toHaveBeenCalled();
+    expect(mocks.decrypt).not.toHaveBeenCalled();
+  });
+
+  it.each(["binding", "scope"])(
+    "fails closed before body or database work when an edge %s is missing",
+    async (missing) => {
+      const limit = vi.fn().mockResolvedValue({ success: true });
+      runtime.env.FIRST_PARTY_INGEST_EDGE_LIMITS_REQUIRED = "true";
+      runtime.env.FIRST_PARTY_INGEST_GLOBAL_RATE_LIMIT = { limit };
+      if (missing === "binding") {
+        runtime.env.FIRST_PARTY_INGEST_RATE_LIMIT_SCOPE = rateLimitScope;
+      } else {
+        runtime.env.FIRST_PARTY_INGEST_CLAIMED_SOURCE_RATE_LIMIT = { limit };
+        runtime.env.FIRST_PARTY_INGEST_RATE_LIMIT = { limit };
+      }
+
+      let bodyPulls = 0;
+      const response = await handleFirstPartyAggregateRequest(
+        new Request("https://app.example.com/api/site-signals/v1/aggregates", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-OpenSEO-Source": sourceId,
+          },
+          body: new ReadableStream<Uint8Array>(
+            {
+              pull(controller) {
+                bodyPulls += 1;
+                controller.close();
+              },
+            },
+            { highWaterMark: 0 },
+          ),
+          duplex: "half",
+        } as RequestInit & { duplex: "half" }),
+      );
+
+      expect(response.status).toBe(503);
+      expect(response.headers.get("Retry-After")).toBe("60");
+      expect(limit).not.toHaveBeenCalled();
+      expect(bodyPulls).toBe(0);
+      expect(mocks.getActiveSourceForIngest).not.toHaveBeenCalled();
+      expect(mocks.decrypt).not.toHaveBeenCalled();
+    },
+  );
+
+  it("fails closed when the coarse edge limiter is unavailable", async () => {
+    runtime.env.FIRST_PARTY_INGEST_EDGE_LIMITS_REQUIRED = "true";
+    runtime.env.FIRST_PARTY_INGEST_RATE_LIMIT_SCOPE = rateLimitScope;
+    runtime.env.FIRST_PARTY_INGEST_GLOBAL_RATE_LIMIT = {
+      limit: vi.fn().mockRejectedValue(new Error("provider unavailable")),
+    };
+    runtime.env.FIRST_PARTY_INGEST_CLAIMED_SOURCE_RATE_LIMIT = {
+      limit: vi.fn().mockResolvedValue({ success: true }),
+    };
+    runtime.env.FIRST_PARTY_INGEST_RATE_LIMIT = {
+      limit: vi.fn().mockResolvedValue({ success: true }),
+    };
+
+    const response = await handleFirstPartyAggregateRequest(
+      await signedRequest(),
+    );
+
+    expect(response.status).toBe(503);
+    expect(mocks.getActiveSourceForIngest).not.toHaveBeenCalled();
+    expect(mocks.decrypt).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/features/first-party-signals/handleAggregateRequest.test.ts
+++ b/src/server/features/first-party-signals/handleAggregateRequest.test.ts
@@ -35,8 +35,19 @@ vi.mock("./FirstPartyCredentialVault", () => ({
 
 vi.mock("./FirstPartySignalsService", () => {
   class FirstPartyBatchConflictError extends Error {}
+  class FirstPartyBatchInProgressError extends Error {
+    retryAfterSeconds: number;
+    rowCount: number;
+
+    constructor(input: { retryAfterSeconds: number; rowCount: number }) {
+      super("in progress");
+      this.retryAfterSeconds = input.retryAfterSeconds;
+      this.rowCount = input.rowCount;
+    }
+  }
   return {
     FirstPartyBatchConflictError,
+    FirstPartyBatchInProgressError,
     FirstPartySignalsService: { saveSnapshot: mocks.saveSnapshot },
   };
 });
@@ -146,6 +157,50 @@ describe("first-party aggregate HTTP ingestion", () => {
     );
     expect(response.status).toBe(200);
     expect(await response.json()).toMatchObject({ duplicate: true });
+  });
+
+  it("returns retryable 202 while the exact batch is still pending", async () => {
+    const { FirstPartyBatchInProgressError } =
+      await import("./FirstPartySignalsService");
+    mocks.saveSnapshot.mockRejectedValue(
+      new FirstPartyBatchInProgressError({
+        retryAfterSeconds: 47,
+        rowCount: 1,
+      }),
+    );
+
+    const response = await handleFirstPartyAggregateRequest(
+      await signedRequest(payload),
+    );
+
+    expect(response.status).toBe(202);
+    expect(response.headers.get("Retry-After")).toBe("47");
+    expect(await response.json()).toEqual({
+      ok: true,
+      accepted: true,
+      duplicate: true,
+      status: "in_progress",
+      rowCount: 1,
+    });
+  });
+
+  it("reserves 409 for conflicting immutable batch identity or bytes", async () => {
+    const { FirstPartyBatchConflictError } =
+      await import("./FirstPartySignalsService");
+    mocks.saveSnapshot.mockRejectedValue(
+      new FirstPartyBatchConflictError("different digest or date"),
+    );
+
+    const response = await handleFirstPartyAggregateRequest(
+      await signedRequest(payload),
+    );
+
+    expect(response.status).toBe(409);
+    expect(response.headers.get("Retry-After")).toBeNull();
+    expect(await response.json()).toEqual({
+      ok: false,
+      error: "BATCH_CONFLICT",
+    });
   });
 
   it("rate-limits an authenticated source before parsing or persistence", async () => {

--- a/src/server/features/first-party-signals/handleAggregateRequest.test.ts
+++ b/src/server/features/first-party-signals/handleAggregateRequest.test.ts
@@ -1,0 +1,222 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FIRST_PARTY_MAX_BODY_BYTES } from "@/shared/first-party-signals";
+import { bytesToHex } from "./encoding";
+import { handleFirstPartyAggregateRequest } from "./handleAggregateRequest";
+
+const runtime = vi.hoisted(() => ({
+  env: {} as {
+    FIRST_PARTY_INGEST_RATE_LIMIT?: { limit: ReturnType<typeof vi.fn> };
+  },
+}));
+
+vi.mock("cloudflare:workers", () => runtime);
+
+const mocks = vi.hoisted(() => ({
+  getActiveSourceForIngest: vi.fn(),
+  decrypt: vi.fn(),
+  saveSnapshot: vi.fn<
+    (input: { snapshot: unknown; payloadDigest: string }) => Promise<{
+      accepted: true;
+      duplicate: boolean;
+      rowCount: number;
+    }>
+  >(),
+}));
+
+vi.mock("./FirstPartySignalsRepository", () => ({
+  FirstPartySignalsRepository: {
+    getActiveSourceForIngest: mocks.getActiveSourceForIngest,
+  },
+}));
+
+vi.mock("./FirstPartyCredentialVault", () => ({
+  FirstPartyCredentialVault: { decrypt: mocks.decrypt },
+}));
+
+vi.mock("./FirstPartySignalsService", () => {
+  class FirstPartyBatchConflictError extends Error {}
+  return {
+    FirstPartyBatchConflictError,
+    FirstPartySignalsService: { saveSnapshot: mocks.saveSnapshot },
+  };
+});
+
+const sourceId = "2d7b09d4-884c-4b99-a2ca-56fd514fb710";
+const secret = "test-secret";
+
+async function sign(timestamp: string, rawBody: Uint8Array) {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const prefix = new TextEncoder().encode(`${timestamp}.`);
+  const message = new Uint8Array(prefix.length + rawBody.length);
+  message.set(prefix);
+  message.set(rawBody, prefix.length);
+  return bytesToHex(
+    new Uint8Array(await crypto.subtle.sign("HMAC", key, message)),
+  );
+}
+
+async function signedRequest(value: unknown, rawBody?: string) {
+  const body = new TextEncoder().encode(rawBody ?? JSON.stringify(value));
+  const timestamp = String(Date.now());
+  return new Request("https://app.example.com/api/site-signals/v1/aggregates", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-OpenSEO-Source": sourceId,
+      "X-OpenSEO-Timestamp": timestamp,
+      "X-OpenSEO-Signature": await sign(timestamp, body),
+    },
+    body,
+  });
+}
+
+const payload = {
+  schemaVersion: 1,
+  batchId: "f1a2ae17-b157-4bb9-b1a1-960ce8d4c01d",
+  snapshotDate: "2026-09-04",
+  rows: [
+    {
+      landingPath: "/pricing",
+      searchStarted: 10,
+      searchCompleted: 8,
+      searchNoResults: 1,
+      registrationsCompleted: 3,
+      checkoutStarted: 2,
+      paymentsCompleted: 1,
+    },
+  ],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete runtime.env.FIRST_PARTY_INGEST_RATE_LIMIT;
+  mocks.getActiveSourceForIngest.mockResolvedValue({
+    id: sourceId,
+    projectId: "project_1",
+    encryptedSecret: "encrypted",
+    projectDomain: "example.com",
+    allowedPaths: ["/pricing"],
+  });
+  mocks.decrypt.mockResolvedValue(secret);
+  mocks.saveSnapshot.mockResolvedValue({
+    accepted: true,
+    duplicate: false,
+    rowCount: 1,
+  });
+});
+
+describe("first-party aggregate HTTP ingestion", () => {
+  it("authenticates the exact bytes before accepting a snapshot", async () => {
+    const response = await handleFirstPartyAggregateRequest(
+      await signedRequest(payload),
+    );
+
+    expect(response.status).toBe(202);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      accepted: true,
+      duplicate: false,
+      rowCount: 1,
+    });
+    expect(mocks.saveSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        snapshot: payload,
+      }),
+    );
+    expect(mocks.saveSnapshot.mock.calls[0]?.[0].payloadDigest).toMatch(
+      /^[a-f\d]{64}$/,
+    );
+  });
+
+  it("returns 200 for an exact idempotent replay", async () => {
+    mocks.saveSnapshot.mockResolvedValue({
+      accepted: true,
+      duplicate: true,
+      rowCount: 1,
+    });
+    const response = await handleFirstPartyAggregateRequest(
+      await signedRequest(payload),
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ duplicate: true });
+  });
+
+  it("rate-limits an authenticated source before parsing or persistence", async () => {
+    const limit = vi.fn().mockResolvedValue({ success: false });
+    runtime.env.FIRST_PARTY_INGEST_RATE_LIMIT = { limit };
+
+    const response = await handleFirstPartyAggregateRequest(
+      await signedRequest(payload),
+    );
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("Retry-After")).toBe("60");
+    expect(limit).toHaveBeenCalledWith({ key: sourceId });
+    expect(mocks.saveSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("rejects a signature made for different JSON bytes", async () => {
+    const signed = await signedRequest(payload);
+    const headers = new Headers(signed.headers);
+    const response = await handleFirstPartyAggregateRequest(
+      new Request(signed.url, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(payload, null, 2),
+      }),
+    );
+    expect(response.status).toBe(401);
+    expect(mocks.saveSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("rejects unknown fields instead of accepting PII or amounts", async () => {
+    const response = await handleFirstPartyAggregateRequest(
+      await signedRequest({
+        ...payload,
+        rows: [{ ...payload.rows[0], email: "person@example.com", amount: 10 }],
+      }),
+    );
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      ok: false,
+      error: "VALIDATION_ERROR",
+    });
+    expect(mocks.saveSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("caps a streaming body before signature or JSON processing", async () => {
+    const response = await handleFirstPartyAggregateRequest(
+      new Request("https://app.example.com/api/site-signals/v1/aggregates", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-OpenSEO-Source": sourceId,
+          "X-OpenSEO-Timestamp": String(Date.now()),
+          "X-OpenSEO-Signature": "00".repeat(32),
+        },
+        body: "x".repeat(FIRST_PARTY_MAX_BODY_BYTES + 1),
+      }),
+    );
+    expect(response.status).toBe(413);
+    expect(mocks.getActiveSourceForIngest).not.toHaveBeenCalled();
+  });
+
+  it("does not distinguish an unknown or revoked source from a bad signature", async () => {
+    mocks.getActiveSourceForIngest.mockResolvedValue(null);
+    const response = await handleFirstPartyAggregateRequest(
+      await signedRequest(payload),
+    );
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      ok: false,
+      error: "INVALID_SIGNATURE",
+    });
+  });
+});

--- a/src/server/features/first-party-signals/handleAggregateRequest.test.ts
+++ b/src/server/features/first-party-signals/handleAggregateRequest.test.ts
@@ -3,9 +3,18 @@ import { FIRST_PARTY_MAX_BODY_BYTES } from "@/shared/first-party-signals";
 import { bytesToHex } from "./encoding";
 import { handleFirstPartyAggregateRequest } from "./handleAggregateRequest";
 
+type RateLimitFn = (input: { key: string }) => Promise<{ success: boolean }>;
+
 const runtime = vi.hoisted(() => ({
   env: {} as {
-    FIRST_PARTY_INGEST_RATE_LIMIT?: { limit: ReturnType<typeof vi.fn> };
+    FIRST_PARTY_INGEST_EDGE_LIMITS_REQUIRED?: string;
+    FIRST_PARTY_INGEST_GLOBAL_RATE_LIMIT?: {
+      limit: RateLimitFn;
+    };
+    FIRST_PARTY_INGEST_CLAIMED_SOURCE_RATE_LIMIT?: {
+      limit: RateLimitFn;
+    };
+    FIRST_PARTY_INGEST_RATE_LIMIT?: { limit: RateLimitFn };
   },
 }));
 
@@ -106,6 +115,9 @@ const payload = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  delete runtime.env.FIRST_PARTY_INGEST_EDGE_LIMITS_REQUIRED;
+  delete runtime.env.FIRST_PARTY_INGEST_GLOBAL_RATE_LIMIT;
+  delete runtime.env.FIRST_PARTY_INGEST_CLAIMED_SOURCE_RATE_LIMIT;
   delete runtime.env.FIRST_PARTY_INGEST_RATE_LIMIT;
   mocks.getActiveSourceForIngest.mockResolvedValue({
     id: sourceId,
@@ -205,6 +217,13 @@ describe("first-party aggregate HTTP ingestion", () => {
 
   it("rate-limits an authenticated source before parsing or persistence", async () => {
     const limit = vi.fn().mockResolvedValue({ success: false });
+    runtime.env.FIRST_PARTY_INGEST_EDGE_LIMITS_REQUIRED = "true";
+    runtime.env.FIRST_PARTY_INGEST_GLOBAL_RATE_LIMIT = {
+      limit: vi.fn().mockResolvedValue({ success: true }),
+    };
+    runtime.env.FIRST_PARTY_INGEST_CLAIMED_SOURCE_RATE_LIMIT = {
+      limit: vi.fn().mockResolvedValue({ success: true }),
+    };
     runtime.env.FIRST_PARTY_INGEST_RATE_LIMIT = { limit };
 
     const response = await handleFirstPartyAggregateRequest(
@@ -215,6 +234,114 @@ describe("first-party aggregate HTTP ingestion", () => {
     expect(response.headers.get("Retry-After")).toBe("60");
     expect(limit).toHaveBeenCalledWith({ key: sourceId });
     expect(mocks.saveSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("bounds a burst of random claimed UUIDs before body, database, or secret work", async () => {
+    const globalLimit = vi
+      .fn<RateLimitFn>()
+      .mockResolvedValueOnce({ success: true })
+      .mockResolvedValueOnce({ success: true })
+      .mockResolvedValue({ success: false });
+    const claimedSourceLimit = vi
+      .fn<RateLimitFn>()
+      .mockResolvedValue({ success: true });
+    runtime.env.FIRST_PARTY_INGEST_EDGE_LIMITS_REQUIRED = "true";
+    runtime.env.FIRST_PARTY_INGEST_GLOBAL_RATE_LIMIT = { limit: globalLimit };
+    runtime.env.FIRST_PARTY_INGEST_CLAIMED_SOURCE_RATE_LIMIT = {
+      limit: claimedSourceLimit,
+    };
+    runtime.env.FIRST_PARTY_INGEST_RATE_LIMIT = {
+      limit: vi.fn().mockResolvedValue({ success: true }),
+    };
+
+    let bodyPulls = 0;
+    const responses: Response[] = [];
+    for (let index = 0; index < 6; index += 1) {
+      const body = new ReadableStream<Uint8Array>(
+        {
+          pull(controller) {
+            bodyPulls += 1;
+            controller.enqueue(new TextEncoder().encode("{}"));
+            controller.close();
+          },
+        },
+        { highWaterMark: 0 },
+      );
+      responses.push(
+        await handleFirstPartyAggregateRequest(
+          new Request(
+            "https://app.example.com/api/site-signals/v1/aggregates",
+            {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                "X-OpenSEO-Source": crypto.randomUUID(),
+              },
+              body,
+              duplex: "half",
+            } as RequestInit & { duplex: "half" },
+          ),
+        ),
+      );
+    }
+
+    expect(responses.map((response) => response.status)).toEqual([
+      401, 401, 429, 429, 429, 429,
+    ]);
+    expect(globalLimit).toHaveBeenCalledTimes(6);
+    expect(claimedSourceLimit).toHaveBeenCalledTimes(2);
+    expect(globalLimit.mock.calls.map(([input]) => input.key)).toEqual(
+      Array.from({ length: 6 }, () => "aggregate-receiver"),
+    );
+    const claimedKeys = claimedSourceLimit.mock.calls.map(
+      ([input]) => input.key,
+    );
+    expect(new Set(claimedKeys).size).toBe(2);
+    expect(claimedKeys.every((key) => /^[0-9a-f-]{36}$/.test(key))).toBe(true);
+    expect(bodyPulls).toBe(0);
+    expect(mocks.getActiveSourceForIngest).not.toHaveBeenCalled();
+    expect(mocks.decrypt).not.toHaveBeenCalled();
+    expect(mocks.saveSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("fails closed before body or database work when an edge binding is missing", async () => {
+    runtime.env.FIRST_PARTY_INGEST_EDGE_LIMITS_REQUIRED = "true";
+    runtime.env.FIRST_PARTY_INGEST_GLOBAL_RATE_LIMIT = {
+      limit: vi.fn().mockResolvedValue({ success: true }),
+    };
+
+    const response = await handleFirstPartyAggregateRequest(
+      await signedRequest(payload),
+    );
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Retry-After")).toBe("60");
+    expect(await response.json()).toMatchObject({
+      error: "INGEST_PROTECTION_UNAVAILABLE",
+    });
+    expect(mocks.getActiveSourceForIngest).not.toHaveBeenCalled();
+    expect(mocks.decrypt).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the coarse edge limiter is unavailable", async () => {
+    runtime.env.FIRST_PARTY_INGEST_EDGE_LIMITS_REQUIRED = "true";
+    runtime.env.FIRST_PARTY_INGEST_GLOBAL_RATE_LIMIT = {
+      limit: vi.fn().mockRejectedValue(new Error("provider unavailable")),
+    };
+    runtime.env.FIRST_PARTY_INGEST_CLAIMED_SOURCE_RATE_LIMIT = {
+      limit: vi.fn().mockResolvedValue({ success: true }),
+    };
+    runtime.env.FIRST_PARTY_INGEST_RATE_LIMIT = {
+      limit: vi.fn().mockResolvedValue({ success: true }),
+    };
+
+    const response = await handleFirstPartyAggregateRequest(
+      await signedRequest(payload),
+    );
+
+    expect(response.status).toBe(503);
+    expect(mocks.getActiveSourceForIngest).not.toHaveBeenCalled();
+    expect(mocks.decrypt).not.toHaveBeenCalled();
   });
 
   it("rejects a signature made for different JSON bytes", async () => {

--- a/src/server/features/first-party-signals/handleAggregateRequest.test.ts
+++ b/src/server/features/first-party-signals/handleAggregateRequest.test.ts
@@ -3,20 +3,7 @@ import { FIRST_PARTY_MAX_BODY_BYTES } from "@/shared/first-party-signals";
 import { bytesToHex } from "./encoding";
 import { handleFirstPartyAggregateRequest } from "./handleAggregateRequest";
 
-type RateLimitFn = (input: { key: string }) => Promise<{ success: boolean }>;
-
-const runtime = vi.hoisted(() => ({
-  env: {} as {
-    FIRST_PARTY_INGEST_EDGE_LIMITS_REQUIRED?: string;
-    FIRST_PARTY_INGEST_GLOBAL_RATE_LIMIT?: {
-      limit: RateLimitFn;
-    };
-    FIRST_PARTY_INGEST_CLAIMED_SOURCE_RATE_LIMIT?: {
-      limit: RateLimitFn;
-    };
-    FIRST_PARTY_INGEST_RATE_LIMIT?: { limit: RateLimitFn };
-  },
-}));
+const runtime = vi.hoisted(() => ({ env: {} }));
 
 vi.mock("cloudflare:workers", () => runtime);
 
@@ -115,10 +102,6 @@ const payload = {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  delete runtime.env.FIRST_PARTY_INGEST_EDGE_LIMITS_REQUIRED;
-  delete runtime.env.FIRST_PARTY_INGEST_GLOBAL_RATE_LIMIT;
-  delete runtime.env.FIRST_PARTY_INGEST_CLAIMED_SOURCE_RATE_LIMIT;
-  delete runtime.env.FIRST_PARTY_INGEST_RATE_LIMIT;
   mocks.getActiveSourceForIngest.mockResolvedValue({
     id: sourceId,
     projectId: "project_1",
@@ -213,135 +196,6 @@ describe("first-party aggregate HTTP ingestion", () => {
       ok: false,
       error: "BATCH_CONFLICT",
     });
-  });
-
-  it("rate-limits an authenticated source before parsing or persistence", async () => {
-    const limit = vi.fn().mockResolvedValue({ success: false });
-    runtime.env.FIRST_PARTY_INGEST_EDGE_LIMITS_REQUIRED = "true";
-    runtime.env.FIRST_PARTY_INGEST_GLOBAL_RATE_LIMIT = {
-      limit: vi.fn().mockResolvedValue({ success: true }),
-    };
-    runtime.env.FIRST_PARTY_INGEST_CLAIMED_SOURCE_RATE_LIMIT = {
-      limit: vi.fn().mockResolvedValue({ success: true }),
-    };
-    runtime.env.FIRST_PARTY_INGEST_RATE_LIMIT = { limit };
-
-    const response = await handleFirstPartyAggregateRequest(
-      await signedRequest(payload),
-    );
-
-    expect(response.status).toBe(429);
-    expect(response.headers.get("Retry-After")).toBe("60");
-    expect(limit).toHaveBeenCalledWith({ key: sourceId });
-    expect(mocks.saveSnapshot).not.toHaveBeenCalled();
-  });
-
-  it("bounds a burst of random claimed UUIDs before body, database, or secret work", async () => {
-    const globalLimit = vi
-      .fn<RateLimitFn>()
-      .mockResolvedValueOnce({ success: true })
-      .mockResolvedValueOnce({ success: true })
-      .mockResolvedValue({ success: false });
-    const claimedSourceLimit = vi
-      .fn<RateLimitFn>()
-      .mockResolvedValue({ success: true });
-    runtime.env.FIRST_PARTY_INGEST_EDGE_LIMITS_REQUIRED = "true";
-    runtime.env.FIRST_PARTY_INGEST_GLOBAL_RATE_LIMIT = { limit: globalLimit };
-    runtime.env.FIRST_PARTY_INGEST_CLAIMED_SOURCE_RATE_LIMIT = {
-      limit: claimedSourceLimit,
-    };
-    runtime.env.FIRST_PARTY_INGEST_RATE_LIMIT = {
-      limit: vi.fn().mockResolvedValue({ success: true }),
-    };
-
-    let bodyPulls = 0;
-    const responses: Response[] = [];
-    for (let index = 0; index < 6; index += 1) {
-      const body = new ReadableStream<Uint8Array>(
-        {
-          pull(controller) {
-            bodyPulls += 1;
-            controller.enqueue(new TextEncoder().encode("{}"));
-            controller.close();
-          },
-        },
-        { highWaterMark: 0 },
-      );
-      responses.push(
-        await handleFirstPartyAggregateRequest(
-          new Request(
-            "https://app.example.com/api/site-signals/v1/aggregates",
-            {
-              method: "POST",
-              headers: {
-                "Content-Type": "application/json",
-                "X-OpenSEO-Source": crypto.randomUUID(),
-              },
-              body,
-              duplex: "half",
-            } as RequestInit & { duplex: "half" },
-          ),
-        ),
-      );
-    }
-
-    expect(responses.map((response) => response.status)).toEqual([
-      401, 401, 429, 429, 429, 429,
-    ]);
-    expect(globalLimit).toHaveBeenCalledTimes(6);
-    expect(claimedSourceLimit).toHaveBeenCalledTimes(2);
-    expect(globalLimit.mock.calls.map(([input]) => input.key)).toEqual(
-      Array.from({ length: 6 }, () => "aggregate-receiver"),
-    );
-    const claimedKeys = claimedSourceLimit.mock.calls.map(
-      ([input]) => input.key,
-    );
-    expect(new Set(claimedKeys).size).toBe(2);
-    expect(claimedKeys.every((key) => /^[0-9a-f-]{36}$/.test(key))).toBe(true);
-    expect(bodyPulls).toBe(0);
-    expect(mocks.getActiveSourceForIngest).not.toHaveBeenCalled();
-    expect(mocks.decrypt).not.toHaveBeenCalled();
-    expect(mocks.saveSnapshot).not.toHaveBeenCalled();
-  });
-
-  it("fails closed before body or database work when an edge binding is missing", async () => {
-    runtime.env.FIRST_PARTY_INGEST_EDGE_LIMITS_REQUIRED = "true";
-    runtime.env.FIRST_PARTY_INGEST_GLOBAL_RATE_LIMIT = {
-      limit: vi.fn().mockResolvedValue({ success: true }),
-    };
-
-    const response = await handleFirstPartyAggregateRequest(
-      await signedRequest(payload),
-    );
-
-    expect(response.status).toBe(503);
-    expect(response.headers.get("Retry-After")).toBe("60");
-    expect(await response.json()).toMatchObject({
-      error: "INGEST_PROTECTION_UNAVAILABLE",
-    });
-    expect(mocks.getActiveSourceForIngest).not.toHaveBeenCalled();
-    expect(mocks.decrypt).not.toHaveBeenCalled();
-  });
-
-  it("fails closed when the coarse edge limiter is unavailable", async () => {
-    runtime.env.FIRST_PARTY_INGEST_EDGE_LIMITS_REQUIRED = "true";
-    runtime.env.FIRST_PARTY_INGEST_GLOBAL_RATE_LIMIT = {
-      limit: vi.fn().mockRejectedValue(new Error("provider unavailable")),
-    };
-    runtime.env.FIRST_PARTY_INGEST_CLAIMED_SOURCE_RATE_LIMIT = {
-      limit: vi.fn().mockResolvedValue({ success: true }),
-    };
-    runtime.env.FIRST_PARTY_INGEST_RATE_LIMIT = {
-      limit: vi.fn().mockResolvedValue({ success: true }),
-    };
-
-    const response = await handleFirstPartyAggregateRequest(
-      await signedRequest(payload),
-    );
-
-    expect(response.status).toBe(503);
-    expect(mocks.getActiveSourceForIngest).not.toHaveBeenCalled();
-    expect(mocks.decrypt).not.toHaveBeenCalled();
   });
 
   it("rejects a signature made for different JSON bytes", async () => {

--- a/src/server/features/first-party-signals/handleAggregateRequest.ts
+++ b/src/server/features/first-party-signals/handleAggregateRequest.ts
@@ -8,6 +8,7 @@ import {
 import { FirstPartyCredentialVault } from "./FirstPartyCredentialVault";
 import {
   FirstPartyBatchConflictError,
+  FirstPartyBatchInProgressError,
   FirstPartySignalsService,
 } from "./FirstPartySignalsService";
 import { FirstPartySignalsRepository } from "./FirstPartySignalsRepository";
@@ -32,6 +33,19 @@ function json(
 }
 
 function safeError(error: unknown): Response {
+  if (error instanceof FirstPartyBatchInProgressError) {
+    return json(
+      202,
+      {
+        ok: true,
+        accepted: true,
+        duplicate: true,
+        status: "in_progress",
+        rowCount: error.rowCount,
+      },
+      { "Retry-After": String(error.retryAfterSeconds) },
+    );
+  }
   if (error instanceof FirstPartyBatchConflictError) {
     return json(409, { ok: false, error: "BATCH_CONFLICT" });
   }

--- a/src/server/features/first-party-signals/handleAggregateRequest.ts
+++ b/src/server/features/first-party-signals/handleAggregateRequest.ts
@@ -18,6 +18,12 @@ import {
 } from "./FirstPartySignature";
 import { sha256Hex } from "./encoding";
 import { BodyLimitExceededError, readBodyCapped } from "./readBodyCapped";
+import {
+  enforceFirstPartyAuthenticatedRateLimit,
+  enforceFirstPartyPreAuthRateLimits,
+  FIRST_PARTY_INGEST_RETRY_AFTER_SECONDS,
+  type FirstPartyIngestRateLimitDecision,
+} from "./FirstPartyIngestRateLimit";
 
 const sourceIdSchema = z.string().uuid();
 
@@ -59,6 +65,23 @@ function safeError(error: unknown): Response {
   return json(500, { ok: false, error: "INTERNAL_ERROR" });
 }
 
+function rateLimitResponse(
+  decision: FirstPartyIngestRateLimitDecision,
+): Response | null {
+  if (decision === "allowed") return null;
+  return json(
+    decision === "rate_limited" ? 429 : 503,
+    {
+      ok: false,
+      error:
+        decision === "rate_limited"
+          ? "RATE_LIMITED"
+          : "INGEST_PROTECTION_UNAVAILABLE",
+    },
+    { "Retry-After": String(FIRST_PARTY_INGEST_RETRY_AFTER_SECONDS) },
+  );
+}
+
 export async function handleFirstPartyAggregateRequest(
   request: Request,
 ): Promise<Response> {
@@ -85,6 +108,13 @@ export async function handleFirstPartyAggregateRequest(
     const sourceIdResult = sourceIdSchema.safeParse(
       request.headers.get("X-OpenSEO-Source"),
     );
+    const preAuthLimitResponse = rateLimitResponse(
+      await enforceFirstPartyPreAuthRateLimits(
+        env,
+        sourceIdResult.success ? sourceIdResult.data : null,
+      ),
+    );
+    if (preAuthLimitResponse) return preAuthLimitResponse;
     const timestamp = parseSignatureTimestamp(
       request.headers.get("X-OpenSEO-Timestamp"),
     );
@@ -125,19 +155,10 @@ export async function handleFirstPartyAggregateRequest(
     ) {
       return json(401, { ok: false, error: "INVALID_SIGNATURE" });
     }
-    // The binding exists on hosted deployments. Local and self-hosted
-    // surfaces remain storage-bounded by one immutable batch per source/day.
-    const rateLimit = env.FIRST_PARTY_INGEST_RATE_LIMIT;
-    if (rateLimit) {
-      const { success } = await rateLimit.limit({ key: source.id });
-      if (!success) {
-        return json(
-          429,
-          { ok: false, error: "RATE_LIMITED" },
-          { "Retry-After": "60" },
-        );
-      }
-    }
+    const authenticatedLimitResponse = rateLimitResponse(
+      await enforceFirstPartyAuthenticatedRateLimit(env, source.id),
+    );
+    if (authenticatedLimitResponse) return authenticatedLimitResponse;
 
     let decoded: unknown;
     try {

--- a/src/server/features/first-party-signals/handleAggregateRequest.ts
+++ b/src/server/features/first-party-signals/handleAggregateRequest.ts
@@ -1,0 +1,156 @@
+import { env } from "cloudflare:workers";
+import { z } from "zod";
+import { AppError } from "@/server/lib/errors";
+import {
+  FIRST_PARTY_MAX_BODY_BYTES,
+  firstPartyAggregateSnapshotSchema,
+} from "@/shared/first-party-signals";
+import { FirstPartyCredentialVault } from "./FirstPartyCredentialVault";
+import {
+  FirstPartyBatchConflictError,
+  FirstPartySignalsService,
+} from "./FirstPartySignalsService";
+import { FirstPartySignalsRepository } from "./FirstPartySignalsRepository";
+import {
+  parseSignatureTimestamp,
+  verifyFirstPartySignature,
+} from "./FirstPartySignature";
+import { sha256Hex } from "./encoding";
+import { BodyLimitExceededError, readBodyCapped } from "./readBodyCapped";
+
+const sourceIdSchema = z.string().uuid();
+
+function json(
+  status: number,
+  body: Record<string, unknown>,
+  headers?: Record<string, string>,
+) {
+  return Response.json(body, {
+    status,
+    headers: { "Cache-Control": "no-store", ...headers },
+  });
+}
+
+function safeError(error: unknown): Response {
+  if (error instanceof FirstPartyBatchConflictError) {
+    return json(409, { ok: false, error: "BATCH_CONFLICT" });
+  }
+  if (error instanceof AppError) {
+    const status = error.code === "NOT_FOUND" ? 404 : 400;
+    return json(status, { ok: false, error: error.code });
+  }
+  console.error("first_party_aggregate_ingest_failed", {
+    errorName: error instanceof Error ? error.name : "UnknownError",
+  });
+  return json(500, { ok: false, error: "INTERNAL_ERROR" });
+}
+
+export async function handleFirstPartyAggregateRequest(
+  request: Request,
+): Promise<Response> {
+  try {
+    if (request.method !== "POST") {
+      return json(405, { ok: false, error: "METHOD_NOT_ALLOWED" });
+    }
+    const mediaType = request.headers
+      .get("Content-Type")
+      ?.split(";", 1)[0]
+      ?.trim()
+      .toLowerCase();
+    if (mediaType !== "application/json") {
+      return json(415, { ok: false, error: "UNSUPPORTED_MEDIA_TYPE" });
+    }
+    const declaredLength = request.headers.get("Content-Length");
+    if (
+      declaredLength &&
+      (!/^\d+$/.test(declaredLength) ||
+        Number(declaredLength) > FIRST_PARTY_MAX_BODY_BYTES)
+    ) {
+      return json(413, { ok: false, error: "PAYLOAD_TOO_LARGE" });
+    }
+    const sourceIdResult = sourceIdSchema.safeParse(
+      request.headers.get("X-OpenSEO-Source"),
+    );
+    const timestamp = parseSignatureTimestamp(
+      request.headers.get("X-OpenSEO-Timestamp"),
+    );
+    if (!sourceIdResult.success || !timestamp) {
+      return json(401, { ok: false, error: "INVALID_SIGNATURE" });
+    }
+
+    let rawBody: Uint8Array;
+    try {
+      rawBody = await readBodyCapped(request.body, FIRST_PARTY_MAX_BODY_BYTES);
+    } catch (error) {
+      if (!(error instanceof BodyLimitExceededError)) throw error;
+      return json(413, { ok: false, error: "PAYLOAD_TOO_LARGE" });
+    }
+
+    const source = await FirstPartySignalsRepository.getActiveSourceForIngest(
+      sourceIdResult.data,
+    );
+    if (!source?.encryptedSecret) {
+      return json(401, { ok: false, error: "INVALID_SIGNATURE" });
+    }
+    let secret: string;
+    try {
+      secret = await FirstPartyCredentialVault.decrypt(source.encryptedSecret);
+    } catch {
+      return json(503, {
+        ok: false,
+        error: "CREDENTIAL_VAULT_UNAVAILABLE",
+      });
+    }
+    if (
+      !(await verifyFirstPartySignature({
+        secret,
+        timestamp,
+        rawBody,
+        signature: request.headers.get("X-OpenSEO-Signature"),
+      }))
+    ) {
+      return json(401, { ok: false, error: "INVALID_SIGNATURE" });
+    }
+    // The binding exists on hosted deployments. Local and self-hosted
+    // surfaces remain storage-bounded by one immutable batch per source/day.
+    const rateLimit = env.FIRST_PARTY_INGEST_RATE_LIMIT;
+    if (rateLimit) {
+      const { success } = await rateLimit.limit({ key: source.id });
+      if (!success) {
+        return json(
+          429,
+          { ok: false, error: "RATE_LIMITED" },
+          { "Retry-After": "60" },
+        );
+      }
+    }
+
+    let decoded: unknown;
+    try {
+      decoded = JSON.parse(
+        new TextDecoder("utf-8", { fatal: true }).decode(rawBody),
+      ) as unknown;
+    } catch {
+      return json(400, { ok: false, error: "INVALID_JSON" });
+    }
+    const parsed = firstPartyAggregateSnapshotSchema.safeParse(decoded);
+    if (!parsed.success) {
+      return json(400, {
+        ok: false,
+        error: "VALIDATION_ERROR",
+        issues: parsed.error.issues.map((issue) => ({
+          path: issue.path.join("."),
+          message: issue.message,
+        })),
+      });
+    }
+    const result = await FirstPartySignalsService.saveSnapshot({
+      source,
+      snapshot: parsed.data,
+      payloadDigest: await sha256Hex(rawBody),
+    });
+    return json(result.duplicate ? 200 : 202, { ok: true, ...result });
+  } catch (error) {
+    return safeError(error);
+  }
+}

--- a/src/server/features/first-party-signals/readBodyCapped.ts
+++ b/src/server/features/first-party-signals/readBodyCapped.ts
@@ -1,0 +1,43 @@
+export class BodyLimitExceededError extends Error {
+  constructor() {
+    super("Request body exceeded the configured byte limit.");
+    this.name = "BodyLimitExceededError";
+  }
+}
+
+export async function readBodyCapped(
+  body: ReadableStream<Uint8Array> | null,
+  maxBytes: number,
+): Promise<Uint8Array> {
+  if (!body) return new Uint8Array();
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        try {
+          await reader.cancel("body_limit_exceeded");
+        } catch {
+          // Cancellation is best-effort. The byte limit is still authoritative.
+        }
+        throw new BodyLimitExceededError();
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const result = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return result;
+}

--- a/src/server/features/sam/samChatTools.ts
+++ b/src/server/features/sam/samChatTools.ts
@@ -57,6 +57,10 @@ import {
   inspectUrlsTool,
 } from "@/server/mcp/tools/search-console-tools";
 import { whoamiTool } from "@/server/mcp/tools/whoami";
+import {
+  getFirstPartyFunnelTool,
+  getFirstPartyLandingConversionsTool,
+} from "@/server/mcp/tools/first-party-signals-tools";
 import { discoverSiteUrls, readPages, readSite } from "@/server/lib/scrape";
 import openSeoFactSheet from "@/server/features/onboarding/openseo-fact-sheet.md?raw";
 
@@ -398,6 +402,10 @@ export function buildSamMcpTools(
     ),
     get_google_analytics_audience_breakdown: adaptObjectTool(
       getGoogleAnalyticsAudienceBreakdownTool,
+    ),
+    get_first_party_funnel: adaptTool(getFirstPartyFunnelTool),
+    get_first_party_landing_conversions: adaptTool(
+      getFirstPartyLandingConversionsTool,
     ),
     run_site_audit: adaptTool(runSiteAuditTool),
     get_audit_status: waitingAuditStatusTool(adaptTool),

--- a/src/server/mcp/server.ts
+++ b/src/server/mcp/server.ts
@@ -69,6 +69,10 @@ import {
   runSiteAuditTool,
 } from "@/server/mcp/tools/site-audit-tools";
 import { whoamiTool } from "@/server/mcp/tools/whoami";
+import {
+  getFirstPartyFunnelTool,
+  getFirstPartyLandingConversionsTool,
+} from "@/server/mcp/tools/first-party-signals-tools";
 
 type ToolSchema = z.ZodType | z.ZodRawShape;
 
@@ -199,6 +203,8 @@ export function createOpenSeoMcpServer(authProps: McpProps) {
   register(getGoogleAnalyticsEcommercePerformanceTool);
   register(getGoogleAnalyticsSiteSearchTool);
   register(getGoogleAnalyticsAudienceBreakdownTool);
+  register(getFirstPartyFunnelTool);
+  register(getFirstPartyLandingConversionsTool);
   register(runSiteAuditTool);
   register(getAuditStatusTool);
   register(getAuditIssuesTool);

--- a/src/server/mcp/tools/first-party-signals-tools.test.ts
+++ b/src/server/mcp/tools/first-party-signals-tools.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { objectSchema } from "@/server/mcp/output-schemas";
+import { makeToolContext } from "./tool-test-support";
+import {
+  getFirstPartyFunnelTool,
+  getFirstPartyLandingConversionsTool,
+} from "./first-party-signals-tools";
+
+vi.mock("cloudflare:workers", () => ({ env: {} }));
+
+const mocks = vi.hoisted(() => ({
+  getProjectForOrganization: vi.fn(),
+  getFunnel: vi.fn(),
+  getLandingConversions: vi.fn(),
+}));
+
+vi.mock("@/server/features/projects/services/ProjectService", () => ({
+  ProjectService: {
+    getProjectForOrganization: mocks.getProjectForOrganization,
+  },
+}));
+
+vi.mock(
+  "@/server/features/first-party-signals/FirstPartySignalsService",
+  () => ({
+    FirstPartySignalsService: {
+      getFunnel: mocks.getFunnel,
+      getLandingConversions: mocks.getLandingConversions,
+    },
+  }),
+);
+
+const context = makeToolContext({ baseUrl: "https://app.example.com" });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.getProjectForOrganization.mockResolvedValue({ id: "project_1" });
+});
+
+describe("first-party signal MCP tools", () => {
+  it("returns project-scoped funnel data with a valid output schema", async () => {
+    mocks.getFunnel.mockResolvedValue({
+      status: "ok",
+      period: {
+        startDate: "2026-09-01",
+        endDate: "2026-09-04",
+        timezone: "UTC",
+      },
+      observedAt: "2026-09-04",
+      receivedAt: "2026-09-04T12:00:00.000Z",
+      totals: {
+        searchStarted: 10,
+        searchCompleted: 8,
+        searchNoResults: 1,
+        registrationsCompleted: 3,
+        checkoutStarted: 2,
+        paymentsCompleted: 1,
+      },
+      conversion: {
+        searchCompletionRate: 0.8,
+        noResultRate: 0.125,
+        registrationPerSearchRate: 0.375,
+        checkoutPerSearchRate: 0.25,
+        paymentPerCheckoutRate: 0.5,
+      },
+      privacy: "Aggregate counts only.",
+    });
+    const result = await getFirstPartyFunnelTool.handler(
+      {
+        projectId: "project_1",
+        startDate: "2026-09-01",
+        endDate: "2026-09-04",
+      },
+      context,
+    );
+    expect(mocks.getProjectForOrganization).toHaveBeenCalledWith(
+      "org_123",
+      "project_1",
+    );
+    expect(result.structuredContent?.status).toBe("ok");
+    await expect(
+      objectSchema(getFirstPartyFunnelTool.config.outputSchema).safeParseAsync(
+        result.structuredContent,
+      ),
+    ).resolves.toMatchObject({ success: true });
+  });
+
+  it("returns landing rows through the shared MCP and SAM definition", async () => {
+    mocks.getLandingConversions.mockResolvedValue({
+      status: "ok",
+      period: {
+        startDate: "2026-09-01",
+        endDate: "2026-09-04",
+        timezone: "UTC",
+      },
+      rows: [
+        {
+          landingPath: "/pricing",
+          searchStarted: 10,
+          searchCompleted: 8,
+          searchNoResults: 1,
+          registrationsCompleted: 3,
+          checkoutStarted: 2,
+          paymentsCompleted: 1,
+          conversion: {
+            searchCompletionRate: 0.8,
+            noResultRate: 0.125,
+            registrationPerSearchRate: 0.375,
+            checkoutPerSearchRate: 0.25,
+            paymentPerCheckoutRate: 0.5,
+          },
+        },
+      ],
+      privacy: "Aggregate counts only.",
+    });
+    const result = await getFirstPartyLandingConversionsTool.handler(
+      {
+        projectId: "project_1",
+        startDate: "2026-09-01",
+        endDate: "2026-09-04",
+        limit: 50,
+      },
+      context,
+    );
+    const text = result.content[0];
+    expect(text.type === "text" && text.text).toContain("/pricing");
+    await expect(
+      objectSchema(
+        getFirstPartyLandingConversionsTool.config.outputSchema,
+      ).safeParseAsync(result.structuredContent),
+    ).resolves.toMatchObject({ success: true });
+  });
+});

--- a/src/server/mcp/tools/first-party-signals-tools.ts
+++ b/src/server/mcp/tools/first-party-signals-tools.ts
@@ -1,0 +1,127 @@
+import { z } from "zod";
+import { FirstPartySignalsService } from "@/server/features/first-party-signals/FirstPartySignalsService";
+import { buildProjectMeta } from "@/server/mcp/context";
+import { mcpResponse } from "@/server/mcp/formatters";
+import { withMcpProjectAuth } from "@/server/mcp/project-auth";
+import { projectIdSchema } from "@/server/mcp/schemas";
+import { formatMcpTable } from "@/server/mcp/table";
+import {
+  firstPartyConversionRatesSchema,
+  firstPartyFunnelTotalsSchema,
+} from "@/shared/first-party-signals";
+
+const date = z.string().date();
+const periodSchema = z.object({
+  startDate: date,
+  endDate: date,
+  timezone: z.literal("UTC"),
+});
+const commonInput = {
+  projectId: projectIdSchema,
+  startDate: date.describe("Inclusive UTC date in YYYY-MM-DD format."),
+  endDate: date.describe("Inclusive UTC date in YYYY-MM-DD format."),
+} as const;
+
+const funnelOutputSchema = z
+  .object({
+    status: z.enum(["ok", "no_data"]),
+    period: periodSchema,
+    observedAt: z.string().nullable(),
+    receivedAt: z.string().nullable(),
+    totals: firstPartyFunnelTotalsSchema.nullable(),
+    conversion: firstPartyConversionRatesSchema.nullable(),
+    privacy: z.string(),
+  })
+  .passthrough();
+
+type FunnelArgs = z.infer<z.ZodObject<typeof commonInput>>;
+
+export const getFirstPartyFunnelTool = {
+  name: "get_first_party_funnel",
+  config: {
+    title: "Get first-party business funnel",
+    description:
+      "Read privacy-safe daily aggregate counts for searches, registrations, checkout, and completed payments. No users, sessions, identifiers, search terms, or amounts are stored.",
+    inputSchema: commonInput,
+    outputSchema: funnelOutputSchema,
+    annotations: {
+      readOnlyHint: true,
+      openWorldHint: false,
+      destructiveHint: false,
+    },
+  },
+  handler: withMcpProjectAuth(async (args: FunnelArgs, context) => {
+    const result = await FirstPartySignalsService.getFunnel(args);
+    const totals = result.totals;
+    const text = totals
+      ? `First-party funnel (${args.startDate} to ${args.endDate}): searches ${totals.searchStarted}, completed ${totals.searchCompleted}, no result ${totals.searchNoResults}, registrations ${totals.registrationsCompleted}, checkout ${totals.checkoutStarted}, payments ${totals.paymentsCompleted}.`
+      : "No first-party aggregate snapshots were received for this period.";
+    return mcpResponse({
+      text,
+      meta: buildProjectMeta(
+        context,
+        args.projectId,
+        `/p/${args.projectId}/settings/integrations`,
+      ),
+      structuredContent: result,
+    });
+  }),
+};
+
+const landingInput = {
+  ...commonInput,
+  limit: z.number().int().min(1).max(250).default(50),
+} as const;
+type LandingArgs = z.infer<z.ZodObject<typeof landingInput>>;
+const landingOutputSchema = z
+  .object({
+    status: z.enum(["ok", "no_data"]),
+    period: periodSchema,
+    rows: z.array(
+      firstPartyFunnelTotalsSchema.extend({
+        landingPath: z.string(),
+        conversion: firstPartyConversionRatesSchema,
+      }),
+    ),
+    privacy: z.string(),
+  })
+  .passthrough();
+
+export const getFirstPartyLandingConversionsTool = {
+  name: "get_first_party_landing_conversions",
+  config: {
+    title: "Get first-party landing conversions",
+    description:
+      "Compare privacy-safe funnel counts by explicitly allowlisted public landing pathname. Query strings and identifiers are never accepted.",
+    inputSchema: landingInput,
+    outputSchema: landingOutputSchema,
+    annotations: {
+      readOnlyHint: true,
+      openWorldHint: false,
+      destructiveHint: false,
+    },
+  },
+  handler: withMcpProjectAuth(async (args: LandingArgs, context) => {
+    const result = await FirstPartySignalsService.getLandingConversions(args);
+    const text = result.rows.length
+      ? `First-party landing conversions (${result.rows.length}):\n${formatMcpTable(
+          result.rows,
+          [
+            { header: "landing", value: (row) => row.landingPath },
+            { header: "searches", value: (row) => row.searchStarted },
+            { header: "checkout", value: (row) => row.checkoutStarted },
+            { header: "payments", value: (row) => row.paymentsCompleted },
+          ],
+        )}`
+      : "No first-party landing aggregate snapshots were received for this period.";
+    return mcpResponse({
+      text,
+      meta: buildProjectMeta(
+        context,
+        args.projectId,
+        `/p/${args.projectId}/settings/integrations`,
+      ),
+      structuredContent: result,
+    });
+  }),
+};

--- a/src/serverFunctions/first-party-signals.ts
+++ b/src/serverFunctions/first-party-signals.ts
@@ -48,8 +48,8 @@ export const revokeFirstPartySignalSource = createServerFn({ method: "POST" })
 
 /**
  * Portable retention entrypoint for Docker and self-hosted installations that
- * do not dispatch Cloudflare scheduled events. Each invocation deletes at most
- * one page for the current project and reports whether another call is needed.
+ * do not dispatch Cloudflare scheduled events. Each invocation drains multiple
+ * pages to a stable bound and reports whether another call is needed.
  */
 export const purgeExpiredFirstPartySignalBatches = createServerFn({
   method: "POST",

--- a/src/serverFunctions/first-party-signals.ts
+++ b/src/serverFunctions/first-party-signals.ts
@@ -1,0 +1,47 @@
+import { createServerFn } from "@tanstack/react-start";
+import { z } from "zod";
+import { requireOrgPermission } from "@/server/auth/org-gate";
+import { FirstPartySignalsService } from "@/server/features/first-party-signals/FirstPartySignalsService";
+import { requireProjectContext } from "@/serverFunctions/middleware";
+
+const projectSchema = z.object({ projectId: z.string().min(1) });
+const configureSchema = projectSchema.extend({
+  name: z.string().trim().min(1).max(80),
+  allowedPaths: z.array(z.string().min(1).max(1_024)).min(1).max(100),
+});
+const revokeSchema = projectSchema.extend({ sourceId: z.string().uuid() });
+
+export const configureFirstPartySignalSource = createServerFn({
+  method: "POST",
+})
+  .middleware(requireProjectContext)
+  .validator(configureSchema)
+  .handler(async ({ data, context }) => {
+    requireOrgPermission(context, { integration: ["manage"] });
+    return FirstPartySignalsService.configureSource({
+      projectId: context.projectId,
+      organizationId: context.organizationId,
+      userId: context.userId,
+      name: data.name,
+      allowedPaths: data.allowedPaths,
+    });
+  });
+
+export const listFirstPartySignalSources = createServerFn({ method: "POST" })
+  .middleware(requireProjectContext)
+  .validator(projectSchema)
+  .handler(({ context }) =>
+    FirstPartySignalsService.listSources(context.projectId),
+  );
+
+export const revokeFirstPartySignalSource = createServerFn({ method: "POST" })
+  .middleware(requireProjectContext)
+  .validator(revokeSchema)
+  .handler(async ({ data, context }) => {
+    requireOrgPermission(context, { integration: ["manage"] });
+    await FirstPartySignalsService.revokeSource(
+      context.projectId,
+      data.sourceId,
+    );
+    return { revoked: true as const };
+  });

--- a/src/serverFunctions/first-party-signals.ts
+++ b/src/serverFunctions/first-party-signals.ts
@@ -45,3 +45,20 @@ export const revokeFirstPartySignalSource = createServerFn({ method: "POST" })
     );
     return { revoked: true as const };
   });
+
+/**
+ * Portable retention entrypoint for Docker and self-hosted installations that
+ * do not dispatch Cloudflare scheduled events. Each invocation deletes at most
+ * one page for the current project and reports whether another call is needed.
+ */
+export const purgeExpiredFirstPartySignalBatches = createServerFn({
+  method: "POST",
+})
+  .middleware(requireProjectContext)
+  .validator(projectSchema)
+  .handler(async ({ context }) => {
+    requireOrgPermission(context, { integration: ["manage"] });
+    return FirstPartySignalsService.purgeExpired({
+      projectId: context.projectId,
+    });
+  });

--- a/src/shared/first-party-signals.test.ts
+++ b/src/shared/first-party-signals.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import {
+  FIRST_PARTY_RETENTION_DAYS,
+  firstPartyOldestRetainedSnapshotDate,
+} from "./first-party-signals";
+
+describe("first-party snapshot retention", () => {
+  it("returns a window containing exactly 400 inclusive UTC dates", () => {
+    const now = new Date("2026-09-04T23:59:59.999Z");
+    const oldest = firstPartyOldestRetainedSnapshotDate(now);
+    const elapsedDays =
+      (Date.parse("2026-09-04T00:00:00.000Z") -
+        Date.parse(`${oldest}T00:00:00.000Z`)) /
+      (24 * 60 * 60 * 1_000);
+
+    expect(oldest).toBe("2025-08-01");
+    expect(elapsedDays + 1).toBe(FIRST_PARTY_RETENTION_DAYS);
+  });
+});

--- a/src/shared/first-party-signals.ts
+++ b/src/shared/first-party-signals.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+
+export const FIRST_PARTY_MAX_BODY_BYTES = 256 * 1024;
+const FIRST_PARTY_MAX_ROWS = 1_000;
+export const FIRST_PARTY_SIGNATURE_MAX_SKEW_MS = 5 * 60 * 1_000;
+export const FIRST_PARTY_RETENTION_DAYS = 400;
+
+const counterSchema = z.number().int().min(0).max(2_147_483_647);
+
+const firstPartyAggregateRowSchema = z
+  .object({
+    landingPath: z.string().min(1).max(1_024),
+    searchStarted: counterSchema,
+    searchCompleted: counterSchema,
+    searchNoResults: counterSchema,
+    registrationsCompleted: counterSchema,
+    checkoutStarted: counterSchema,
+    paymentsCompleted: counterSchema,
+  })
+  .strict();
+
+export const firstPartyAggregateSnapshotSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    batchId: z.string().uuid(),
+    snapshotDate: z.string().date(),
+    rows: z.array(firstPartyAggregateRowSchema).max(FIRST_PARTY_MAX_ROWS),
+  })
+  .strict();
+
+export type FirstPartyAggregateSnapshot = z.infer<
+  typeof firstPartyAggregateSnapshotSchema
+>;
+
+export const firstPartyFunnelTotalsSchema = z.object({
+  searchStarted: z.number(),
+  searchCompleted: z.number(),
+  searchNoResults: z.number(),
+  registrationsCompleted: z.number(),
+  checkoutStarted: z.number(),
+  paymentsCompleted: z.number(),
+});
+
+export const firstPartyConversionRatesSchema = z.object({
+  searchCompletionRate: z.number().nullable(),
+  noResultRate: z.number().nullable(),
+  registrationPerSearchRate: z.number().nullable(),
+  checkoutPerSearchRate: z.number().nullable(),
+  paymentPerCheckoutRate: z.number().nullable(),
+});

--- a/src/shared/first-party-signals.ts
+++ b/src/shared/first-party-signals.ts
@@ -5,6 +5,13 @@ const FIRST_PARTY_MAX_ROWS = 1_000;
 export const FIRST_PARTY_SIGNATURE_MAX_SKEW_MS = 5 * 60 * 1_000;
 export const FIRST_PARTY_RETENTION_DAYS = 400;
 
+/** Oldest UTC snapshot date retained when today counts as the first day. */
+export function firstPartyOldestRetainedSnapshotDate(now: Date): string {
+  const oldest = new Date(now);
+  oldest.setUTCDate(oldest.getUTCDate() - (FIRST_PARTY_RETENTION_DAYS - 1));
+  return oldest.toISOString().slice(0, 10);
+}
+
 const counterSchema = z.number().int().min(0).max(2_147_483_647);
 
 const firstPartyAggregateRowSchema = z

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -24,6 +24,7 @@ declare namespace Cloudflare {
 		// absent in the wrangler.jsonc surfaces (local dev and Docker).
 		MCP_RATE_LIMIT?: RateLimit;
 		FIRST_PARTY_INGEST_EDGE_LIMITS_REQUIRED?: string;
+		FIRST_PARTY_INGEST_RATE_LIMIT_SCOPE?: string;
 		FIRST_PARTY_INGEST_GLOBAL_RATE_LIMIT?: RateLimit;
 		FIRST_PARTY_INGEST_CLAIMED_SOURCE_RATE_LIMIT?: RateLimit;
 		FIRST_PARTY_INGEST_RATE_LIMIT?: RateLimit;

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -23,6 +23,9 @@ declare namespace Cloudflare {
 		// Hand-patched: Alchemy-only bindings declared in alchemy.run.ts,
 		// absent in the wrangler.jsonc surfaces (local dev and Docker).
 		MCP_RATE_LIMIT?: RateLimit;
+		FIRST_PARTY_INGEST_EDGE_LIMITS_REQUIRED?: string;
+		FIRST_PARTY_INGEST_GLOBAL_RATE_LIMIT?: RateLimit;
+		FIRST_PARTY_INGEST_CLAIMED_SOURCE_RATE_LIMIT?: RateLimit;
 		FIRST_PARTY_INGEST_RATE_LIMIT?: RateLimit;
 		// Hand-patched: the class moved to src/audit-worker.ts and a full regen pulls
 		// unrelated runtime-type drift (see cf-typegen); keep this in sync until then.

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -20,9 +20,10 @@ declare namespace Cloudflare {
 		LOOPS_TRANSACTIONAL_RESET_PASSWORD_ID: string;
 		POSTHOG_HOST: string;
 		POSTHOG_PUBLIC_KEY: string;
-		// Hand-patched: hosted-prod-only binding declared in alchemy.run.ts,
-		// absent in the wrangler.jsonc surfaces (local dev, Docker self-host).
+		// Hand-patched: Alchemy-only bindings declared in alchemy.run.ts,
+		// absent in the wrangler.jsonc surfaces (local dev and Docker).
 		MCP_RATE_LIMIT?: RateLimit;
+		FIRST_PARTY_INGEST_RATE_LIMIT?: RateLimit;
 		// Hand-patched: the class moved to src/audit-worker.ts and a full regen pulls
 		// unrelated runtime-type drift (see cf-typegen); keep this in sync until then.
 		SITE_AUDIT_WORKFLOW: Workflow<Parameters<import("./src/audit-worker").SiteAuditWorkflow['run']>[0]['payload']>;


### PR DESCRIPTION
Closes #287

## Summary

- add POST /api/site-signals/v1/aggregates with HMAC-SHA256 over timestamp + "." + exactRawBody
- add a minimal project integration for one-time secret creation, rotation, allowlisted paths, revocation, and portable bounded retention cleanup
- store only six daily aggregate counters, with D1/PostgreSQL parity and exactly 400 inclusive UTC snapshot dates of retention
- add get_first_party_funnel and get_first_party_landing_conversions to MCP, SAM, and the tool catalog

## Security and privacy model

- 32 random bytes of secret material, encrypted with the Better Auth secret and never returned by list APIs
- mask the one-time credential from capture tooling and keep it out of React Query mutation data
- five-minute timestamp window, constant-time WebCrypto verification, 256 KiB body cap, and strict Zod boundaries
- on Alchemy-hosted Cloudflare deployments, apply a constant-key coarse limiter and an opaque claimed-source limiter before body, database, secret-decryption, or HMAC work; a random UUID spray is still contained by the constant key, no IP/PII key is used or logged, and an incomplete or unavailable configured limiter set fails closed
- prefix every limiter key with a trusted, stage-specific Worker name injected by Alchemy, because Cloudflare bindings that reuse a namespace ID can share counters across Workers; an absent deployment scope fails closed before touching the body, database, secrets, HMAC, or any limiter
- preserve the stricter authenticated per-source limiter after HMAC verification
- one source per project and one immutable batch per source/UTC day, bounding retained receipts
- rows are namespaced by processing attempt; only the current lease can publish, so a stale worker cannot corrupt visible data
- project ownership is derived defensively through aggregate → batch → source; no denormalized project/source ownership fields exist on aggregate rows
- UUID-only batch keys, canonical exact public-path allowlists, complete path-set validation, and rejection of nested encoded separators/traversal, private aliases, opaque IDs, users, sessions, orders, terms, and amounts
- exact retries during an active processing lease return retryable HTTP 202 plus Retry-After; HTTP 409 is reserved for immutable digest/date conflicts

## Retention behavior

Today counts as the first retained UTC date, so the accepted window contains exactly 400 dates: today plus the preceding 399 dates. Ingestion validation and maintenance cleanup use the same shared cutoff helper, with boundary tests for the oldest accepted date and its immediately preceding rejected date.

Cloudflare scheduled deployments drain up to twenty ordered pages (5,000 batches) per daily event. If more work remains, the scheduled invocation fails observably and the next run safely continues from the oldest remaining rows. Docker and other self-hosted runtimes do not have an implicit cron; integration managers can invoke the same bounded, project-scoped drain from the UI until hasMore is false. The additive retention index remains present in both migration lanes.

## Deliberately excluded

No raw events, users, sessions, identifiers, search terms, monetary values, dynamic dimensions, downstream branding, external emitter, Cloudflare analytics, Bing, IndexNow, or broader Site Signals UI.

## Validation

- pnpm ci:check
- pnpm test:ci — 148 files / 1,234 tests
- focused retention boundary suite — 2 files / 13 tests
- pnpm build
- clean local D1 migration through 0046_first_party_retention_index.sql — 47 migrations, index verified
- clean PostgreSQL 17 migration through 0024_first_party_retention_index.sql — 25 migrations, index verified
- generated snapshot drift check: only the intended retention index differs
- credential-pattern and downstream-branding scan

## Base and review note

Built from exact OpenSEO v0.1.7 commit ac9ee482d2b4cd8f472065d6f9b57db35cec560e; current POC head: daca2a2. This is intentionally a focused POC because the current contribution guide prefers issues and does not promise PR merges.

OpenAI Codex assisted with implementation and test drafting. I reviewed the resulting code, incorporated findings from separate security reviews, and ran all validation above.
