### PR TITLE
fix: align papercut routing and narrow prose review

### DIFF
--- a/.agents/skills/deslop/SKILL.md
+++ b/.agents/skills/deslop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deslop
-description: Remove AI writing patterns from prose. Use this skill when writing, drafting, editing, reviewing, or revising any text to eliminate predictable AI tells, slop, and formulaic patterns. Trigger this skill whenever the user asks to "deslop", "de-AI", "make it sound human," "remove AI patterns," "remove AI tropes," "clean up AI writing," fix "slop," "deslop" text, or review prose for authenticity. Also use when the user asks you to write or draft anything and wants it to sound natural rather than AI-generated. Common use cases include scientific writing (manuscripts, abstracts, cover letters, grant narratives, discussion sections, peer review responses), blog posts, newsletters, memos, reports, and any other substantial prose.
+description: Edit prose to remove formulaic AI phrasing while preserving meaning and the author's voice. Use for prose editing or an explicit style review.
 metadata:
   internal: true
 ---
@@ -87,7 +87,7 @@ Run these before delivering any prose:
 
 ## Scoring
 
-When reviewing text, rate 1-10 on each dimension:
+For an explicit style audit, use the dimensions below to explain material weaknesses. For a small edit, improve the text directly without a scorecard.
 
 | Dimension | Question |
 |-----------|----------|
@@ -97,7 +97,7 @@ When reviewing text, rate 1-10 on each dimension:
 | Authenticity | Sounds like a specific human wrote it? |
 | Density | Anything cuttable? |
 
-Below 35/50: revise.
+Revise material weaknesses before returning the result; scores are an optional review aid, not a completion gate.
 
 ## Reference Files
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@
 
 ## Log papercuts
 
-When small, non-blocking repository friction occurs—a retried tool call, confusing setup step, flaky command, stale cache, misleading error, or non-obvious gotcha—use the `papercuts` skill and append it to `.agents/PAPERCUTS.md` in the moment. Continue the current task. Real bugs and tracked work are not papercuts, and sensitive data must never be logged.
+Use `papercuts` only for recurring friction that another contributor can reproduce and a change in this repository can fix. Do not invoke it for transient retries, local shell mistakes, sandbox restrictions, or third-party failures with no repository fix. Continue the current task; real bugs and tracked work are not papercuts, and sensitive data must never be logged.
 
 Do not mine an entire session for papercuts or start a broad cleanup unless the user explicitly asks.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@
 
 ## Log papercuts
 
-When small, non-blocking repository friction occurs—a retried tool call, confusing setup step, flaky command, stale cache, misleading error, or non-obvious gotcha—use the `papercuts` skill and append it to `.agents/PAPERCUTS.md` in the moment. Continue the current task. Real bugs and tracked work are not papercuts, and sensitive data must never be logged.
+Use `papercuts` only for recurring friction that another contributor can reproduce and a change in this repository can fix. Do not invoke it for transient retries, local shell mistakes, sandbox restrictions, or third-party failures with no repository fix. Continue the current task; real bugs and tracked work are not papercuts, and sensitive data must never be logged.
 
 Do not mine an entire session for papercuts or start a broad cleanup unless the user explicitly asks.
 


### PR DESCRIPTION
AGENTS.md and CLAUDE.md disagree on when to log papercuts, and small prose edits can trigger an unnecessarily broad review. This gives both entry points the same reproducible, repository-fixable threshold and limits the prose scorecard to explicit audit requests.

Validation: both papercut rules were checked for alignment; the deslop skill passes the metadata validator; `git diff --check` passes. No application runtime or model behavior was tested.
