### PR TITLE
fix(audit): distinguish 'no issues found' from 'no issue data' (#289)

### DIFF
--- a/src/server/mcp/tools/site-audit-tools.test.ts
+++ b/src/server/mcp/tools/site-audit-tools.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getAuditIssuesTool } from "./site-audit-tools";
+import { makeToolContext, textContent } from "./tool-test-support";
+
+const mocks = vi.hoisted(() => ({
+  getProjectForOrganization: vi.fn(),
+  getAuditForProject: vi.fn(),
+  getIssuesForAudit: vi.fn(),
+  hasPagesForAudit: vi.fn(),
+}));
+
+vi.mock("cloudflare:workers", () => ({ env: {} }));
+
+vi.mock("@/server/features/projects/services/ProjectService", () => ({
+  ProjectService: {
+    getProjectForOrganization: mocks.getProjectForOrganization,
+  },
+}));
+
+vi.mock("@/server/features/audit/repositories/AuditRepository", () => ({
+  AuditRepository: {
+    getAuditForProject: mocks.getAuditForProject,
+    getIssuesForAudit: mocks.getIssuesForAudit,
+    hasPagesForAudit: mocks.hasPagesForAudit,
+  },
+}));
+
+const toolContext = makeToolContext();
+const AUDIT = { id: "audit_1", startUrl: "https://example.com/" };
+
+beforeEach(() => {
+  mocks.getProjectForOrganization.mockResolvedValue({ id: "project_1" });
+  mocks.getAuditForProject.mockResolvedValue(AUDIT);
+  mocks.getIssuesForAudit.mockResolvedValue([]);
+});
+
+describe("get_audit_issues empty-state messages", () => {
+  it("says 'no issues found' when the audit ran checks but found nothing", async () => {
+    mocks.hasPagesForAudit.mockResolvedValue(true);
+
+    const result = await getAuditIssuesTool.handler(
+      { projectId: "project_1", auditId: "audit_1" },
+      toolContext,
+    );
+
+    expect(textContent(result)).toBe(
+      "Audit audit_1 (https://example.com/): no issues found.",
+    );
+  });
+
+  it("keeps the legacy 'no issue data' hint when the audit has no crawled pages", async () => {
+    mocks.hasPagesForAudit.mockResolvedValue(false);
+
+    const result = await getAuditIssuesTool.handler(
+      { projectId: "project_1", auditId: "audit_1" },
+      toolContext,
+    );
+
+    expect(textContent(result)).toContain("No issue data for audit audit_1.");
+    expect(textContent(result)).toContain(
+      "audits run before issue checks existed have no issue data",
+    );
+  });
+
+  it("still says 'no issues matching filters' when filters are set", async () => {
+    mocks.hasPagesForAudit.mockResolvedValue(true);
+
+    const result = await getAuditIssuesTool.handler(
+      {
+        projectId: "project_1",
+        auditId: "audit_1",
+        severity: "critical",
+      },
+      toolContext,
+    );
+
+    expect(textContent(result)).toBe(
+      "No issues found for audit audit_1 matching the given filters.",
+    );
+  });
+});

--- a/src/server/mcp/tools/site-audit-tools.ts
+++ b/src/server/mcp/tools/site-audit-tools.ts
@@ -304,7 +304,9 @@ export const getAuditIssuesTool = {
       rows.length === 0
         ? args.severity || args.issueType
           ? `No issues found for audit ${audit.id} matching the given filters.`
-          : `No issues recorded for audit ${audit.id}. Note: audits run before issue checks existed have no issue data — re-run the audit with run_site_audit to get a real report.`
+          : (await AuditRepository.hasPagesForAudit(audit.id))
+            ? `Audit ${audit.id} (${audit.startUrl}): no issues found.`
+            : `No issue data for audit ${audit.id}. Note: audits run before issue checks existed have no issue data — re-run the audit with run_site_audit to get a real report.`
         : [
             `Audit ${audit.id} (${audit.startUrl}): ${rows.length} issues${rows.length > limit ? ` (showing ${limit})` : ""}.`,
             "By type:",


### PR DESCRIPTION
## Summary

Fix `get_audit_issues` (#289) so a clean audit no longer looks like missing data.

When a fresh audit ran the multipage checks and found nothing, the tool returned "No issues recorded ... re-run the audit with `run_site_audit` to get a real report." That message is meant for old audits that predate the issue checks. For a brand new audit on a clean site, it sends the user into an unnecessary re-crawl of every page — exactly what happened in #289.

## What changed

- `get_audit_issues` now distinguishes the two cases by checking whether the audit has any rows in `audit_pages`. The current pipeline always persists pages and always runs the multipage checks, so a non-empty `audit_pages` with zero `audit_issues` means the checks ran and found nothing.
- Empty `audit_pages` keeps the original "no issue data" hint — that's still the right message for audits written before the checks existed.
- Filter-only empty results (e.g. `severity=critical` on a clean audit) are unchanged.

## How to verify

- Clean audit (has pages, zero issues): `Audit <id> (<startUrl>): no issues found.`
- Pre-checks audit (no pages): `No issue data for audit <id>. Note: audits run before issue checks existed have no issue data — re-run the audit with run_site_audit to get a real report.`
- Filter mismatch: `No issues found for audit <id> matching the given filters.`

Three unit tests cover all three branches.

## Notes

- One extra `hasPagesForAudit` query is added on the empty-issues path only, so there's no impact on the common case where an audit returns issues.
- No schema change — `audit_pages` is already the right signal because the multipage-checks step requires pages to exist before it can run.