### PR TITLE
fix(audit): match meta description names case-insensitively

### DIFF
--- a/src/server/lib/audit/issues/page-reporters.test.ts
+++ b/src/server/lib/audit/issues/page-reporters.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { runPageReporters } from "@/server/lib/audit/issues/page-reporters";
+import { analyzeHtml } from "@/server/lib/audit/page-analyzer";
 import {
   findDuplicates,
   findRedirectChainsAndLoops,
@@ -59,6 +60,44 @@ function makePage(overrides: Partial<CrawledPageResult>): CrawledPageResult {
 function issueTypes(page: CrawledPageResult): string[] {
   return runPageReporters(page).map((issue) => issue.issueType);
 }
+
+describe("meta description extraction and reporting", () => {
+  it.each(["description", "Description", "DESCRIPTION", "dEsCrIpTiOn"])(
+    "does not report a missing description for name=%s",
+    (name) => {
+      const analysis = analyzeHtml(
+        `<head><meta name="${name}" content="Actual text"></head>`,
+        "https://example.com/a",
+        200,
+        0,
+      );
+
+      expect(
+        issueTypes(makePage({ metaDescription: analysis.metaDescription })),
+      ).not.toContain("missing-meta-description");
+    },
+  );
+
+  it.each([
+    ["absent", ""],
+    ["empty", '<meta name="description" content="">'],
+    ["empty with mixed case", '<meta name="Description" content="">'],
+    ["whitespace only", '<meta name="DESCRIPTION" content="   ">'],
+    ["missing content", '<meta name="dEsCrIpTiOn">'],
+  ])("reports a missing description when %s", (_label, meta) => {
+    const analysis = analyzeHtml(
+      `<head>${meta}</head>`,
+      "https://example.com/a",
+      200,
+      0,
+    );
+
+    expect(analysis.metaDescription).toBe("");
+    expect(
+      issueTypes(makePage({ metaDescription: analysis.metaDescription })),
+    ).toContain("missing-meta-description");
+  });
+});
 
 describe("runPageReporters", () => {
   it("reports nothing for a healthy page", () => {

--- a/src/server/lib/audit/page-analyzer.test.ts
+++ b/src/server/lib/audit/page-analyzer.test.ts
@@ -207,6 +207,40 @@ describe("analyzeHtml parity with the DOM reference", () => {
   });
 });
 
+describe("analyzeHtml meta description contract", () => {
+  it.each(["description", "Description", "DESCRIPTION", "dEsCrIpTiOn"])(
+    "extracts the exact content for name=%s",
+    (name) => {
+      const content = "Actual text: OpenSEO keeps MiXeD case and  two spaces.";
+      const analysis = analyzeHtml(
+        `<head><meta name="${name}" content="${content}"></head>`,
+        PAGE_URL,
+        200,
+        0,
+      );
+
+      expect(analysis.metaDescription).toBe(content);
+    },
+  );
+
+  it.each(["description", "Description"])(
+    "keeps the first description when name=%s precedes a duplicate",
+    (name) => {
+      const analysis = analyzeHtml(
+        `<head>
+          <meta name="${name}" content="First description">
+          <meta name="description" content="Second description">
+        </head>`,
+        PAGE_URL,
+        200,
+        0,
+      );
+
+      expect(analysis.metaDescription).toBe("First description");
+    },
+  );
+});
+
 describe("analyzeHtml extraction caps", () => {
   it("caps links and images per page", () => {
     const links = Array.from(

--- a/src/server/lib/audit/page-analyzer.ts
+++ b/src/server/lib/audit/page-analyzer.ts
@@ -87,7 +87,7 @@ export function analyzeHtml(
 
   const handleMetaTag = (attribs: Record<string, string>) => {
     const content = attribs["content"];
-    if (attribs["name"] === "description") {
+    if (attribs["name"]?.toLowerCase() === "description") {
       metaDescription ??= content?.trim() ?? "";
     } else if (attribs["name"] === "robots") {
       robotsMeta ??= content ?? null;


### PR DESCRIPTION
Fixes #293.

Site audits treated the `name` value on meta description tags as case-sensitive, so valid tags such as `<meta name="Description">` were reported as missing. The parser now recognizes description names regardless of capitalization while preserving content trimming and first-description-wins behavior.

Regression coverage verifies lowercase, title-case, uppercase, and mixed-case names; exact extracted content; duplicate handling; and absent or empty descriptions.

Validation:

- `pnpm run ci:check`
- `pnpm run test:ci` — 1,180 tests passed
- `pnpm vite build`
- `pnpm --dir web run types:check`
- `pnpm --dir web run build`

Docker image verification was not run because the local Docker daemon is unavailable.
