### PR TITLE
Add historical domain traffic comparisons

### DIFF
--- a/src/client/features/ai-mcp/AvailableTools.tsx
+++ b/src/client/features/ai-mcp/AvailableTools.tsx
@@ -107,6 +107,11 @@ const toolCategories: ToolCategory[] = [
         description: "Summarize a domain's organic footprint.",
       },
       {
+        name: "get_domain_history",
+        title: "Compare domain history",
+        description: "Compare monthly traffic estimates across domains.",
+      },
+      {
         name: "get_domain_keyword_suggestions",
         title: "Get domain keywords",
         description: "Find keywords a domain already ranks for.",

--- a/src/client/features/domain/DomainOverviewPage.tsx
+++ b/src/client/features/domain/DomainOverviewPage.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/client/features/domain/domainSearchValidation";
 import { useDomainOverviewQuery } from "@/client/features/domain/hooks/useDomainOverviewQuery";
 import { DomainOverviewLoadingState } from "@/client/features/domain/components/DomainOverviewLoadingState";
+import { DomainTrafficHistory } from "@/client/features/domain/components/DomainTrafficHistory";
 import { DomainHistorySection } from "@/client/features/domain/components/DomainHistorySection";
 import { DomainSearchCard } from "@/client/features/domain/components/DomainSearchCard";
 import { KeywordsTab } from "@/client/features/domain/components/KeywordsTab";
@@ -620,6 +621,13 @@ export function DomainOverviewPage({
                 hint={overviewMetricsHint}
               />
             </div>
+
+            <DomainTrafficHistory
+              key={`${state.overview.domain}:${routeState.locationCode}`}
+              projectId={projectId}
+              domain={state.overview.domain}
+              locationCode={routeState.sentLocationCode}
+            />
 
             {!state.overview.hasData ? (
               <div className="alert alert-info">

--- a/src/client/features/domain/components/DomainTrafficHistory.tsx
+++ b/src/client/features/domain/components/DomainTrafficHistory.tsx
@@ -12,7 +12,7 @@ import {
   YAxis,
 } from "recharts";
 import { getDomainHistory } from "@/serverFunctions/domain";
-import { normalizeDomain } from "@/types/schemas/domain";
+import { normalizeDomainHistoryTarget } from "@/types/schemas/domain";
 import {
   DOMAIN_HISTORY_MAX_DOMAINS,
   type DomainHistoryResult,
@@ -232,12 +232,12 @@ export function DomainTrafficHistory({
 function parseDomains(primaryDomain: string, rawCompetitors: string) {
   try {
     const domains = [
-      normalizeDomain(primaryDomain),
+      normalizeDomainHistoryTarget(primaryDomain),
       ...rawCompetitors
         .split(",")
         .map((value) => value.trim())
         .filter(Boolean)
-        .map(normalizeDomain),
+        .map(normalizeDomainHistoryTarget),
     ];
     const unique = [...new Set(domains)];
     if (unique.length > DOMAIN_HISTORY_MAX_DOMAINS) {
@@ -250,7 +250,8 @@ function parseDomains(primaryDomain: string, rawCompetitors: string) {
   } catch {
     return {
       ok: false as const,
-      message: "Enter competitors as domains, separated by commas.",
+      message:
+        "Historical traffic supports domains and subdomains only. DataForSEO cannot return folder history such as example.com/jp.",
     };
   }
 }

--- a/src/client/features/domain/components/DomainTrafficHistory.tsx
+++ b/src/client/features/domain/components/DomainTrafficHistory.tsx
@@ -1,0 +1,298 @@
+import { useMemo, useState, type FormEvent } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { sortBy } from "remeda";
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { getDomainHistory } from "@/serverFunctions/domain";
+import { normalizeDomain } from "@/types/schemas/domain";
+import {
+  DOMAIN_HISTORY_MAX_DOMAINS,
+  type DomainHistoryResult,
+  type DomainHistorySeries,
+  currentIsoDate,
+  dateMonthsAgo,
+  estimateDomainHistoryCostUsd,
+} from "@/shared/domain-history";
+import { applyBillingMarkupUsd } from "@/shared/billing";
+import { isHostedClientAuthMode } from "@/lib/auth-mode";
+import { getStandardErrorMessage } from "@/client/lib/error-messages";
+
+const PERIOD_OPTIONS = [6, 12, 24, 60] as const;
+const COLORS = ["#2563eb", "#f97316", "#16a34a", "#a855f7", "#e11d48"];
+
+type Metric = "organicTraffic" | "organicKeywords";
+
+export function DomainTrafficHistory({
+  projectId,
+  domain,
+  locationCode,
+}: {
+  projectId: string;
+  domain: string;
+  locationCode: number | undefined;
+}) {
+  const [competitors, setCompetitors] = useState("");
+  const [periodMonths, setPeriodMonths] = useState<number>(24);
+  const [metric, setMetric] = useState<Metric>("organicTraffic");
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const dateFrom = dateMonthsAgo(periodMonths);
+  const dateTo = currentIsoDate();
+  const parsedDomains = useMemo(
+    () => parseDomains(domain, competitors),
+    [competitors, domain],
+  );
+  const rawCost = estimateDomainHistoryCostUsd(
+    parsedDomains.ok ? parsedDomains.domains.length : 1,
+    dateFrom,
+    dateTo,
+  );
+  const displayedCost = isHostedClientAuthMode()
+    ? applyBillingMarkupUsd(rawCost)
+    : rawCost;
+
+  const historyMutation = useMutation<DomainHistoryResult, Error, string[]>({
+    mutationFn: (domains: string[]) =>
+      getDomainHistory({
+        data: {
+          projectId,
+          domains,
+          dateFrom,
+          dateTo,
+          locationCode,
+        },
+      }),
+  });
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    if (!parsedDomains.ok) {
+      setValidationError(parsedDomains.message);
+      return;
+    }
+    setValidationError(null);
+    historyMutation.mutate(parsedDomains.domains);
+  };
+
+  const chart = useMemo(
+    () => buildChartData(historyMutation.data?.series ?? [], metric),
+    [historyMutation.data, metric],
+  );
+
+  return (
+    <section className="rounded-xl border border-base-300 bg-base-100">
+      <div className="border-b border-base-300 p-4">
+        <div className="flex flex-col gap-1">
+          <h2 className="font-semibold">Historical search visibility</h2>
+          <p className="text-sm text-base-content/65">
+            Compare monthly DataForSEO estimates. Data is available from October
+            2020 and refreshed weekly.
+          </p>
+        </div>
+
+        <form
+          onSubmit={handleSubmit}
+          className="mt-4 grid gap-3 lg:grid-cols-[minmax(0,1fr)_auto_auto_auto] lg:items-end"
+        >
+          <label className="form-control min-w-0">
+            <span className="label-text mb-1 text-xs font-medium">
+              Competitors
+            </span>
+            <input
+              type="text"
+              className={`input input-bordered w-full ${validationError ? "input-error" : ""}`}
+              placeholder="competitor.com, another.com"
+              value={competitors}
+              onChange={(event) => setCompetitors(event.target.value)}
+              aria-invalid={validationError ? true : undefined}
+            />
+          </label>
+
+          <label className="form-control">
+            <span className="label-text mb-1 text-xs font-medium">Period</span>
+            <select
+              className="select select-bordered"
+              value={periodMonths}
+              onChange={(event) => setPeriodMonths(Number(event.target.value))}
+            >
+              {PERIOD_OPTIONS.map((months) => (
+                <option key={months} value={months}>
+                  {months < 12 ? `${months} months` : `${months / 12} years`}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="form-control">
+            <span className="label-text mb-1 text-xs font-medium">Metric</span>
+            <select
+              className="select select-bordered"
+              value={metric}
+              onChange={(event) => {
+                if (isMetric(event.target.value)) {
+                  setMetric(event.target.value);
+                }
+              }}
+            >
+              <option value="organicTraffic">Estimated traffic</option>
+              <option value="organicKeywords">Ranking keywords</option>
+            </select>
+          </label>
+
+          <button
+            type="submit"
+            className="btn btn-primary"
+            disabled={historyMutation.isPending}
+          >
+            {historyMutation.isPending
+              ? "Loading..."
+              : `Compare · up to $${displayedCost.toFixed(2)}`}
+          </button>
+        </form>
+
+        <p className="mt-2 text-xs text-base-content/55">
+          The current domain is included automatically. Add up to four more.
+          Cached repeats do not make another provider request.
+        </p>
+        {validationError ? (
+          <p className="mt-2 text-sm text-error">{validationError}</p>
+        ) : null}
+        {historyMutation.isError ? (
+          <p className="mt-2 text-sm text-error">
+            {getStandardErrorMessage(
+              historyMutation.error,
+              "Historical comparison failed.",
+            )}
+          </p>
+        ) : null}
+      </div>
+
+      {historyMutation.data ? (
+        chart.rows.length === 0 ? (
+          <div className="p-8 text-center text-sm text-base-content/60">
+            No historical estimates were returned for these domains.
+          </div>
+        ) : (
+          <div className="h-80 min-w-0 p-4" aria-label="Domain history chart">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={chart.rows} margin={{ left: 8, right: 16 }}>
+                <CartesianGrid
+                  stroke="currentColor"
+                  strokeDasharray="3 3"
+                  opacity={0.12}
+                />
+                <XAxis
+                  dataKey="date"
+                  tickFormatter={formatMonth}
+                  minTickGap={28}
+                />
+                <YAxis tickFormatter={formatAxisValue} width={58} />
+                <Tooltip
+                  formatter={(value) =>
+                    typeof value === "number"
+                      ? value.toLocaleString()
+                      : String(value ?? "")
+                  }
+                  labelFormatter={(value) => formatMonth(String(value))}
+                />
+                <Legend />
+                {chart.series.map((item, index) => (
+                  <Line
+                    key={item.domain}
+                    type="monotone"
+                    dataKey={item.key}
+                    name={item.domain}
+                    stroke={COLORS[index % COLORS.length]}
+                    strokeWidth={2}
+                    dot={false}
+                    connectNulls
+                  />
+                ))}
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        )
+      ) : (
+        <div className="p-6 text-sm text-base-content/60">
+          Run the comparison to load the selected historical period. These are
+          modeled estimates, not Google Search Console measurements.
+        </div>
+      )}
+    </section>
+  );
+}
+
+function parseDomains(primaryDomain: string, rawCompetitors: string) {
+  try {
+    const domains = [
+      normalizeDomain(primaryDomain),
+      ...rawCompetitors
+        .split(",")
+        .map((value) => value.trim())
+        .filter(Boolean)
+        .map(normalizeDomain),
+    ];
+    const unique = [...new Set(domains)];
+    if (unique.length > DOMAIN_HISTORY_MAX_DOMAINS) {
+      return {
+        ok: false as const,
+        message: `Compare up to ${DOMAIN_HISTORY_MAX_DOMAINS} domains at once.`,
+      };
+    }
+    return { ok: true as const, domains: unique };
+  } catch {
+    return {
+      ok: false as const,
+      message: "Enter competitors as domains, separated by commas.",
+    };
+  }
+}
+
+function buildChartData(series: DomainHistorySeries[], metric: Metric) {
+  const dates = sortBy(
+    [
+      ...new Set(
+        series.flatMap((item) => item.points.map((point) => point.date)),
+      ),
+    ],
+    (date) => date,
+  );
+  const keyedSeries = series.map((item, index) => ({
+    domain: item.domain,
+    key: `domain${index}`,
+    values: new Map(item.points.map((point) => [point.date, point[metric]])),
+  }));
+  const rows = dates.map((date) => {
+    const row: Record<string, string | number | null> = { date };
+    for (const item of keyedSeries) {
+      row[item.key] = item.values.get(date) ?? null;
+    }
+    return row;
+  });
+  return { rows, series: keyedSeries };
+}
+
+function isMetric(value: string): value is Metric {
+  return value === "organicTraffic" || value === "organicKeywords";
+}
+
+function formatAxisValue(value: unknown) {
+  if (typeof value !== "number") return "";
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${Math.round(value / 1_000)}K`;
+  return String(value);
+}
+
+function formatMonth(value: string) {
+  const date = new Date(`${value.slice(0, 10)}T00:00:00Z`);
+  return Number.isNaN(date.valueOf())
+    ? value
+    : date.toLocaleDateString(undefined, { month: "short", year: "numeric" });
+}

--- a/src/server/features/domain/services/DomainService.ts
+++ b/src/server/features/domain/services/DomainService.ts
@@ -1,6 +1,7 @@
 import { waitUntil } from "cloudflare:workers";
 import { buildCacheKey, getCached, setCached } from "@/server/lib/r2-cache";
 import { z } from "zod";
+import { sortBy } from "remeda";
 import type { BillingCustomerContext } from "@/server/billing/subscription";
 import type { CreditFeature } from "@/shared/billing-credit-features";
 import { createDataforseoClient } from "@/server/lib/dataforseo";
@@ -8,6 +9,11 @@ import { buildRankedKeywordsScopeFilter } from "@/server/lib/dataforseo/research
 import { joinClauses } from "@/server/lib/dataforseo/filters";
 import { parseResearchTargetOrThrow } from "@/server/lib/domainUtils";
 import type { ResearchScope } from "@/shared/researchScope";
+import type {
+  DomainHistoryResult,
+  DomainHistorySeries,
+} from "@/shared/domain-history";
+import type { DomainHistoricalRankItem } from "@/server/lib/dataforseo";
 import { mapKeywordItem } from "@/server/features/domain/services/domainKeywordMapper";
 import { getKeywordsPage } from "@/server/features/domain/services/domainKeywordsPage";
 import { getPagesPage } from "@/server/features/domain/services/domainPagesPage";
@@ -29,6 +35,18 @@ const domainOverviewResultSchema = z.object({
   backlinks: z.number().nullable(),
   referringDomains: z.number().nullable(),
   hasData: z.boolean(),
+  fetchedAt: z.string(),
+});
+
+const domainHistoryPointSchema = z.object({
+  date: z.string(),
+  organicTraffic: z.number().nullable(),
+  organicKeywords: z.number().nullable(),
+});
+
+const domainHistorySeriesSchema = z.object({
+  domain: z.string(),
+  points: z.array(domainHistoryPointSchema),
   fetchedAt: z.string(),
 });
 
@@ -117,6 +135,114 @@ async function getOverview(
   }
 
   return { ...stored, scope: target.scope, displayTarget: target.display };
+}
+
+async function getHistoricalOverview(
+  input: {
+    projectId: string;
+    domains: string[];
+    dateFrom: string;
+    dateTo: string;
+    locationCode: number;
+    languageCode: string;
+  },
+  billingCustomer: BillingCustomerContext,
+): Promise<DomainHistoryResult> {
+  const series = await Promise.all(
+    input.domains.map((domain) =>
+      getHistoricalSeries(
+        {
+          ...input,
+          domain,
+        },
+        billingCustomer,
+      ),
+    ),
+  );
+
+  return {
+    dateFrom: input.dateFrom,
+    dateTo: input.dateTo,
+    locationCode: input.locationCode,
+    languageCode: input.languageCode,
+    series,
+  };
+}
+
+async function getHistoricalSeries(
+  input: {
+    projectId: string;
+    domain: string;
+    dateFrom: string;
+    dateTo: string;
+    locationCode: number;
+    languageCode: string;
+  },
+  billingCustomer: BillingCustomerContext,
+): Promise<DomainHistorySeries> {
+  const target = parseResearchTargetOrThrow(input.domain, "subdomains");
+  const domain = target.hostname;
+  const cacheKey = await buildCacheKey("domain:historical-overview", {
+    organizationId: billingCustomer.organizationId,
+    projectId: input.projectId,
+    domain,
+    dateFrom: input.dateFrom,
+    dateTo: input.dateTo,
+    locationCode: input.locationCode,
+    languageCode: input.languageCode,
+  });
+
+  const cached = domainHistorySeriesSchema.safeParse(await getCached(cacheKey));
+  if (cached.success) return cached.data;
+
+  const dataforseo = createDataforseoClient(billingCustomer);
+  const items: DomainHistoricalRankItem[] =
+    await dataforseo.domain.historicalRankOverview({
+      target: domain,
+      locationCode: input.locationCode,
+      languageCode: input.languageCode,
+      dateFrom: input.dateFrom,
+      dateTo: input.dateTo,
+    });
+
+  const stored: DomainHistorySeries = {
+    domain,
+    fetchedAt: new Date().toISOString(),
+    points: sortBy(
+      items.flatMap((item) => {
+        const year = item.year;
+        const month = item.month;
+        if (
+          year == null ||
+          month == null ||
+          !Number.isInteger(year) ||
+          !Number.isInteger(month) ||
+          month < 1 ||
+          month > 12
+        ) {
+          return [];
+        }
+        const organic = item.metrics?.organic;
+        return [
+          {
+            date: `${year}-${String(month).padStart(2, "0")}-01`,
+            organicTraffic:
+              organic?.etv == null ? null : Math.round(organic.etv),
+            organicKeywords:
+              organic?.count == null ? null : Math.round(organic.count),
+          },
+        ];
+      }),
+      (point) => point.date,
+    ),
+  };
+
+  waitUntil(
+    setCached(cacheKey, stored, DOMAIN_OVERVIEW_TTL_SECONDS).catch((error) => {
+      console.error("domain.historical-overview.cache-write failed:", error);
+    }),
+  );
+  return stored;
 }
 
 async function getSuggestedKeywords(
@@ -218,6 +344,7 @@ async function getSuggestedKeywords(
 
 export const DomainService = {
   getOverview,
+  getHistoricalOverview,
   getSuggestedKeywords,
   getKeywordsPage,
   getPagesPage,

--- a/src/server/lib/dataforseo/client.test.ts
+++ b/src/server/lib/dataforseo/client.test.ts
@@ -60,6 +60,7 @@ vi.mock("@/server/lib/dataforseo/labs", () => ({
   fetchKeywordSuggestions: vi.fn(),
   fetchKeywordIdeas: vi.fn(),
   fetchDomainRankOverview: vi.fn(),
+  fetchDomainHistoricalRankOverview: vi.fn(),
   fetchRankedKeywords: vi.fn(),
   fetchRelevantPages: vi.fn(),
   fetchKeywordOverview: vi.fn(),
@@ -399,6 +400,15 @@ describe("mapDataforseoPathToCreditFeature", () => {
         "dataforseo_labs",
         "google",
         "domain_rank_overview",
+        "live",
+      ]),
+    ).toBe("domain_overview");
+    expect(
+      mapDataforseoPathToCreditFeature([
+        "v3",
+        "dataforseo_labs",
+        "google",
+        "historical_rank_overview",
         "live",
       ]),
     ).toBe("domain_overview");

--- a/src/server/lib/dataforseo/client.ts
+++ b/src/server/lib/dataforseo/client.ts
@@ -28,6 +28,7 @@ import {
   fetchReferringDomains,
 } from "@/server/lib/dataforseo/backlinks";
 import {
+  fetchDomainHistoricalRankOverview,
   fetchDomainRankOverview,
   fetchKeywordIdeas,
   fetchKeywordOverview,
@@ -114,6 +115,11 @@ export function createDataforseoClient(customer: BillingCustomerContext) {
       adsSearchVolume: meter(customer, fetchAdsSearchVolume),
     },
     domain: {
+      historicalRankOverview: meter(
+        customer,
+        fetchDomainHistoricalRankOverview,
+        "domain_overview",
+      ),
       rankOverview: meter(customer, fetchDomainRankOverview),
       rankedKeywords: meter(customer, fetchRankedKeywords),
       relevantPages: meter(customer, fetchRelevantPages),

--- a/src/server/lib/dataforseo/index.ts
+++ b/src/server/lib/dataforseo/index.ts
@@ -36,6 +36,7 @@ export {
 
 export type {
   LabsKeywordDataItem,
+  DomainHistoricalRankItem,
   DomainRankedKeywordItem,
   RelevantPagesItem,
 } from "@/server/lib/dataforseo/labs";

--- a/src/server/lib/dataforseo/labs-history.test.ts
+++ b/src/server/lib/dataforseo/labs-history.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchDomainHistoricalRankOverview } from "@/server/lib/dataforseo/labs";
+
+vi.mock("@/server/lib/runtime-env", () => ({
+  getRequiredEnvValue: vi.fn(async () => "test-api-key"),
+}));
+
+describe("DataForSEO historical rank overview", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("requests correlated monthly history without clickstream pricing", async () => {
+    const path = [
+      "v3",
+      "dataforseo_labs",
+      "google",
+      "historical_rank_overview",
+      "live",
+    ];
+    const item = {
+      year: 2026,
+      month: 8,
+      metrics: { organic: { etv: 1234.5, count: 456 } },
+    };
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      Response.json({
+        status_code: 20000,
+        tasks: [
+          {
+            status_code: 20000,
+            path,
+            cost: 0.1488,
+            result_count: 1,
+            result: [{ items: [item] }],
+          },
+        ],
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchDomainHistoricalRankOverview({
+      target: "example.com",
+      locationCode: 2392,
+      languageCode: "ja",
+      dateFrom: "2024-09-01",
+      dateTo: "2026-09-06",
+    });
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "https://api.dataforseo.com/v3/dataforseo_labs/google/historical_rank_overview/live",
+    );
+    expect(parseRequestBody(fetchMock.mock.calls[0]?.[1])).toEqual([
+      {
+        target: "example.com",
+        location_code: 2392,
+        language_code: "ja",
+        date_from: "2024-09-01",
+        date_to: "2026-09-06",
+        correlate: true,
+        include_clickstream_data: false,
+      },
+    ]);
+    expect(result).toEqual({
+      data: [item],
+      billing: { path, costUsd: 0.1488 },
+    });
+  });
+});
+
+function parseRequestBody(init: RequestInit | undefined): unknown {
+  if (typeof init?.body !== "string") {
+    throw new Error("Expected request body to be a string");
+  }
+  return JSON.parse(init.body) as unknown;
+}

--- a/src/server/lib/dataforseo/labs.ts
+++ b/src/server/lib/dataforseo/labs.ts
@@ -64,6 +64,11 @@ type DomainMetricsItem = {
   [key: string]: unknown;
 };
 
+export interface DomainHistoricalRankItem extends DomainMetricsItem {
+  year?: number | null;
+  month?: number | null;
+}
+
 export interface RelevantPagesItem {
   page_address?: string | null;
   metrics?: LabsMetricsBlock | null;
@@ -247,6 +252,33 @@ export async function fetchDomainRankOverview(input: {
       },
     ],
   );
+  const task = assertOk(response);
+  return {
+    data: task.result?.[0]?.items ?? [],
+    billing: buildTaskBilling(task),
+  };
+}
+
+export async function fetchDomainHistoricalRankOverview(input: {
+  target: string;
+  locationCode: number;
+  languageCode: string;
+  dateFrom: string;
+  dateTo: string;
+}): Promise<DataforseoApiResponse<DomainHistoricalRankItem[]>> {
+  const response = await dataforseoPost<
+    DataforseoItemsTask<DomainHistoricalRankItem>
+  >("/v3/dataforseo_labs/google/historical_rank_overview/live", [
+    {
+      target: input.target,
+      location_code: input.locationCode,
+      language_code: input.languageCode,
+      date_from: input.dateFrom,
+      date_to: input.dateTo,
+      correlate: true,
+      include_clickstream_data: false,
+    },
+  ]);
   const task = assertOk(response);
   return {
     data: task.result?.[0]?.items ?? [],

--- a/src/server/mcp/server.ts
+++ b/src/server/mcp/server.ts
@@ -15,6 +15,7 @@ import { getBacklinksOverviewTool } from "@/server/mcp/tools/get-backlinks-overv
 import { getBacklinksProfileTool } from "@/server/mcp/tools/get-backlinks-profile";
 import { getDomainKeywordSuggestionsTool } from "@/server/mcp/tools/get-domain-keyword-suggestions";
 import { getDomainOverviewTool } from "@/server/mcp/tools/get-domain-overview";
+import { getDomainHistoryTool } from "@/server/mcp/tools/get-domain-history";
 import { addRankTrackingKeywordsTool } from "@/server/mcp/tools/add-rank-tracking-keywords";
 import { createRankTrackerTool } from "@/server/mcp/tools/create-rank-tracker";
 import { estimateRankTrackerCostTool } from "@/server/mcp/tools/estimate-rank-tracker-cost";
@@ -166,6 +167,7 @@ export function createOpenSeoMcpServer(authProps: McpProps) {
   register(researchKeywordsTool);
   register(saveKeywordsTool);
   register(getDomainOverviewTool);
+  register(getDomainHistoryTool);
   register(getDomainKeywordSuggestionsTool);
   register(getBacklinksOverviewTool);
   register(getBacklinksProfileTool);

--- a/src/server/mcp/tools/get-domain-history.ts
+++ b/src/server/mcp/tools/get-domain-history.ts
@@ -14,7 +14,7 @@ import {
   locationCodeSchema,
   projectIdSchema,
 } from "@/server/mcp/schemas";
-import { domainField } from "@/types/schemas/domain";
+import { domainHistoryTargetField } from "@/types/schemas/domain";
 import {
   DOMAIN_HISTORY_MAX_DOMAINS,
   DOMAIN_HISTORY_MIN_DATE,
@@ -27,11 +27,13 @@ const isoDateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Use YYYY-MM-DD");
 const inputSchema = {
   projectId: projectIdSchema,
   domains: z
-    .array(domainField)
+    .array(domainHistoryTargetField)
     .min(1)
     .max(DOMAIN_HISTORY_MAX_DOMAINS)
     .transform((domains) => [...new Set(domains)])
-    .describe("Domains to compare. Each domain is one billed task."),
+    .describe(
+      "Domains or subdomains to compare. Folder paths are not supported by DataForSEO. Each target is one billed task.",
+    ),
   dateFrom: isoDateSchema.describe(
     `First month to return. Data starts at ${DOMAIN_HISTORY_MIN_DATE}.`,
   ),

--- a/src/server/mcp/tools/get-domain-history.ts
+++ b/src/server/mcp/tools/get-domain-history.ts
@@ -1,0 +1,138 @@
+import { z } from "zod";
+import { DomainService } from "@/server/features/domain/services/DomainService";
+import { mcpResponse } from "@/server/mcp/formatters";
+import { buildProjectMeta } from "@/server/mcp/context";
+import { optionalMetaOutputSchema } from "@/server/mcp/output-schemas";
+import { withMcpProjectAuth } from "@/server/mcp/project-auth";
+import { resolveLabsMarket } from "@/shared/keyword-locations";
+import {
+  assertLabsLocationCode,
+  assertLanguageForLocation,
+} from "@/server/lib/market";
+import {
+  languageCodeSchema,
+  locationCodeSchema,
+  projectIdSchema,
+} from "@/server/mcp/schemas";
+import { domainField } from "@/types/schemas/domain";
+import {
+  DOMAIN_HISTORY_MAX_DOMAINS,
+  DOMAIN_HISTORY_MIN_DATE,
+  estimateDomainHistoryCostUsd,
+} from "@/shared/domain-history";
+import { AppError } from "@/server/lib/errors";
+
+const isoDateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Use YYYY-MM-DD");
+
+const inputSchema = {
+  projectId: projectIdSchema,
+  domains: z
+    .array(domainField)
+    .min(1)
+    .max(DOMAIN_HISTORY_MAX_DOMAINS)
+    .transform((domains) => [...new Set(domains)])
+    .describe("Domains to compare. Each domain is one billed task."),
+  dateFrom: isoDateSchema.describe(
+    `First month to return. Data starts at ${DOMAIN_HISTORY_MIN_DATE}.`,
+  ),
+  dateTo: isoDateSchema.describe("Last month to return."),
+  locationCode: locationCodeSchema.optional(),
+  languageCode: languageCodeSchema.optional(),
+} as const;
+
+type Args = z.infer<z.ZodObject<typeof inputSchema>>;
+
+const pointSchema = z.object({
+  date: z.string(),
+  organicTraffic: z.number().nullable(),
+  organicKeywords: z.number().nullable(),
+});
+
+export const getDomainHistoryTool = {
+  name: "get_domain_history",
+  config: {
+    title: "Compare historical domain traffic",
+    description:
+      "Returns monthly estimated organic traffic and ranking-keyword history for up to five domains. DataForSEO history starts in October 2020 and is updated weekly. These are modeled estimates, not Search Console measurements. Charges about $0.12 per domain plus $0.0012 per returned month; cached for 12 hours.",
+    inputSchema,
+    outputSchema: z
+      .object({
+        dateFrom: z.string(),
+        dateTo: z.string(),
+        locationCode: z.number(),
+        languageCode: z.string(),
+        estimatedMaxCostUsd: z.number(),
+        series: z.array(
+          z.object({
+            domain: z.string(),
+            points: z.array(pointSchema),
+            fetchedAt: z.string(),
+          }),
+        ),
+        ...optionalMetaOutputSchema,
+      })
+      .passthrough(),
+    annotations: {
+      readOnlyHint: false,
+      openWorldHint: false,
+      destructiveHint: false,
+    },
+  },
+  handler: withMcpProjectAuth(async (args: Args, context) => {
+    if (args.dateFrom < DOMAIN_HISTORY_MIN_DATE) {
+      throw new AppError(
+        "VALIDATION_ERROR",
+        `Historical data starts at ${DOMAIN_HISTORY_MIN_DATE}`,
+      );
+    }
+    if (args.dateFrom > args.dateTo) {
+      throw new AppError("VALIDATION_ERROR", "dateFrom must be before dateTo");
+    }
+
+    const { locationCode, languageCode } = resolveLabsMarket(
+      args,
+      context.project,
+    );
+    assertLabsLocationCode(locationCode);
+    assertLanguageForLocation(locationCode, languageCode);
+    const result = await DomainService.getHistoricalOverview(
+      {
+        projectId: args.projectId,
+        domains: args.domains,
+        dateFrom: args.dateFrom,
+        dateTo: args.dateTo,
+        locationCode,
+        languageCode,
+      },
+      context.billing,
+    );
+    const estimatedMaxCostUsd = estimateDomainHistoryCostUsd(
+      args.domains.length,
+      args.dateFrom,
+      args.dateTo,
+    );
+    const summary = result.series.map((item) => {
+      const first = item.points[0];
+      const last = item.points.at(-1);
+      return `${item.domain}: ${first?.organicTraffic ?? "?"} (${first?.date ?? "no data"}) -> ${last?.organicTraffic ?? "?"} (${last?.date ?? "no data"})`;
+    });
+
+    return mcpResponse({
+      text: [
+        `Historical organic traffic estimates for ${args.dateFrom} to ${args.dateTo}:`,
+        ...summary,
+        `Estimated maximum provider cost: $${estimatedMaxCostUsd.toFixed(4)} (cached repeats may cost less).`,
+      ].join("\n"),
+      meta: buildProjectMeta(
+        context,
+        args.projectId,
+        `/p/${args.projectId}/domain`,
+        { domain: args.domains[0] },
+      ),
+      structuredContent: {
+        ...result,
+        estimatedMaxCostUsd,
+      },
+    });
+  }),
+};

--- a/src/serverFunctions/domain.ts
+++ b/src/serverFunctions/domain.ts
@@ -2,6 +2,7 @@ import { createServerFn } from "@tanstack/react-start";
 import { requireProjectContext } from "@/serverFunctions/middleware";
 import {
   domainOverviewSchema,
+  domainHistoryRequestSchema,
   domainKeywordSuggestionsSchema,
   domainKeywordsPageRequestSchema,
   domainPagesPageRequestSchema,
@@ -33,6 +34,20 @@ export const getDomainOverview = createServerFn({ method: "POST" })
 
     return DomainService.getOverview(input, context);
   });
+
+export const getDomainHistory = createServerFn({ method: "POST" })
+  .middleware(requireProjectContext)
+  .validator(domainHistoryRequestSchema)
+  .handler(async ({ data, context }) =>
+    DomainService.getHistoricalOverview(
+      {
+        ...data,
+        ...resolveLabsMarket(data, context.project),
+        projectId: context.projectId,
+      },
+      context,
+    ),
+  );
 
 export const getDomainKeywordSuggestions = createServerFn({ method: "POST" })
   .middleware(requireProjectContext)

--- a/src/shared/billing-credit-features.ts
+++ b/src/shared/billing-credit-features.ts
@@ -60,6 +60,7 @@ export function mapDataforseoPathToCreditFeature(
       const endpoint = normalizedPath[3] ?? "";
       if (
         endpoint.startsWith("domain_") ||
+        endpoint === "historical_rank_overview" ||
         endpoint === "ranked_keywords" ||
         endpoint === "relevant_pages"
       ) {

--- a/src/shared/domain-history.test.ts
+++ b/src/shared/domain-history.test.ts
@@ -4,6 +4,7 @@ import {
   dateMonthsAgo,
   estimateDomainHistoryCostUsd,
 } from "@/shared/domain-history";
+import { domainHistoryRequestSchema } from "@/types/schemas/domain";
 
 describe("domain history estimates", () => {
   it("counts inclusive calendar months and estimates one task per domain", () => {
@@ -17,5 +18,28 @@ describe("domain history estimates", () => {
     expect(dateMonthsAgo(24, new Date("2026-09-06T00:00:00Z"))).toBe(
       "2024-10-01",
     );
+  });
+
+  it("accepts domains and subdomains but rejects folder targets", () => {
+    const base = {
+      projectId: "550e8400-e29b-41d4-a716-446655440000",
+      dateFrom: "2024-10-01",
+      dateTo: "2026-09-06",
+    };
+    expect(
+      domainHistoryRequestSchema.parse({
+        ...base,
+        domains: ["https://www.example.com/", "docs.example.com"],
+      }).domains,
+    ).toEqual(["example.com", "docs.example.com"]);
+
+    const folder = domainHistoryRequestSchema.safeParse({
+      ...base,
+      domains: ["https://www.cdata.com/jp/"],
+    });
+    expect(folder.success).toBe(false);
+    if (!folder.success) {
+      expect(folder.error.issues[0]?.message).toContain("folder paths");
+    }
   });
 });

--- a/src/shared/domain-history.test.ts
+++ b/src/shared/domain-history.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import {
+  countInclusiveMonths,
+  dateMonthsAgo,
+  estimateDomainHistoryCostUsd,
+} from "@/shared/domain-history";
+
+describe("domain history estimates", () => {
+  it("counts inclusive calendar months and estimates one task per domain", () => {
+    expect(countInclusiveMonths("2024-10-01", "2026-09-06")).toBe(24);
+    expect(
+      estimateDomainHistoryCostUsd(3, "2024-10-01", "2026-09-06"),
+    ).toBeCloseTo(0.4464);
+  });
+
+  it("builds an inclusive period start", () => {
+    expect(dateMonthsAgo(24, new Date("2026-09-06T00:00:00Z"))).toBe(
+      "2024-10-01",
+    );
+  });
+});

--- a/src/shared/domain-history.ts
+++ b/src/shared/domain-history.ts
@@ -1,0 +1,62 @@
+export const DOMAIN_HISTORY_MIN_DATE = "2020-10-01";
+export const DOMAIN_HISTORY_MAX_DOMAINS = 5;
+
+export type DomainHistoryPoint = {
+  date: string;
+  organicTraffic: number | null;
+  organicKeywords: number | null;
+};
+
+export type DomainHistorySeries = {
+  domain: string;
+  points: DomainHistoryPoint[];
+  fetchedAt: string;
+};
+
+export type DomainHistoryResult = {
+  dateFrom: string;
+  dateTo: string;
+  locationCode: number;
+  languageCode: string;
+  series: DomainHistorySeries[];
+};
+
+// DataForSEO Labs Historical Rank Overview pricing, checked 2026-09-06:
+// $0.12 per task plus $0.0012 per returned month. Each domain is one task.
+const DOMAIN_HISTORY_TASK_COST_USD = 0.12;
+const DOMAIN_HISTORY_MONTH_COST_USD = 0.0012;
+
+export function countInclusiveMonths(dateFrom: string, dateTo: string) {
+  const [fromYear, fromMonth] = parseDateParts(dateFrom);
+  const [toYear, toMonth] = parseDateParts(dateTo);
+  return (toYear - fromYear) * 12 + toMonth - fromMonth + 1;
+}
+
+export function estimateDomainHistoryCostUsd(
+  domainCount: number,
+  dateFrom: string,
+  dateTo: string,
+) {
+  const months = Math.max(0, countInclusiveMonths(dateFrom, dateTo));
+  return (
+    domainCount *
+    (DOMAIN_HISTORY_TASK_COST_USD + months * DOMAIN_HISTORY_MONTH_COST_USD)
+  );
+}
+
+export function dateMonthsAgo(months: number, now = new Date()) {
+  const date = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - months + 1, 1),
+  );
+  return date.toISOString().slice(0, 10);
+}
+
+export function currentIsoDate(now = new Date()) {
+  return now.toISOString().slice(0, 10);
+}
+
+function parseDateParts(value: string): [number, number] {
+  const match = /^(\d{4})-(\d{2})-\d{2}$/.exec(value);
+  if (!match) return [0, 0];
+  return [Number(match[1]), Number(match[2])];
+}

--- a/src/types/schemas/domain.ts
+++ b/src/types/schemas/domain.ts
@@ -42,6 +42,40 @@ export const domainField = z
     }
   });
 
+const DOMAIN_HISTORY_TARGET_ERROR =
+  "Historical traffic supports domains and subdomains only; folder paths such as example.com/jp are not available from DataForSEO.";
+
+export function normalizeDomainHistoryTarget(input: string): string {
+  let value = input.trim().toLowerCase();
+  if (!/^[a-z]+:\/\//.test(value)) value = `https://${value}`;
+  const url = new URL(value);
+  if (url.pathname !== "/" || url.search || url.hash) {
+    throw new Error(DOMAIN_HISTORY_TARGET_ERROR);
+  }
+  const hostname = url.hostname.replace(/^www\./, "");
+  if (!hostname.includes(".") || !isValidDomainHost(hostname)) {
+    throw new Error("Enter a valid domain like example.com");
+  }
+  return hostname;
+}
+
+export const domainHistoryTargetField = z
+  .string()
+  .min(1)
+  .max(2048)
+  .transform((value, ctx) => {
+    try {
+      return normalizeDomainHistoryTarget(value);
+    } catch (error) {
+      ctx.addIssue({
+        code: "custom",
+        message:
+          error instanceof Error ? error.message : DOMAIN_HISTORY_TARGET_ERROR,
+      });
+      return z.NEVER;
+    }
+  });
+
 export const booleanSearchParamSchema = z
   .union([z.boolean(), z.enum(["true", "false"])])
   .transform((value) => value === true || value === "true");
@@ -65,7 +99,7 @@ export const domainHistoryRequestSchema = z
   .object({
     projectId: z.string().uuid(),
     domains: z
-      .array(domainField)
+      .array(domainHistoryTargetField)
       .min(1)
       .max(DOMAIN_HISTORY_MAX_DOMAINS)
       .transform((domains) => [...new Set(domains)]),

--- a/src/types/schemas/domain.ts
+++ b/src/types/schemas/domain.ts
@@ -1,5 +1,9 @@
 import { z } from "zod";
 import { isValidDomainHost, researchScopeSchema } from "@/shared/researchScope";
+import {
+  DOMAIN_HISTORY_MAX_DOMAINS,
+  DOMAIN_HISTORY_MIN_DATE,
+} from "@/shared/domain-history";
 
 /**
  * Extract and validate a bare hostname from user input that may be a full URL.
@@ -49,6 +53,43 @@ export const domainOverviewSchema = z.object({
   locationCode: z.number().int().positive().optional(),
   languageCode: z.string().min(2).max(8).optional(),
 });
+
+const isoDateSchema = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, "Use YYYY-MM-DD")
+  .refine((value) => !Number.isNaN(Date.parse(`${value}T00:00:00Z`)), {
+    message: "Enter a valid date",
+  });
+
+export const domainHistoryRequestSchema = z
+  .object({
+    projectId: z.string().uuid(),
+    domains: z
+      .array(domainField)
+      .min(1)
+      .max(DOMAIN_HISTORY_MAX_DOMAINS)
+      .transform((domains) => [...new Set(domains)]),
+    dateFrom: isoDateSchema,
+    dateTo: isoDateSchema,
+    locationCode: z.number().int().positive().optional(),
+    languageCode: z.string().min(2).max(8).optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.dateFrom < DOMAIN_HISTORY_MIN_DATE) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["dateFrom"],
+        message: `Historical data starts at ${DOMAIN_HISTORY_MIN_DATE}`,
+      });
+    }
+    if (value.dateFrom > value.dateTo) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["dateFrom"],
+        message: "Start date must be before end date",
+      });
+    }
+  });
 
 /* ------------------------------------------------------------------ */
 /*  URL search params schema for /p/$projectId/domain                  */


### PR DESCRIPTION
## Summary\n\n- add DataForSEO historical rank overview support\n- compare estimated organic traffic and ranking keywords for up to five domains\n- expose the comparison in Domain Overview and through the get_domain_history MCP tool\n- show estimated provider cost before running, disable clickstream pricing, and cache results for 12 hours\n- reject folder URLs because DataForSEO historical endpoints only support domains and subdomains\n\n## Verification\n\n- 1,168 tests passed across 140 test files\n- TypeScript check passed\n- type-aware lint passed\n- production Vite build passed\n- live DataForSEO request returned 23 monthly points per domain at 0.1476 USD per target\n\n## Provider notes\n\nHistorical data begins in October 2020 and updates weekly. Results are modeled estimates rather than Search Console measurements.\n\nDataForSEO documentation:\nhttps://docs.dataforseo.com/v3/dataforseo_labs-google-historical_rank_overview-live/